### PR TITLE
add atomWithReducer.test

### DIFF
--- a/tests/utils/atomWithReducer.test.tsx
+++ b/tests/utils/atomWithReducer.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import { fireEvent, render } from '@testing-library/react'
+import { Provider, useAtom } from '../../src/index'
+import { atomWithReducer } from '../../src/utils'
+
+it('atomWithReducer with optional action argument', async () => {
+  const reducer = (state: number, action?: 'INCREASE' | 'DECREASE') => {
+    switch (action) {
+      case 'INCREASE':
+        return state + 1
+      case 'DECREASE':
+        return state - 1
+      case undefined:
+        return state
+    }
+  }
+  const countAtom = atomWithReducer(0, reducer)
+
+  const Parent: React.FC = () => {
+    const [count, dispatch] = useAtom(countAtom)
+    return (
+      <>
+        <div>count: {count}</div>
+        <button onClick={() => dispatch('INCREASE')}>dispatch INCREASE</button>
+        <button onClick={() => dispatch('DECREASE')}>dispatch DECREASE</button>
+        <button onClick={() => dispatch()}>dispatch empty</button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Parent />
+    </Provider>
+  )
+
+  await findByText('count: 0')
+
+  fireEvent.click(getByText('dispatch INCREASE'))
+  await findByText('count: 1')
+
+  fireEvent.click(getByText('dispatch empty'))
+  await findByText('count: 1')
+
+  fireEvent.click(getByText('dispatch DECREASE'))
+  await findByText('count: 0')
+})
+
+it('atomWithReducer with non-optional action argument', async () => {
+  const reducer = (state: number, action: 'INCREASE' | 'DECREASE') => {
+    switch (action) {
+      case 'INCREASE':
+        return state + 1
+      case 'DECREASE':
+        return state - 1
+    }
+  }
+  const countAtom = atomWithReducer(0, reducer)
+
+  const Parent: React.FC = () => {
+    const [count, dispatch] = useAtom(countAtom)
+    return (
+      <>
+        <div>count: {count}</div>
+        <button onClick={() => dispatch('INCREASE')}>dispatch INCREASE</button>
+        <button onClick={() => dispatch('DECREASE')}>dispatch DECREASE</button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Parent />
+    </Provider>
+  )
+
+  await findByText('count: 0')
+
+  fireEvent.click(getByText('dispatch INCREASE'))
+  await findByText('count: 1')
+
+  fireEvent.click(getByText('dispatch DECREASE'))
+  await findByText('count: 0')
+})


### PR DESCRIPTION
I was just thinking, is there any reason there is no reducer-without-argument function signature for this one.

The specific one I'm thinking about is:

```typescript
export function atomWithReducer<Value, Action>(
  initialValue: Value,
  reducer: (v: Value) => Value
): WritableAtom<Value, undefined>
``` 
(Or similar)