### PR TITLE
simplify async read atom types

### DIFF
--- a/src/atom.ts
+++ b/src/atom.ts
@@ -2,15 +2,9 @@ import { Getter, Setter, Atom, WritableAtom, PrimitiveAtom } from './types'
 
 let keyCount = 0 // global key count for all atoms
 
-// async-read writable derived atom
-export function atom<Value, Update>(
-  read: (get: Getter) => Promise<Value>,
-  write: (get: Getter, set: Setter, update: Update) => void | Promise<void>
-): WritableAtom<Value, Update>
-
 // writable derived atom
 export function atom<Value, Update>(
-  read: (get: Getter) => Value,
+  read: (get: Getter) => Value | Promise<Value>,
   write: (get: Getter, set: Setter, update: Update) => void | Promise<void>
 ): WritableAtom<Value, Update>
 
@@ -26,14 +20,9 @@ export function atom<Value, Update>(
   write: (get: Getter, set: Setter, update: Update) => void | Promise<void>
 ): WritableAtom<Value, Update>
 
-// async-read read-only derived atom
-export function atom<Value, Update extends never = never>(
-  read: (get: Getter) => Promise<Value>
-): Atom<Value>
-
 // read-only derived atom
 export function atom<Value, Update extends never = never>(
-  read: (get: Getter) => Value
+  read: (get: Getter) => Value | Promise<Value>
 ): Atom<Value>
 
 // invalid read-only derived atom

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,18 +106,9 @@ type AtomFamily<Param, AtomType> = {
   remove(param: Param): void
 }
 
-// async-read writable derived atom
-export function atomFamily<Param, Value, Update>(
-  initializeRead: (param: Param) => (get: Getter) => Promise<Value>,
-  initializeWrite: (
-    param: Param
-  ) => (get: Getter, set: Setter, update: Update) => void | Promise<void>,
-  areEqual?: (a: Param, b: Param) => boolean
-): AtomFamily<Param, WritableAtom<Value, Update>>
-
 // writable derived atom
 export function atomFamily<Param, Value, Update>(
-  initializeRead: (param: Param) => (get: Getter) => Value,
+  initializeRead: (param: Param) => (get: Getter) => Value | Promise<Value>,
   initializeWrite: (
     param: Param
   ) => (get: Getter, set: Setter, update: Update) => void | Promise<void>,
@@ -142,16 +133,9 @@ export function atomFamily<Param, Value, Update>(
   areEqual?: (a: Param, b: Param) => boolean
 ): AtomFamily<Param, WritableAtom<Value, Update>>
 
-// async-read read-only derived atom
-export function atomFamily<Param, Value, Update extends never = never>(
-  initializeRead: (param: Param) => (get: Getter) => Promise<Value>,
-  initializeWrite?: null,
-  areEqual?: (a: Param, b: Param) => boolean
-): AtomFamily<Param, Atom<Value>>
-
 // read-only derived atom
 export function atomFamily<Param, Value, Update extends never = never>(
-  initializeRead: (param: Param) => (get: Getter) => Value,
+  initializeRead: (param: Param) => (get: Getter) => Value | Promise<Value>,
   initializeWrite?: null,
   areEqual?: (a: Param, b: Param) => boolean
 ): AtomFamily<Param, Atom<Value>>


### PR DESCRIPTION
We used to distinguish async-read and normal read for certain reason, but it seems we no longer need it.