### PR TITLE
New impl dependents in state no gc

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 18481,
-    "minified": 8300,
-    "gzipped": 3029,
+    "bundled": 18201,
+    "minified": 8250,
+    "gzipped": 3019,
     "treeshaked": {
       "rollup": {
         "code": 318,
@@ -14,14 +14,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 22018,
-    "minified": 10282,
-    "gzipped": 3534
+    "bundled": 21812,
+    "minified": 10254,
+    "gzipped": 3531
   },
   "index.iife.js": {
-    "bundled": 23339,
-    "minified": 8378,
-    "gzipped": 3204
+    "bundled": 23121,
+    "minified": 8350,
+    "gzipped": 3200
   },
   "utils.js": {
     "bundled": 1894,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 18696,
-    "minified": 8361,
-    "gzipped": 3064,
+    "bundled": 18675,
+    "minified": 8358,
+    "gzipped": 3056,
     "treeshaked": {
       "rollup": {
         "code": 318,
@@ -14,14 +14,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 22222,
-    "minified": 10311,
-    "gzipped": 3545
+    "bundled": 22201,
+    "minified": 10312,
+    "gzipped": 3541
   },
   "index.iife.js": {
-    "bundled": 23565,
-    "minified": 8439,
-    "gzipped": 3223
+    "bundled": 23542,
+    "minified": 8440,
+    "gzipped": 3224
   },
   "utils.js": {
     "bundled": 1894,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,27 +1,27 @@
 {
   "index.js": {
-    "bundled": 16565,
-    "minified": 7255,
-    "gzipped": 2784,
+    "bundled": 18696,
+    "minified": 8361,
+    "gzipped": 3064,
     "treeshaked": {
       "rollup": {
         "code": 318,
         "import_statements": 85
       },
       "webpack": {
-        "code": 1437
+        "code": 1441
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 20089,
-    "minified": 9283,
-    "gzipped": 3315
+    "bundled": 22222,
+    "minified": 10311,
+    "gzipped": 3545
   },
   "index.iife.js": {
-    "bundled": 21288,
-    "minified": 7622,
-    "gzipped": 2961
+    "bundled": 23565,
+    "minified": 8439,
+    "gzipped": 3223
   },
   "utils.js": {
     "bundled": 1894,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 18675,
-    "minified": 8358,
-    "gzipped": 3056,
+    "bundled": 18481,
+    "minified": 8300,
+    "gzipped": 3029,
     "treeshaked": {
       "rollup": {
         "code": 318,
@@ -14,14 +14,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 22201,
-    "minified": 10312,
-    "gzipped": 3541
+    "bundled": 22018,
+    "minified": 10282,
+    "gzipped": 3534
   },
   "index.iife.js": {
-    "bundled": 23542,
-    "minified": 8440,
-    "gzipped": 3224
+    "bundled": 23339,
+    "minified": 8378,
+    "gzipped": 3204
   },
   "utils.js": {
     "bundled": 1894,

--- a/docs/core.md
+++ b/docs/core.md
@@ -38,7 +38,7 @@ const Root = () => (
 
 ## useAtom
 
-The useAtom hook is to read an atom value stored in the Provider. It returns the atom value and an updating function as a tuple, just like useState. It takes an atom config created with `atom()`. Initially, there is no value stored in the Provider. The first time the atom is used via `useAtom`, it will add an initial value in the Provider. If the atom is a derived atom, the read function is executed to compute an initial value. When an atom is no longer used, meaning the component using it is unmounted, the value is removed from the Provider.
+The useAtom hook is to read an atom value stored in the Provider. It returns the atom value and an updating function as a tuple, just like useState. It takes an atom config created with `atom()`. Initially, there is no value stored in the Provider. The first time the atom is used via `useAtom`, it will add an initial value in the Provider. If the atom is a derived atom, the read function is executed to compute an initial value. When an atom is no longer used, meaning and the component using it is unmounted, and the atom config no longer exists, the value is removed from the Provider.
 
 ```js
 const [value, updateValue] = useAtom(anAtom)

--- a/docs/core.md
+++ b/docs/core.md
@@ -38,7 +38,7 @@ const Root = () => (
 
 ## useAtom
 
-The useAtom hook is to read an atom value stored in the Provider. It returns the atom value and an updating function as a tuple, just like useState. It takes an atom config created with `atom()`. Initially, there is no value stored in the Provider. The first time the atom is used via `useAtom`, it will add an initial value in the Provider. If the atom is a derived atom, the read function is executed to compute an initial value. When an atom is no longer used, meaning and the component using it is unmounted, and the atom config no longer exists, the value is removed from the Provider.
+The useAtom hook is to read an atom value stored in the Provider. It returns the atom value and an updating function as a tuple, just like useState. It takes an atom config created with `atom()`. Initially, there is no value stored in the Provider. The first time the atom is used via `useAtom`, it will add an initial value in the Provider. If the atom is a derived atom, the read function is executed to compute an initial value. When an atom is no longer used, meaning all the components using it is unmounted, and the atom config no longer exists, the value is removed from the Provider.
 
 ```js
 const [value, updateValue] = useAtom(anAtom)

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -49,52 +49,11 @@ const warningObject = new Proxy(
   }
 )
 
-// dependents for read operation
-type DependentsMap = Map<AnyAtom, Set<AnyAtom | symbol>> // symbol is id from useAtom
-
-const addDependent = (
-  dependentsMap: DependentsMap,
-  atom: AnyAtom,
-  dependent: AnyAtom | symbol
-) => {
-  let dependents = dependentsMap.get(atom)
-  if (!dependents) {
-    dependents = new Set<AnyAtom | symbol>()
-    dependentsMap.set(atom, dependents)
-  }
-  dependents.add(dependent)
-}
-
-const deleteDependent = (
-  dependentsMap: DependentsMap,
-  dependent: AnyAtom | symbol
-) => {
-  dependentsMap.forEach((dependents) => {
-    dependents.delete(dependent)
-  })
-}
-
-const setDependencies = (
-  dependentsMap: DependentsMap,
-  atom: AnyAtom,
-  dependencies: Set<AnyAtom>
-) => {
-  deleteDependent(dependentsMap, atom)
-  dependencies.forEach((dependency) => {
-    addDependent(dependentsMap, dependency, atom)
-  })
-}
-
-const listDependents = (
-  dependentsMap: DependentsMap,
-  atom: AnyAtom,
-  excludeSelf: boolean
-) => {
-  const dependents = new Set(dependentsMap.get(atom))
-  if (excludeSelf) {
-    dependents.delete(atom)
-  }
-  return dependents
+const warnAtomStateNotFound = (info: string, atom: AnyAtom) => {
+  console.warn(
+    '[Bug] Atom state not found. Please file an issue with repro: ' + info,
+    atom
+  )
 }
 
 export type AtomState<Value = unknown> = {
@@ -102,9 +61,18 @@ export type AtomState<Value = unknown> = {
   readP?: Promise<void> // read promise
   writeP?: Promise<void> // write promise
   value?: Value
+  deps: Set<AnyAtom> // read dependents
 }
 
 type State = ImmutableMap<AnyAtom, AtomState>
+const initialState: State = mCreate()
+
+type UsedState = ImmutableMap<AnyAtom, Set<symbol>> // symbol is id from useAtom
+const initialUsedState: UsedState = mCreate()
+
+// we store last atom state before deleting from provider state
+// and reuse it as long as it's not gc'd
+type AtomStateCache = WeakMap<AnyAtom, AtomState>
 
 // pending state for adding a new atom
 type ReadPendingMap = WeakMap<State, State> // the value is next state
@@ -115,7 +83,7 @@ type WriteThunk = (lastState: State) => State // returns next state
 
 export type Actions = {
   add: <Value>(id: symbol, atom: Atom<Value>) => void
-  del: (id: symbol) => void
+  del: <Value>(id: symbol, atom: Atom<Value>) => void
   read: <Value>(state: State, atom: Atom<Value>) => AtomState<Value>
   write: <Value, Update>(
     atom: WritableAtom<Value, Update>,
@@ -123,51 +91,109 @@ export type Actions = {
   ) => void | Promise<void>
 }
 
-const initialState: State = mCreate()
-
-const getAtomStateValue = (atom: AnyAtom, state: State) => {
-  const atomState = mGet(state, atom)
+const updateAtomState = <Value>(
+  atom: Atom<Value>,
+  prevState: State,
+  partial: Partial<AtomState<Value>>,
+  prevPromise?: Promise<void>,
+  isNew?: boolean
+) => {
+  let atomState = mGet(prevState, atom) as AtomState<Value> | undefined
   if (!atomState) {
-    console.warn(
-      'Atom state not found. Possibly a bug. Please file an issue with repro.'
-    )
-    return atom.init
+    if (!isNew && process.env.NODE_ENV !== 'production') {
+      warnAtomStateNotFound('updateAtomState', atom)
+    }
+    atomState = { deps: new Set() }
   }
-  return atomState.value
+  if (prevPromise && prevPromise !== atomState.readP) {
+    return prevState
+  }
+  const nextAtomState: AtomState<Value> = { ...atomState, ...partial }
+  return mSet(prevState, atom, nextAtomState)
+}
+
+const addDependent = (atom: AnyAtom, dependent: AnyAtom, prevState: State) => {
+  let nextState = prevState
+  const atomState = mGet(nextState, atom)
+  if (atomState) {
+    if (!atomState.deps.has(dependent)) {
+      const newDeps = new Set(atomState.deps).add(dependent)
+      nextState = mSet(nextState, atom, { ...atomState, deps: newDeps })
+    }
+  } else if (process.env.NODE_ENV !== 'production') {
+    warnAtomStateNotFound('addDependent', atom)
+  }
+  return nextState
+}
+
+const replaceDependencies = (
+  atom: AnyAtom,
+  prevState: State,
+  dependenciesToReplace: Set<AnyAtom>
+) => {
+  const dependencies = new Set(dependenciesToReplace)
+  let nextState = prevState
+  mKeys(nextState).forEach((a) => {
+    const aState = mGet(nextState, a) as AtomState<unknown>
+    if (aState.deps.has(atom)) {
+      if (dependencies.has(a)) {
+        // not changed
+        dependencies.delete(a)
+      } else {
+        const newDeps = new Set(aState.deps)
+        newDeps.delete(atom)
+        nextState = mSet(nextState, a, { ...aState, deps: newDeps })
+      }
+    }
+  })
+  dependencies.forEach((a) => {
+    const aState = mGet(nextState, a)
+    if (aState) {
+      const newDeps = new Set(aState.deps).add(atom)
+      nextState = mSet(nextState, a, { ...aState, deps: newDeps })
+    } else if (process.env.NODE_ENV !== 'production') {
+      warnAtomStateNotFound('replaceDependencies', a)
+    }
+  })
+  return nextState
 }
 
 const readAtomState = <Value>(
   atom: Atom<Value>,
   prevState: State,
   setState: Dispatch<(prev: State) => State>,
-  dependentsMap: DependentsMap,
-  force?: boolean
+  atomStateCache?: AtomStateCache // read state then cache
 ) => {
-  if (!force) {
-    const atomState = mGet(prevState, atom) as AtomState<Value> | undefined
+  if (atomStateCache) {
+    let atomState = mGet(prevState, atom) as AtomState<Value> | undefined
     if (atomState) {
       return [atomState, prevState] as const
     }
+    atomState = atomStateCache.get(atom) as AtomState<Value> | undefined
+    if (atomState) {
+      return [atomState, mSet(prevState, atom, atomState)] as const
+    }
   }
+  let isSync = true
   let nextState = prevState
   let error: Error | undefined = undefined
   let promise: Promise<void> | undefined = undefined
   let value: Value | undefined = undefined
   let dependencies: Set<AnyAtom> | null = new Set()
-  let isSync = true
+  let flushDependencies = false
   try {
     const promiseOrValue = atom.read(((a: AnyAtom) => {
       if (dependencies) {
         dependencies.add(a)
       } else {
-        addDependent(dependentsMap, a, atom)
+        setState((prev) => addDependent(a, atom, prev))
       }
       if (a !== atom) {
         const [aState, nextNextState] = readAtomState(
           a,
           nextState,
           setState,
-          dependentsMap
+          atomStateCache
         )
         if (isSync) {
           nextState = nextNextState
@@ -196,32 +222,49 @@ const readAtomState = <Value>(
     if (promiseOrValue instanceof Promise) {
       promise = promiseOrValue
         .then((value) => {
-          setDependencies(dependentsMap, atom, dependencies as Set<AnyAtom>)
+          const dependenciesToReplace = dependencies as Set<AnyAtom>
           dependencies = null
           setState((prev) => {
-            const prevPromise = mGet(prev, atom)?.readP
-            if (prevPromise && prevPromise !== promise) {
-              return prev
-            }
-            return mSet(prev, atom, { value })
+            let nextState = prev
+            nextState = replaceDependencies(
+              atom,
+              nextState,
+              dependenciesToReplace
+            )
+            nextState = updateAtomState(
+              atom,
+              nextState,
+              { readE: undefined, readP: undefined, value },
+              promise
+            )
+            return nextState
           })
         })
         .catch((e) => {
+          const dependenciesToReplace = dependencies as Set<AnyAtom>
+          dependencies = null
           setState((prev) => {
-            const prevPromise = mGet(prev, atom)?.readP
-            if (prevPromise && prevPromise !== promise) {
-              return prev
-            }
-            return mSet(prev, atom, {
-              value: getAtomStateValue(atom, prev),
-              readE: e instanceof Error ? e : new Error(e),
-            })
+            let nextState = prev
+            nextState = replaceDependencies(
+              atom,
+              nextState,
+              dependenciesToReplace
+            )
+            nextState = updateAtomState(
+              atom,
+              nextState,
+              {
+                readE: e instanceof Error ? e : new Error(e),
+                readP: undefined,
+              },
+              promise
+            )
+            return nextState
           })
         })
     } else {
-      setDependencies(dependentsMap, atom, dependencies)
-      dependencies = null
       value = promiseOrValue
+      flushDependencies = true
     }
   } catch (errorOrPromise) {
     if (errorOrPromise instanceof Promise) {
@@ -231,48 +274,58 @@ const readAtomState = <Value>(
     } else {
       error = new Error(errorOrPromise)
     }
+    flushDependencies = true
   }
-  const nextAtomState: AtomState<Value> = {
-    readE: error,
-    readP: promise,
-    value: promise ? atom.init : value,
+  nextState = updateAtomState(
+    atom,
+    nextState,
+    {
+      readE: error,
+      readP: promise,
+      value: promise ? atom.init : value,
+    },
+    undefined,
+    true
+  )
+  if (flushDependencies) {
+    nextState = replaceDependencies(atom, nextState, dependencies)
+    dependencies = null
   }
-  nextState = mSet(nextState, atom, nextAtomState)
+  const atomState = mGet(nextState, atom) as AtomState<Value>
   isSync = false
-  return [nextAtomState, nextState] as const
+  return [atomState, nextState] as const
 }
 
 const updateDependentsState = <Value>(
   atom: Atom<Value>,
   prevState: State,
-  setState: Dispatch<(prev: State) => State>,
-  dependentsMap: DependentsMap
+  setState: Dispatch<(prev: State) => State>
 ) => {
   let nextState = prevState
-  listDependents(dependentsMap, atom, true).forEach((dependent) => {
+  const atomState = mGet(nextState, atom)
+  if (!atomState) {
+    if (process.env.NODE_ENV !== 'production') {
+      warnAtomStateNotFound('updateDependentsState', atom)
+    }
+    return nextState
+  }
+  atomState.deps.forEach((dependent) => {
+    if (dependent === atom) return
     if (typeof dependent === 'symbol') return
+    if (!mGet(nextState, dependent)) return
     const [dependentState, nextNextState] = readAtomState(
       dependent,
       nextState,
-      setState,
-      dependentsMap,
-      true
+      setState
     )
     const promise = dependentState.readP
     if (promise) {
       promise.then(() => {
-        setState((prev) =>
-          updateDependentsState(dependent, prev, setState, dependentsMap)
-        )
+        setState((prev) => updateDependentsState(dependent, prev, setState))
       })
       nextState = nextNextState
     } else {
-      nextState = updateDependentsState(
-        dependent,
-        nextNextState,
-        setState,
-        dependentsMap
-      )
+      nextState = updateDependentsState(dependent, nextNextState, setState)
     }
   })
   return nextState
@@ -282,15 +335,15 @@ const readAtom = <Value>(
   state: State,
   readingAtom: Atom<Value>,
   setState: Dispatch<(prev: State) => State>,
-  dependentsMap: DependentsMap,
-  readPendingMap: ReadPendingMap
+  readPendingMap: ReadPendingMap,
+  atomStateCache?: AtomStateCache
 ) => {
   let prevState = readPendingMap.get(state) || state
   const [atomState, nextState] = readAtomState(
     readingAtom,
     prevState,
     setState,
-    dependentsMap
+    atomStateCache
   )
   if (nextState !== prevState) {
     readPendingMap.set(state, nextState)
@@ -298,51 +351,10 @@ const readAtom = <Value>(
   return atomState
 }
 
-const addAtom = <Value>(
-  id: symbol,
-  atom: Atom<Value>,
-  dependentsMap: DependentsMap
-) => {
-  addDependent(dependentsMap, atom, id)
-}
-
-const delAtom = (
-  id: symbol,
-  setGcCount: Dispatch<SetStateAction<number>>,
-  dependentsMap: DependentsMap
-) => {
-  deleteDependent(dependentsMap, id)
-  setGcCount((c) => c + 1) // trigger re-render for gc
-}
-
-const gcAtom = (
-  state: State,
-  setState: Dispatch<State>,
-  dependentsMap: DependentsMap
-) => {
-  let nextState = state
-  let deleted: boolean
-  do {
-    deleted = false
-    mKeys(nextState).forEach((atom) => {
-      const isEmpty = dependentsMap.get(atom)?.size === 0
-      if (isEmpty) {
-        nextState = mDel(nextState, atom)
-        dependentsMap.delete(atom)
-        deleted = true
-      }
-    })
-  } while (deleted)
-  if (nextState !== state) {
-    setState(nextState)
-  }
-}
-
 const writeAtom = <Value, Update>(
   writingAtom: WritableAtom<Value, Update>,
   update: Update,
   setState: Dispatch<(prev: State) => State>,
-  dependentsMap: DependentsMap,
   addWriteThunk: (thunk: WriteThunk) => void
 ) => {
   const pendingPromises: Promise<void>[] = []
@@ -365,37 +377,31 @@ const writeAtom = <Value, Update>(
     try {
       const promiseOrVoid = atom.write(
         ((a: AnyAtom) => {
-          if (process.env.NODE_ENV !== 'production') {
-            const s = mGet(nextState, a)
-            if (s && s.readP) {
-              // TODO will try to detect this
-              console.warn(
-                'Reading pending atom state in write operation. We need to detect this and fallback. Please file an issue for repro.',
-                a
-              )
+          const aState = mGet(nextState, a)
+          if (!aState) {
+            if (process.env.NODE_ENV !== 'production') {
+              warnAtomStateNotFound('writeAtomState', a)
             }
+            return a.init
           }
-          return getAtomStateValue(a, nextState)
+          if (aState.readP && process.env.NODE_ENV !== 'production') {
+            // TODO will try to detect this
+            console.warn(
+              'Reading pending atom state in write operation. We need to detect this and fallback. Please file an issue with repro.',
+              a
+            )
+          }
+          return aState.value
         }) as Getter,
         ((a: AnyWritableAtom, v: unknown) => {
           if (a === atom) {
-            const nextAtomState: AtomState = { value: v }
+            const u = { readE: undefined, readP: undefined, value: v }
             if (isSync) {
-              nextState = mSet(nextState, a, nextAtomState)
-              nextState = updateDependentsState(
-                a,
-                nextState,
-                setState,
-                dependentsMap
-              )
+              nextState = updateAtomState(a, nextState, u)
+              nextState = updateDependentsState(a, nextState, setState)
             } else {
               setState((prev) =>
-                updateDependentsState(
-                  a,
-                  mSet(prev, a, nextAtomState),
-                  setState,
-                  dependentsMap
-                )
+                updateDependentsState(a, updateAtomState(a, prev, u), setState)
               )
             }
           } else {
@@ -410,18 +416,13 @@ const writeAtom = <Value, Update>(
       )
       if (promiseOrVoid instanceof Promise) {
         pendingPromises.push(promiseOrVoid)
-        const nextAtomState: AtomState = {
-          ...mGet(nextState, atom),
+        nextState = updateAtomState(atom, nextState, {
           writeP: promiseOrVoid.then(() => {
             addWriteThunk((prev) =>
-              mSet(prev, atom, {
-                ...mGet(prev, atom),
-                writeP: undefined,
-              })
+              updateAtomState(atom, prev, { writeP: undefined })
             )
           }),
-        }
-        nextState = mSet(nextState, atom, nextAtomState)
+        })
       }
     } catch (e) {
       if (pendingPromises.length) {
@@ -510,14 +511,14 @@ const InnerProvider: React.FC<{
 export const Provider: React.FC = ({ children }) => {
   const contextUpdateRef = useRef<ContextUpdate>()
 
-  const dependentsMapRef = useRef<DependentsMap>()
-  if (!dependentsMapRef.current) {
-    dependentsMapRef.current = new Map()
-  }
-
   const readPendingMapRef = useRef<ReadPendingMap>()
   if (!readPendingMapRef.current) {
     readPendingMapRef.current = new WeakMap()
+  }
+
+  const atomStateCacheRef = useRef<AtomStateCache>()
+  if (!atomStateCacheRef.current) {
+    atomStateCacheRef.current = new WeakMap()
   }
 
   const [state, setStateOrig] = useState(initialState)
@@ -543,10 +544,37 @@ export const Provider: React.FC = ({ children }) => {
     lastStateRef.current = state
   })
 
-  const [gcCount, setGcCount] = useState(0) // to trigger gc
+  const [used, setUsed] = useState(initialUsedState)
   useEffect(() => {
-    gcAtom(state, setState, dependentsMapRef.current as DependentsMap)
-  }, [state, gcCount])
+    const lastState = lastStateRef.current
+    if (!lastState) {
+      return
+    }
+    let nextState = lastState
+    let deleted: boolean
+    do {
+      deleted = false
+      mKeys(nextState).forEach((a) => {
+        const aState = mGet(nextState, a) as AtomState<unknown>
+        if (aState.writeP || aState.readP) {
+          // wait until promises are resolved
+          return
+        }
+        const depsSize = aState.deps.size
+        const isEmpty =
+          (depsSize === 0 || (depsSize === 1 && aState.deps.has(a))) &&
+          !mGet(used, a)?.size
+        if (isEmpty) {
+          ;(atomStateCacheRef.current as AtomStateCache).set(a, aState)
+          nextState = mDel(nextState, a)
+          deleted = true
+        }
+      })
+    } while (deleted)
+    if (nextState !== lastState) {
+      setState(nextState)
+    }
+  }, [used])
 
   const writeThunkQueueRef = useRef<WriteThunk[]>([])
   useEffect(() => {
@@ -561,43 +589,48 @@ export const Provider: React.FC = ({ children }) => {
 
   const actions = useMemo(
     () => ({
-      add: <Value>(id: symbol, atom: Atom<Value>) =>
-        addAtom(id, atom, dependentsMapRef.current as DependentsMap),
-      del: (id: symbol) =>
-        delAtom(id, setGcCount, dependentsMapRef.current as DependentsMap),
+      add: <Value>(id: symbol, atom: Atom<Value>) => {
+        setUsed((prev) => mSet(prev, atom, new Set(mGet(prev, atom)).add(id)))
+      },
+      del: <Value>(id: symbol, atom: Atom<Value>) => {
+        setUsed((prev) => {
+          const oldSet = mGet(prev, atom)
+          if (!oldSet) return prev
+          const newSet = new Set(oldSet)
+          newSet.delete(id)
+          if (newSet.size) {
+            return mSet(prev, atom, newSet)
+          }
+          return mDel(prev, atom)
+        })
+      },
       read: <Value>(state: State, atom: Atom<Value>) =>
         readAtom(
           state,
           atom,
           setState,
-          dependentsMapRef.current as DependentsMap,
-          readPendingMapRef.current as ReadPendingMap
+          readPendingMapRef.current as ReadPendingMap,
+          atomStateCacheRef.current as AtomStateCache
         ),
       write: <Value, Update>(
         atom: WritableAtom<Value, Update>,
         update: Update
       ) =>
-        writeAtom(
-          atom,
-          update,
-          setState,
-          dependentsMapRef.current as DependentsMap,
-          (thunk: WriteThunk) => {
-            writeThunkQueueRef.current.push(thunk)
-            if (lastStateRef.current) {
-              runWriteThunk(
-                lastStateRef,
-                pendingStateRef,
-                setState,
-                contextUpdateRef.current as ContextUpdate,
-                writeThunkQueueRef.current
-              )
-            } else {
-              // force update (FIXME this is a workaround for now)
-              setState((prev) => mMerge(prev, mCreate()))
-            }
+        writeAtom(atom, update, setState, (thunk: WriteThunk) => {
+          writeThunkQueueRef.current.push(thunk)
+          if (lastStateRef.current) {
+            runWriteThunk(
+              lastStateRef,
+              pendingStateRef,
+              setState,
+              contextUpdateRef.current as ContextUpdate,
+              writeThunkQueueRef.current
+            )
+          } else {
+            // force update (FIXME this is a workaround for now)
+            setState((prev) => mMerge(prev, mCreate()))
           }
-        ),
+        }),
     }),
     []
   )
@@ -616,12 +649,15 @@ export const Provider: React.FC = ({ children }) => {
   )
 }
 
+const atomToPrintable = (atom: AnyAtom) =>
+  `${atom.key}:${atom.debugLabel ?? '<no debugLabel>'}`
+
+const stateToPrintable = (state: State) =>
+  mToPrintable(state, atomToPrintable, (v) => ({
+    value: v.readE || v.readP || v.writeP || v.value,
+    deps: Array.from(v.deps).map(atomToPrintable),
+  }))
+
 const useDebugState = (state: State) => {
-  useDebugValue(state, (s: State) =>
-    mToPrintable(
-      s,
-      (k) => `${k.key}:${k.debugLabel ?? '<no debugLabel>'}`,
-      (v) => v.readE || v.readP || v.writeP || v.value
-    )
-  )
+  useDebugValue(state, stateToPrintable)
 }

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -113,17 +113,16 @@ const updateAtomState = <Value>(
 }
 
 const addDependent = (atom: AnyAtom, dependent: AnyAtom, prevState: State) => {
-  let nextState = prevState
-  const atomState = mGet(nextState, atom)
+  const atomState = mGet(prevState, atom)
   if (atomState) {
     if (!atomState.deps.has(dependent)) {
       const newDeps = new Set(atomState.deps).add(dependent)
-      nextState = mSet(nextState, atom, { ...atomState, deps: newDeps })
+      return mSet(prevState, atom, { ...atomState, deps: newDeps })
     }
   } else if (process.env.NODE_ENV !== 'production') {
     warnAtomStateNotFound('addDependent', atom)
   }
-  return nextState
+  return prevState
 }
 
 const replaceDependencies = (
@@ -557,7 +556,7 @@ export const Provider: React.FC = ({ children }) => {
       mKeys(nextState).forEach((a) => {
         const aState = mGet(nextState, a) as AtomState<unknown>
         if (aState.writeP || aState.readP) {
-          // wait until promises are resolved
+          // do not delete while promises are not resolved
           return
         }
         const depsSize = aState.deps.size

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -230,43 +230,29 @@ const readAtomState = <Value>(
         .then((value) => {
           const dependenciesToReplace = dependencies as Set<AnyAtom>
           dependencies = null
-          setState((prev) => {
-            let nextState = prev
-            nextState = replaceDependencies(
+          setState((prev) =>
+            updateAtomState(
               atom,
-              nextState,
-              dependenciesToReplace
-            )
-            nextState = updateAtomState(
-              atom,
-              nextState,
+              replaceDependencies(atom, prev, dependenciesToReplace),
               { readE: undefined, readP: undefined, value },
               promise
             )
-            return nextState
-          })
+          )
         })
         .catch((e) => {
           const dependenciesToReplace = dependencies as Set<AnyAtom>
           dependencies = null
-          setState((prev) => {
-            let nextState = prev
-            nextState = replaceDependencies(
+          setState((prev) =>
+            updateAtomState(
               atom,
-              nextState,
-              dependenciesToReplace
-            )
-            nextState = updateAtomState(
-              atom,
-              nextState,
+              replaceDependencies(atom, prev, dependenciesToReplace),
               {
                 readE: e instanceof Error ? e : new Error(e),
                 readP: undefined,
               },
               promise
             )
-            return nextState
-          })
+          )
         })
     } else {
       value = promiseOrValue

--- a/src/core/useAtom.ts
+++ b/src/core/useAtom.ts
@@ -1,9 +1,8 @@
-import { useCallback, useDebugValue } from 'react'
+import { useEffect, useCallback, useDebugValue } from 'react'
 import { useContext, useContextSelector } from 'use-context-selector'
 
 import { StateContext, ActionsContext } from './Provider'
 import { Atom, WritableAtom, AnyWritableAtom } from './types'
-import { useIsoLayoutEffect } from './useIsoLayoutEffect'
 
 const isWritable = <Value, Update>(
   atom: Atom<Value> | WritableAtom<Value, Update>
@@ -45,11 +44,11 @@ export function useAtom<Value, Update>(
     )
   )
 
-  useIsoLayoutEffect(() => {
+  useEffect(() => {
     const id = Symbol()
     actions.add(id, atom)
     return () => {
-      actions.del(id)
+      actions.del(id, atom)
     }
   }, [actions, atom])
 

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -277,6 +277,45 @@ it('works with async get', async () => {
   await findByText('commits: 2, count: 1, delayedCount: 1')
 })
 
+it('works with async get without setTimeout', async () => {
+  const countAtom = atom(0)
+  const asyncCountAtom = atom(async (get) => {
+    return get(countAtom)
+  })
+
+  const Counter: React.FC = () => {
+    const [count, setCount] = useAtom(countAtom)
+    const [delayedCount] = useAtom(asyncCountAtom)
+    return (
+      <>
+        <div>
+          count: {count}, delayedCount: {delayedCount}
+        </div>
+        <button onClick={() => setCount((c) => c + 1)}>button</button>
+      </>
+    )
+  }
+
+  const { getByText, findByText } = render(
+    <Provider>
+      <React.Suspense fallback="loading">
+        <Counter />
+      </React.Suspense>
+    </Provider>
+  )
+
+  await findByText('loading')
+  await findByText('count: 0, delayedCount: 0')
+
+  fireEvent.click(getByText('button'))
+  await findByText('loading')
+  await findByText('count: 1, delayedCount: 1')
+
+  fireEvent.click(getByText('button'))
+  await findByText('loading')
+  await findByText('count: 2, delayedCount: 2')
+})
+
 it('shows loading with async set', async () => {
   const countAtom = atom(0)
   const asyncCountAtom = atom(


### PR DESCRIPTION
This is a non trivial rewrite in core:
- `dependents` are now in provider state, which should be better for CM
- Provider debug value shows `deps(=dependens)`, which allows easier debugging
- Provider no longer garbage collect atom values even when all useAtoms' are gone
  - They will only be garbage collected by JS
  - https://github.com/pmndrs/jotai/issues/84#issuecomment-703967151
