### PR TITLE
fix: return write error in promise

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 18149,
-    "minified": 8200,
-    "gzipped": 3016,
+    "bundled": 18487,
+    "minified": 8298,
+    "gzipped": 3056,
     "treeshaked": {
       "rollup": {
         "code": 318,
@@ -14,17 +14,17 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 21765,
-    "minified": 10208,
-    "gzipped": 3532
+    "bundled": 22089,
+    "minified": 10295,
+    "gzipped": 3572
   },
   "index.iife.js": {
-    "bundled": 23140,
-    "minified": 8369,
-    "gzipped": 3224
+    "bundled": 23492,
+    "minified": 8456,
+    "gzipped": 3260
   },
   "utils.js": {
-    "bundled": 2762,
+    "bundled": 2687,
     "minified": 1271,
     "gzipped": 563,
     "treeshaked": {
@@ -38,7 +38,7 @@
     }
   },
   "utils.cjs.js": {
-    "bundled": 3662,
+    "bundled": 3587,
     "minified": 1875,
     "gzipped": 679
   },

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -445,7 +445,23 @@ const writeAtom = <Value, Update>(
     return nextState
   }
 
-  addWriteThunk((prevState) => writeAtomState(prevState, writingAtom, update))
+  let isSync = true
+  let writeResolve: () => void
+  const writePromise = new Promise<void>((resolve) => {
+    writeResolve = resolve
+  })
+  pendingPromises.unshift(writePromise)
+  addWriteThunk((prevState) => {
+    if (isSync) {
+      pendingPromises.shift()
+    }
+    const nextState = writeAtomState(prevState, writingAtom, update)
+    if (!isSync) {
+      writeResolve()
+    }
+    return nextState
+  })
+  isSync = false
 
   if (pendingPromises.length) {
     return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
This might be a bit controversial. 
Currently, we throw read errors in useAtom, but for write errors we throw them (or reject promises) in write function (more precisely SetAtom function).
This PR fixes some edge cases where it fails to return errors in a promise.

If a write function is async, we always return a promise, however, if a write function is sync, we may throw an error or return a promise which can contain an error. It's not very predictable for users.

Unless there's any better idea, it can't be helped much...