### PR TITLE
Minor README changes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,14 @@ A write only atom doesn't need an initial value or a read method.
 
 ```jsx
 import { create } from 'jotai'
+import countAtom from './countAtom'
 
 const multiplyCountAtom = create({
   write: ({ get, set }, multiplicator) => set(countAtom, get(countAtom) * multiplicator),
 })
 
 function Controls() {
-  const [, multiply] = useAtom(decrementCountAtom)
+  const [, multiply] = useAtom(multiplyCountAtom)
   return <button onClick={() => multiply(3)}>triple</button>
 }
 ```


### PR DESCRIPTION
I tried to make the README more new user friendly.

A couple of questions:

```jsx
const multiplyCountAtom = create({
  write: ({ get, set }, multiplicator) => set(countAtom, get(countAtom) * multiplicator),
})
```

can this be written like

```jsx
const multiplyCountAtom = create({
  write: ({ get, set }, multiplicator) => {
     set(countAtom, get(countAtom) * multiplicator)
 },
})
```

Or does it need the return value of set() ?

---

Same here, can it be rewritten with {} to make it less cryptic?

```jsx
import { create } from 'jotai'
import countAtom from './countAtom.js'

const multiplyCountAtom = create({
  write: ({ get, set }, multiplicator) => {
     set(countAtom, get(countAtom) * multiplicator)
  }
})

function Controls() {
  const [, multiply] = useAtom(decrementCountAtom)
  return <button onClick={() => multiply(3)}>triple</button>
}
```

TLDR I would be careful with the short syntax for arrow functions because it can imply something that isn't necessary ( this is strictly related to the README )