### PR TITLE
add shouldRemove in atomFamily

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -24,9 +24,9 @@
     "gzipped": 3455
   },
   "utils.js": {
-    "bundled": 2687,
-    "minified": 1271,
-    "gzipped": 563,
+    "bundled": 3183,
+    "minified": 1448,
+    "gzipped": 655,
     "treeshaked": {
       "rollup": {
         "code": 28,
@@ -38,9 +38,9 @@
     }
   },
   "utils.cjs.js": {
-    "bundled": 3587,
-    "minified": 1875,
-    "gzipped": 679
+    "bundled": 4087,
+    "minified": 2041,
+    "gzipped": 767
   },
   "immer.js": {
     "bundled": 797,

--- a/src/utils/atomFamily.ts
+++ b/src/utils/atomFamily.ts
@@ -7,7 +7,7 @@ type ShouldRemove<Param> = (createdAt: number, param: Param) => boolean
 type AtomFamily<Param, AtomType> = {
   (param: Param): AtomType
   remove(param: Param): void
-  gc(shoudRemove: ShouldRemove<Param> | null): void
+  setShouldRemove(shouldRemove: ShouldRemove<Param> | null): void
 }
 
 // writable derived atom
@@ -90,7 +90,7 @@ export function atomFamily<Param, Value, Update>(
       atoms.splice(index, 1)
     }
   }
-  createAtom.gc = (fn: ShouldRemove<Param> | null) => {
+  createAtom.setShouldRemove = (fn: ShouldRemove<Param> | null) => {
     shouldRemove = fn
     if (!shouldRemove) return
     let index = 0

--- a/src/utils/atomFamily.ts
+++ b/src/utils/atomFamily.ts
@@ -94,7 +94,7 @@ export function atomFamily<Param, Value, Update>(
     shouldRemove = fn
     if (!shouldRemove) return
     let index = 0
-    while (index < atom.length) {
+    while (index < atoms.length) {
       const item = atoms[index]
       if (shouldRemove(item[2], item[0])) {
         atoms.splice(index, 1)


### PR DESCRIPTION
close #155 

This adds a new functionality to atomFamily.
Typical use case would be to remove atoms if it's created a long time ago, and refresh them.

This use case is probably for experts. Naive shouldRemove can lead to infinite loop.

----

### Usage

```js
const family = atomFamily(...)
family.setShouldRemove((createdAt, param) => createdAt + 60 * 1000 < Date.now())
```
