### PR TITLE
useContextUpdate in use-context-selector v1.2

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,27 +1,27 @@
 {
   "index.js": {
-    "bundled": 17476,
-    "minified": 7007,
-    "gzipped": 2492,
+    "bundled": 17781,
+    "minified": 7174,
+    "gzipped": 2551,
     "treeshaked": {
       "rollup": {
-        "code": 300,
-        "import_statements": 67
+        "code": 318,
+        "import_statements": 85
       },
       "webpack": {
-        "code": 1372
+        "code": 1425
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 19299,
-    "minified": 7967,
-    "gzipped": 2641
+    "bundled": 19605,
+    "minified": 8123,
+    "gzipped": 2699
   },
   "index.iife.js": {
-    "bundled": 20394,
-    "minified": 6527,
-    "gzipped": 2384
+    "bundled": 20696,
+    "minified": 6648,
+    "gzipped": 2446
   },
   "utils.js": {
     "bundled": 1966,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 17032,
-    "minified": 6774,
-    "gzipped": 2438,
+    "bundled": 17476,
+    "minified": 7007,
+    "gzipped": 2492,
     "treeshaked": {
       "rollup": {
         "code": 300,
@@ -14,14 +14,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 18750,
-    "minified": 7704,
-    "gzipped": 2584
+    "bundled": 19299,
+    "minified": 7967,
+    "gzipped": 2641
   },
   "index.iife.js": {
-    "bundled": 19815,
-    "minified": 6334,
-    "gzipped": 2327
+    "bundled": 20394,
+    "minified": 6527,
+    "gzipped": 2384
   },
   "utils.js": {
     "bundled": 1966,

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@types/jest": "^26.0.14",
     "@types/react": "^16.9.50",
     "@types/react-dom": "^16.9.8",
+    "@types/scheduler": "^0.16.1",
     "@typescript-eslint/eslint-plugin": "^4.3.0",
     "@typescript-eslint/parser": "^4.3.0",
     "copyfiles": "^2.4.0",
@@ -119,9 +120,11 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-size-snapshot": "^0.12.0",
     "rollup-plugin-typescript2": "^0.27.3",
+    "scheduler": "^0.19.1",
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "scheduler": ">=0.19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     ]
   },
   "dependencies": {
-    "use-context-selector": "1.2.2"
+    "use-context-selector": "1.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -550,7 +550,7 @@ const runWriteThunk = (
 export const ActionsContext = createContext(warningObject as Actions)
 export const StateContext = createContext(warningObject as State)
 
-const InnerStateProvider: React.FC<{
+const InnerProvider: React.FC<{
   contextUpdateRef: MutableRefObject<((t: () => void) => void) | undefined>
 }> = ({ contextUpdateRef, children }) => {
   const contextUpdate = useContextUpdate(StateContext)
@@ -652,7 +652,7 @@ export const Provider: React.FC = ({ children }) => {
     createElement(
       StateContext.Provider,
       { value: state },
-      createElement(InnerStateProvider, { contextUpdateRef }, children)
+      createElement(InnerProvider, { contextUpdateRef }, children)
     )
   )
 }

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,4 +1,4 @@
-import React, { StrictMode, useEffect } from 'react'
+import React, { StrictMode, useEffect, useRef } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { Provider, atom, useAtom, WritableAtom } from '../src/index'
 
@@ -177,11 +177,14 @@ it('only re-renders if value has changed', async () => {
   type Props = { countAtom: typeof count1Atom; name: string }
   const Counter: React.FC<Props> = ({ countAtom, name }) => {
     const [count, setCount] = useAtom(countAtom)
-    const renderCount = React.useRef(0)
+    const commits = useRef(1)
+    useEffect(() => {
+      ++commits.current
+    })
     return (
       <>
         <div>
-          renderCount: {++renderCount.current}, {name}: {count}
+          commits: {commits.current}, {name}: {count}
         </div>
         <button onClick={() => setCount((c) => c + 1)}>button-{name}</button>
       </>
@@ -190,11 +193,14 @@ it('only re-renders if value has changed', async () => {
 
   const Product: React.FC = () => {
     const [product] = useAtom(productAtom)
-    const renderCount = React.useRef(0)
+    const commits = useRef(1)
+    useEffect(() => {
+      ++commits.current
+    })
     return (
       <>
-        <div>
-          renderCount: {++renderCount.current}, product: {product}
+        <div data-testid="product">
+          commits: {commits.current}, product: {product}
         </div>
       </>
     )
@@ -208,19 +214,19 @@ it('only re-renders if value has changed', async () => {
     </Provider>
   )
 
-  await findByText('renderCount: 1, count1: 0')
-  await findByText('renderCount: 1, count2: 0')
-  await findByText('renderCount: 1, product: 0')
+  await findByText('commits: 1, count1: 0')
+  await findByText('commits: 1, count2: 0')
+  await findByText('commits: 1, product: 0')
 
   fireEvent.click(getByText('button-count1'))
-  await findByText('renderCount: 2, count1: 1')
-  await findByText('renderCount: 1, count2: 0')
-  await findByText('renderCount: 1, product: 0')
+  await findByText('commits: 2, count1: 1')
+  await findByText('commits: 1, count2: 0')
+  await findByText('commits: 1, product: 0')
 
   fireEvent.click(getByText('button-count2'))
-  await findByText('renderCount: 2, count1: 1')
-  await findByText('renderCount: 2, count2: 1')
-  await findByText('renderCount: 2, product: 1')
+  await findByText('commits: 2, count1: 1')
+  await findByText('commits: 2, count2: 1')
+  await findByText('commits: 2, product: 1')
 })
 
 it('works with async get', async () => {
@@ -233,11 +239,14 @@ it('works with async get', async () => {
   const Counter: React.FC = () => {
     const [count, setCount] = useAtom(countAtom)
     const [delayedCount] = useAtom(asyncCountAtom)
-    const renderCount = React.useRef(0)
+    const commits = useRef(1)
+    useEffect(() => {
+      ++commits.current
+    })
     return (
       <>
         <div>
-          renderCount: {++renderCount.current}, count: {count}, delayedCount:{' '}
+          commits: {commits.current}, count: {count}, delayedCount:{' '}
           {delayedCount}
         </div>
         <button onClick={() => setCount((c) => c + 1)}>button</button>
@@ -254,11 +263,11 @@ it('works with async get', async () => {
   )
 
   await findByText('loading')
-  await findByText('renderCount: 1, count: 0, delayedCount: 0')
+  await findByText('commits: 1, count: 0, delayedCount: 0')
 
   fireEvent.click(getByText('button'))
   await findByText('loading')
-  await findByText('renderCount: 2, count: 1, delayedCount: 1')
+  await findByText('commits: 2, count: 1, delayedCount: 1')
 })
 
 it('shows loading with async set', async () => {
@@ -273,11 +282,14 @@ it('shows loading with async set', async () => {
 
   const Counter: React.FC = () => {
     const [count, setCount] = useAtom(asyncCountAtom)
-    const renderCount = React.useRef(0)
+    const commits = useRef(1)
+    useEffect(() => {
+      ++commits.current
+    })
     return (
       <>
         <div>
-          renderCount: {++renderCount.current}, count: {count}
+          commits: {commits.current}, count: {count}
         </div>
         <button onClick={() => setCount(count + 1)}>button</button>
       </>
@@ -292,12 +304,12 @@ it('shows loading with async set', async () => {
     </Provider>
   )
 
-  await findByText('renderCount: 1, count: 0')
+  await findByText('commits: 1, count: 0')
 
   fireEvent.click(getByText('button'))
   await findByText('loading')
 
-  await findByText('renderCount: 2, count: 1')
+  await findByText('commits: 2, count: 1')
 })
 
 it('uses atoms with tree dependencies', async () => {
@@ -314,11 +326,14 @@ it('uses atoms with tree dependencies', async () => {
   const Counter: React.FC = () => {
     const [count] = useAtom(leftAtom)
     const [, setCount] = useAtom(rightAtom)
-    const renderCount = React.useRef(0)
+    const commits = useRef(1)
+    useEffect(() => {
+      ++commits.current
+    })
     return (
       <>
         <div>
-          renderCount: {++renderCount.current}, count: {count}
+          commits: {commits.current}, count: {count}
         </div>
         <button onClick={() => setCount((c) => c + 1)}>button</button>
       </>
@@ -333,15 +348,15 @@ it('uses atoms with tree dependencies', async () => {
     </Provider>
   )
 
-  await findByText('renderCount: 1, count: 0')
+  await findByText('commits: 1, count: 0')
 
   fireEvent.click(getByText('button'))
   await findByText('loading')
-  await findByText('renderCount: 2, count: 1')
+  await findByText('commits: 2, count: 1')
 
   fireEvent.click(getByText('button'))
   await findByText('loading')
-  await findByText('renderCount: 3, count: 2')
+  await findByText('commits: 3, count: 2')
 })
 
 it('runs update only once in StrictMode', async () => {
@@ -394,11 +409,14 @@ it('uses an async write-only atom', async () => {
   const Counter: React.FC = () => {
     const [count] = useAtom(countAtom)
     const [, setCount] = useAtom(asyncCountAtom)
-    const renderCount = React.useRef(0)
+    const commits = useRef(1)
+    useEffect(() => {
+      ++commits.current
+    })
     return (
       <>
         <div>
-          renderCount: {++renderCount.current}, count: {count}
+          commits: {commits.current}, count: {count}
         </div>
         <button onClick={() => setCount((c) => c + 1)}>button</button>
       </>
@@ -413,12 +431,12 @@ it('uses an async write-only atom', async () => {
     </Provider>
   )
 
-  await findByText('renderCount: 1, count: 0')
+  await findByText('commits: 1, count: 0')
 
   fireEvent.click(getByText('button'))
   await findByText('loading')
 
-  await findByText('renderCount: 2, count: 1')
+  await findByText('commits: 2, count: 1')
 })
 
 it('uses a writable atom without read function', async () => {
@@ -520,12 +538,15 @@ it('only invoke read function on use atom', async () => {
   const Counter: React.FC = () => {
     const [count, setCount] = useAtom(countAtom)
     const [doubledCount] = useAtom(doubledCountAtom)
-    const renderCount = React.useRef(0)
+    const commits = useRef(1)
+    useEffect(() => {
+      ++commits.current
+    })
     return (
       <>
         <div>
-          renderCount: {++renderCount.current}, count: {count}, readCount:{' '}
-          {readCount}, doubled: {doubledCount}
+          commits: {commits.current}, count: {count}, readCount: {readCount},
+          doubled: {doubledCount}
         </div>
         <button onClick={() => setCount((c) => c + 1)}>button</button>
       </>
@@ -538,10 +559,10 @@ it('only invoke read function on use atom', async () => {
     </Provider>
   )
 
-  await findByText('renderCount: 1, count: 0, readCount: 1, doubled: 0')
+  await findByText('commits: 1, count: 0, readCount: 1, doubled: 0')
 
   fireEvent.click(getByText('button'))
-  await findByText('renderCount: 2, count: 1, readCount: 2, doubled: 2')
+  await findByText('commits: 2, count: 1, readCount: 2, doubled: 2')
 })
 
 it('uses a read-write derived atom with two primitive atoms', async () => {

--- a/tests/dependency.test.tsx
+++ b/tests/dependency.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import { fireEvent, cleanup, render } from '@testing-library/react'
 import { Provider, atom, useAtom } from '../src/index'
 
@@ -17,12 +17,15 @@ it('works with 2 level dependencies', async () => {
     const [count, setCount] = useAtom(countAtom)
     const [doubledCount] = useAtom(doubledAtom)
     const [tripledCount] = useAtom(tripledAtom)
-    const renderCount = React.useRef(0)
+    const commits = useRef(1)
+    useEffect(() => {
+      ++commits.current
+    })
     return (
       <>
         <div>
-          renderCount: {++renderCount.current}, count: {count}, doubled:{' '}
-          {doubledCount}, tripled: {tripledCount}
+          commits: {commits.current}, count: {count}, doubled: {doubledCount},
+          tripled: {tripledCount}
         </div>
         <button onClick={() => setCount((c) => c + 1)}>button</button>
       </>
@@ -35,8 +38,8 @@ it('works with 2 level dependencies', async () => {
     </Provider>
   )
 
-  await findByText('renderCount: 1, count: 1, doubled: 2, tripled: 6')
+  await findByText('commits: 1, count: 1, doubled: 2, tripled: 6')
 
   fireEvent.click(getByText('button'))
-  await findByText('renderCount: 2, count: 2, doubled: 4, tripled: 12')
+  await findByText('commits: 2, count: 2, doubled: 4, tripled: 12')
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7066,10 +7066,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-context-selector@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/use-context-selector/-/use-context-selector-1.2.2.tgz#b1a7d0899e7ab4391a5a08a3d7ab71f1e27cf5de"
-  integrity sha512-1kkfRrlk3ol422nWurgdGq1M2xig4n/cYNd9Xqly1MtrNPiEbxQYLBE1adE5BeGu374pIq0garxtf6/wd1GNbw==
+use-context-selector@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/use-context-selector/-/use-context-selector-1.2.3.tgz#f60cc928871c67f5b506f8c12eb94bf46ef11ec2"
+  integrity sha512-IZuqaT3mxLyDMXbDJQdMqnd6sDI199aQrxfTiz4I8O1vvA5z8valZmtyBLxnM8dOF2hserHdFSza+cjf5gWdyg==
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1346,6 +1346,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/scheduler@^0.16.1":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"


### PR DESCRIPTION
The whole point of v0.8.0 was updating to use-context-selector v1.2, but I forgot to apply this change to use useContextUpdate. I also found a bug in use-context-selector v1.2 which is fixed.