### PR TITLE
atom family util

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -48,9 +48,9 @@
     "gzipped": 1866
   },
   "utils.js": {
-    "bundled": 1251,
-    "minified": 629,
-    "gzipped": 311,
+    "bundled": 1827,
+    "minified": 865,
+    "gzipped": 434,
     "treeshaked": {
       "rollup": {
         "code": 28,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -48,9 +48,9 @@
     "gzipped": 1927
   },
   "utils.js": {
-    "bundled": 1827,
-    "minified": 865,
-    "gzipped": 434,
+    "bundled": 1823,
+    "minified": 870,
+    "gzipped": 436,
     "treeshaked": {
       "rollup": {
         "code": 28,

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -110,3 +110,67 @@ const countReducerAtom = atomWithReducer(0, countReducer)
 ```
 
 https://codesandbox.io/s/react-typescript-forked-g3tsx
+
+## atomFamily
+
+Ref: https://github.com/pmndrs/jotai/issues/23
+
+### Usage
+
+```js
+atomFamily(initializeRead, initializeWrite, areEqual): (param) => Atom
+```
+
+This will create a function that takes `param` and returns an atom.
+If it's already created, it will return it from the cache.
+`initializeRead` and `initializeWrite` are functions and return
+`read` and `write` respectively that are fed into `atom()`.
+Note that `initializeWrite` is optional.
+The third argument `areEqual` is also optional, which tell
+if two params are equal (defaults to `Object.is`.)
+
+To reproduce the similar behavior to [Recoil's atomFamily/selectorFamily](https://recoiljs.org/docs/api-reference/utils/atomFamily),
+specify a deepEqual function to `areEqual`. For example:
+
+```js
+import deepEqual from 'fast-deep-equal'
+
+const fooFamily = atomFamily((param) => param, null, deepEqual)
+```
+
+### Examples
+
+```js
+import { atomFamily } from 'jotai/utils'
+
+const todoFamily = atomFamily((name) => name)
+
+  todoFamily('foo')
+  // this will create a new atom('foo'), or return the one if already created
+```
+
+```js
+import { atomFamily } from 'jotai/utils'
+
+const todoFamily = atomFamily(
+  (name) => (get) => get(todosAtom)[name],
+  (name) => (get, set, arg) => {
+    const prev = get(todosAtom)
+    return { ...prev, [name]: { ...prev[name], ...arg } }
+  }
+)
+```
+
+```js
+import { atomFamily } from 'jotai/utils'
+
+const todoFamily = atomFamily(
+  ({ id, name }) => ({ name }),
+  null,
+  (a, b) => a.id === b.id
+)
+```
+
+### Codesandbox
+
+https://codesandbox.io/s/react-typescript-forked-8zfrn

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,8 @@ import { atom, useAtom, Atom, WritableAtom, PrimitiveAtom } from 'jotai'
 
 import type { SetStateAction, Getter, Setter } from './types'
 
+// -----------------------------------------------------------------------
+
 export const useUpdateAtom = <Value, Update>(
   anAtom: WritableAtom<Value, Update>
 ) => {
@@ -12,6 +14,8 @@ export const useUpdateAtom = <Value, Update>(
   )
   return useAtom(writeOnlyAtom)[1]
 }
+
+// -----------------------------------------------------------------------
 
 const RESET = Symbol()
 
@@ -42,6 +46,8 @@ export const useResetAtom = <Value>(
   return useAtom(writeOnlyAtom)[1]
 }
 
+// -----------------------------------------------------------------------
+
 export const useReducerAtom = <Value, Action>(
   anAtom: PrimitiveAtom<Value>,
   reducer: (v: Value, a: Action) => Value
@@ -56,6 +62,8 @@ export const useReducerAtom = <Value, Action>(
   return [state, dispatch] as const
 }
 
+// -----------------------------------------------------------------------
+
 export const atomWithReducer = <Value, Action>(
   initialValue: Value,
   reducer: (v: Value, a: Action) => Value
@@ -65,6 +73,8 @@ export const atomWithReducer = <Value, Action>(
   )
   return anAtom as WritableAtom<Value, Action>
 }
+
+// -----------------------------------------------------------------------
 
 type AtomFamily<Param, AtomType> = {
   (param: Param): AtomType
@@ -162,3 +172,5 @@ export function atomFamily<Param, Value, Update>(
   }
   return createAtom
 }
+
+// -----------------------------------------------------------------------

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,12 @@
 import { useCallback, useMemo } from 'react'
-import { atom, WritableAtom, useAtom } from 'jotai'
+import { atom, useAtom, Atom, WritableAtom, PrimitiveAtom } from 'jotai'
 
 import type {
   NonPromise,
   NonFunction,
   SetStateAction,
-  PrimitiveAtom,
+  Getter,
+  Setter,
 } from './types'
 
 export const useUpdateAtom = <Value, Update>(
@@ -71,4 +72,81 @@ export const atomWithReducer = <Value, Action>(
     set(anAtom, reducer(get(anAtom), action))
   )
   return anAtom as WritableAtom<Value, Action>
+}
+
+type AtomFamilyReturnType<Param, AtomType> = {
+  (param: Param): AtomType
+  remove(atom: AtomType): void
+}
+
+type AtomFamily = {
+  // writable derived atom
+  <Param, Value, Update>(
+    initializeRead: (param?: Param) => (get: Getter) => NonPromise<Value>,
+    initializeWrite: (
+      param?: Param
+    ) => (get: Getter, set: Setter, update: Update) => void | Promise<void>,
+    areEqual?: (a: Param, b: Param) => boolean
+  ): AtomFamilyReturnType<Param, WritableAtom<Value, Update>>
+  // write-only derived atom
+  <Param, Value, Update>(
+    initializeRead: (param?: Param) => NonFunction<NonPromise<Value>>,
+    initializeWrite: (
+      param?: Param
+    ) => (get: Getter, set: Setter, update: Update) => void | Promise<void>,
+    areEqual?: (a: Param, b: Param) => boolean
+  ): AtomFamilyReturnType<Param, WritableAtom<Value, Update>>
+  // async-read writable derived atom
+  <Param, Value, Update>(
+    initializeRead: (param?: Param) => (get: Getter) => Promise<Value>,
+    initializeWrite: (
+      param?: Param
+    ) => (get: Getter, set: Setter, update: Update) => void | Promise<void>,
+    areEqual?: (a: Param, b: Param) => boolean
+  ): AtomFamilyReturnType<Param, WritableAtom<Value | Promise<Value>, Update>>
+  // read-only derived atom
+  <Param, Value>(
+    initializeRead: (param?: Param) => (get: Getter) => NonPromise<Value>,
+    initializeWrite?: null,
+    areEqual?: (a: Param, b: Param) => boolean
+  ): AtomFamilyReturnType<Param, Atom<Value>>
+  // async-read read-only derived atom
+  <Param, Value>(
+    initializeRead: (param?: Param) => (get: Getter) => Promise<Value>,
+    initializeWrite?: null,
+    areEqual?: (a: Param, b: Param) => boolean
+  ): AtomFamilyReturnType<Param, Atom<Value | Promise<Value>>>
+  // primitive atom
+  <Param, Value>(
+    initializeRead: (param?: Param) => NonFunction<NonPromise<Value>>,
+    initializeWrite?: null,
+    areEqual?: (a: Param, b: Param) => boolean
+  ): AtomFamilyReturnType<Param, PrimitiveAtom<Value>>
+}
+
+export const atomFamily: AtomFamily = <Param, AtomType>(
+  initializeRead: (param?: Param) => any,
+  initializeWrite?: null | ((param?: Param) => any),
+  areEqual: (a: Param, b: Param) => boolean = Object.is
+) => {
+  const atoms: [Param, AtomType][] = []
+  const createAtom = (param: Param) => {
+    const found = atoms.find((x) => areEqual(x[0], param))
+    if (found) {
+      return found[1]
+    }
+    const newAtom = (atom(
+      initializeRead(param),
+      initializeWrite && initializeWrite(param)
+    ) as unknown) as AtomType
+    atoms.unshift([param, newAtom])
+    return newAtom
+  }
+  createAtom.remove = (a: AtomType) => {
+    const index = atoms.findIndex((x) => x[1] === a)
+    if (index >= 0) {
+      atoms.splice(index, 1)
+    }
+  }
+  return createAtom
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,7 +76,8 @@ export function atomFamily<Param, Value, Update>(
   initializeRead: (param: Param) => (get: Getter) => Promise<Value>,
   initializeWrite: (
     param: Param
-  ) => (get: Getter, set: Setter, update: Update) => void | Promise<void>
+  ) => (get: Getter, set: Setter, update: Update) => void | Promise<void>,
+  areEqual?: (a: Param, b: Param) => boolean
 ): AtomFamily<Param, WritableAtom<Value | Promise<Value>, Update>>
 
 // writable derived atom
@@ -84,7 +85,8 @@ export function atomFamily<Param, Value, Update>(
   initializeRead: (param: Param) => (get: Getter) => Value,
   initializeWrite: (
     param: Param
-  ) => (get: Getter, set: Setter, update: Update) => void | Promise<void>
+  ) => (get: Getter, set: Setter, update: Update) => void | Promise<void>,
+  areEqual?: (a: Param, b: Param) => boolean
 ): AtomFamily<Param, WritableAtom<Value, Update>>
 
 // invalid writable derived atom
@@ -92,7 +94,8 @@ export function atomFamily<Param, Value, Update>(
   initializeRead: (param: Param) => Function,
   initializeWrite: (
     param: Param
-  ) => (get: Getter, set: Setter, update: Update) => void | Promise<void>
+  ) => (get: Getter, set: Setter, update: Update) => void | Promise<void>,
+  areEqual?: (a: Param, b: Param) => boolean
 ): never
 
 // write-only derived atom
@@ -100,27 +103,36 @@ export function atomFamily<Param, Value, Update>(
   initializeRead: (param: Param) => Value,
   initializeWrite: (
     param: Param
-  ) => (get: Getter, set: Setter, update: Update) => void | Promise<void>
+  ) => (get: Getter, set: Setter, update: Update) => void | Promise<void>,
+  areEqual?: (a: Param, b: Param) => boolean
 ): AtomFamily<Param, WritableAtom<Value, Update>>
 
 // async-read read-only derived atom
 export function atomFamily<Param, Value, Update extends never = never>(
-  initializeRead: (param: Param) => (get: Getter) => Promise<Value>
+  initializeRead: (param: Param) => (get: Getter) => Promise<Value>,
+  initializeWrite?: null,
+  areEqual?: (a: Param, b: Param) => boolean
 ): AtomFamily<Param, Atom<Value | Promise<Value>>>
 
 // read-only derived atom
 export function atomFamily<Param, Value, Update extends never = never>(
-  initializeRead: (param: Param) => (get: Getter) => Value
+  initializeRead: (param: Param) => (get: Getter) => Value,
+  initializeWrite?: null,
+  areEqual?: (a: Param, b: Param) => boolean
 ): AtomFamily<Param, Atom<Value>>
 
 // invalid read-only derived atom
 export function atomFamily<Param, Value, Update>(
-  initializeRead: (param: Param) => Function
+  initializeRead: (param: Param) => Function,
+  initializeWrite?: null,
+  areEqual?: (a: Param, b: Param) => boolean
 ): never
 
 // primitive atom
 export function atomFamily<Param, Value, Update extends never = never>(
-  initializeRead: (param: Param) => Value
+  initializeRead: (param: Param) => Value,
+  initializeWrite?: null,
+  areEqual?: (a: Param, b: Param) => boolean
 ): AtomFamily<Param, PrimitiveAtom<Value>>
 
 export function atomFamily<Param, Value, Update>(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,7 +77,7 @@ type AtomReturnType<Read, Write> = typeof atom extends (
 
 type AtomFamilyReturnType<Param, Read, Write> = {
   (param: Param): AtomReturnType<Read, Write>
-  remove(atom: any): void
+  remove(param: Param): void
 }
 
 type AtomFamily = {
@@ -112,8 +112,8 @@ export const atomFamily: AtomFamily = <Param, Read, Write>(
     atoms.unshift([param, newAtom])
     return newAtom
   }
-  createAtom.remove = (a: AtomType) => {
-    const index = atoms.findIndex((x) => x[1] === a)
+  createAtom.remove = (p: Param) => {
+    const index = atoms.findIndex((x) => x[0] === p)
     if (index >= 0) {
       atoms.splice(index, 1)
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,7 +78,7 @@ export function atomFamily<Param, Value, Update>(
     param: Param
   ) => (get: Getter, set: Setter, update: Update) => void | Promise<void>,
   areEqual?: (a: Param, b: Param) => boolean
-): AtomFamily<Param, WritableAtom<Value | Promise<Value>, Update>>
+): AtomFamily<Param, WritableAtom<Value, Update>>
 
 // writable derived atom
 export function atomFamily<Param, Value, Update>(
@@ -112,7 +112,7 @@ export function atomFamily<Param, Value, Update extends never = never>(
   initializeRead: (param: Param) => (get: Getter) => Promise<Value>,
   initializeWrite?: null,
   areEqual?: (a: Param, b: Param) => boolean
-): AtomFamily<Param, Atom<Value | Promise<Value>>>
+): AtomFamily<Param, Atom<Value>>
 
 // read-only derived atom
 export function atomFamily<Param, Value, Update extends never = never>(


### PR DESCRIPTION
Close #23 

- [x] example snippet
- [x] example codesandbox
- [x] docs/utils.md (how to use areEqual for recoil-like-behavior)

```js
import { atomFamily } from 'jotai/utils'

const todoFamily = atomFamily((name) => name)

  todoFamily('foo')
  // this will create a new atom('foo'), or return the one if already created
```

```js
import { atomFamily } from 'jotai/utils'

const todoFamily = atomFamily(
  (name) => (get) => get(todosAtom)[name],
  (name) => (get, set, arg) => {
    const prev = get(todosAtom)
    return { ...prev, [name]: { ...prev[name], ...arg } }
  }
)
```

```js
import { atomFamily } from 'jotai/utils'

const todoFamily = atomFamily(
  ({ id, name }) => ({ name }),
  null,
  (a, b) => a.id === b.id
)
```
