### PR TITLE
Detect react experimental and fix some bugs

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,27 +1,27 @@
 {
   "index.js": {
-    "bundled": 19093,
-    "minified": 8544,
-    "gzipped": 3130,
+    "bundled": 19439,
+    "minified": 8732,
+    "gzipped": 3243,
     "treeshaked": {
       "rollup": {
-        "code": 318,
-        "import_statements": 85
+        "code": 390,
+        "import_statements": 92
       },
       "webpack": {
-        "code": 1441
+        "code": 1519
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 22735,
-    "minified": 10562,
-    "gzipped": 3638
+    "bundled": 23291,
+    "minified": 10914,
+    "gzipped": 3785
   },
   "index.iife.js": {
-    "bundled": 24162,
-    "minified": 8716,
-    "gzipped": 3343
+    "bundled": 24730,
+    "minified": 8962,
+    "gzipped": 3455
   },
   "utils.js": {
     "bundled": 2687,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint:ci": "eslint '{src,examples/src}/**/*.{js,ts,jsx,tsx}'",
     "prepare": "yarn build",
     "pretest": "tsc --noEmit",
-    "test": "jest",
+    "test": "jest && jest --setupFiles ./tests/setReactExperimental.ts",
     "test:dev": "jest --watch --no-coverage",
     "test:coverage:watch": "jest --watch",
     "copy": "shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && shx cp dist/utils.d.ts dist/utils.cjs.d.ts && shx cp dist/immer.d.ts dist/immer.cjs.d.ts && copyfiles -f package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.husky=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\""

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -85,8 +85,8 @@ const initialUsedState: UsedState = mCreate()
 // and reuse it as long as it's not gc'd
 type AtomStateCache = WeakMap<AnyAtom, AtomState>
 
-// pending state for adding a new atom
-type ReadPendingMap = WeakMap<State, State> // the value is next state
+// pending state for adding a new atom and write batching
+type PendingStateMap = WeakMap<State, State> // the value is next state
 
 type ContextUpdate = (t: () => void) => void
 
@@ -349,11 +349,11 @@ const updateDependentsState = <Value>(
 const readAtom = <Value>(
   state: State,
   readingAtom: Atom<Value>,
-  setState: Dispatch<(prev: State) => State>,
-  readPendingMap: ReadPendingMap,
+  setState: Dispatch<SetStateAction<State>>,
+  pendingStateMap: PendingStateMap,
   atomStateCache: AtomStateCache
 ) => {
-  const prevState = readPendingMap.get(state) || state
+  const prevState = pendingStateMap.get(state) || state
   const [atomState, nextState] = readAtomState(
     readingAtom,
     prevState,
@@ -361,7 +361,7 @@ const readAtom = <Value>(
     atomStateCache
   )
   if (nextState !== prevState) {
-    readPendingMap.set(state, nextState)
+    pendingStateMap.set(state, nextState)
   }
   return atomState
 }
@@ -507,25 +507,27 @@ const writeAtom = <Value, Update>(
 }
 
 const runWriteThunk = (
-  lastStateRef: MutableRefObject<State | null>,
-  pendingStateRef: MutableRefObject<State | null>,
+  lastStateRef: MutableRefObject<State>,
+  isLastStateValidRef: MutableRefObject<boolean>,
+  pendingStateMap: PendingStateMap,
   setState: Dispatch<State>,
   contextUpdate: ContextUpdate,
   writeThunkQueue: WriteThunk[]
 ) => {
   while (true) {
-    if (!lastStateRef.current || !writeThunkQueue.length) {
+    if (!isLastStateValidRef.current || !writeThunkQueue.length) {
       return
     }
     const thunk = writeThunkQueue.shift() as WriteThunk
-    const prevState = pendingStateRef.current || lastStateRef.current
+    const prevState =
+      pendingStateMap.get(lastStateRef.current) || lastStateRef.current
     const nextState = thunk(prevState)
     if (nextState !== prevState) {
-      pendingStateRef.current = nextState
+      pendingStateMap.set(lastStateRef.current, nextState)
       Promise.resolve().then(() => {
-        const pendingState = pendingStateRef.current
+        const pendingState = pendingStateMap.get(lastStateRef.current)
         if (pendingState) {
-          pendingStateRef.current = null
+          pendingStateMap.delete(lastStateRef.current)
           contextUpdate(() => {
             setState(pendingState)
           })
@@ -561,48 +563,48 @@ const InnerProvider: React.FC<{
 export const Provider: React.FC = ({ children }) => {
   const contextUpdateRef = useRef<ContextUpdate>()
 
-  const readPendingMap = useWeakMapRef<ReadPendingMap>()
+  const pendingStateMap = useWeakMapRef<PendingStateMap>()
 
   const atomStateCache = useWeakMapRef<AtomStateCache>()
 
   const [state, setStateOrig] = useState(initialState)
-  const lastStateRef = useRef<State | null>(null)
-  const pendingStateRef = useRef<State | null>(null)
+  const lastStateRef = useRef<State>(state)
+  const isLastStateValidRef = useRef(false)
   const setState = useCallback(
     (setStateAction: SetStateAction<State>) => {
-      const pendingState = pendingStateRef.current
+      const pendingState = pendingStateMap.get(lastStateRef.current)
       if (pendingState) {
-        pendingStateRef.current = null
+        if (
+          typeof setStateAction !== 'function' &&
+          process.env.NODE_ENV !== 'production'
+        ) {
+          console.warn(
+            '[Bug] pendingState can only be applied with function update'
+          )
+        }
         setStateOrig(pendingState)
       }
-      if (lastStateRef.current) {
-        const readPending = readPendingMap.get(lastStateRef.current)
-        if (readPending) {
-          setStateOrig(readPending)
-          if (pendingState && process.env.NODE_ENV !== 'production') {
-            console.warn('[Bug] conflict pendingState and readPending')
-          }
-        }
-      }
-      lastStateRef.current = null
+      isLastStateValidRef.current = false
       setStateOrig(setStateAction)
     },
-    [readPendingMap]
+    [pendingStateMap]
   )
 
   useIsoLayoutEffect(() => {
-    const readPending = readPendingMap.get(state)
-    if (readPending) {
-      setState(readPending)
+    const pendingState = pendingStateMap.get(state)
+    if (pendingState) {
+      pendingStateMap.delete(state)
+      setState(pendingState)
       return
     }
     lastStateRef.current = state
+    isLastStateValidRef.current = true
   })
 
   const [used, setUsed] = useState(initialUsedState)
   useEffect(() => {
+    if (!isLastStateValidRef.current) return
     const lastState = lastStateRef.current
-    if (!lastState) return
     let nextState = lastState
     let deleted: boolean
     do {
@@ -631,12 +633,13 @@ export const Provider: React.FC = ({ children }) => {
   useEffect(() => {
     runWriteThunk(
       lastStateRef,
-      pendingStateRef,
+      isLastStateValidRef,
+      pendingStateMap,
       setState,
       contextUpdateRef.current as ContextUpdate,
       writeThunkQueueRef.current
     )
-  }, [state, setState])
+  }, [state, setState, pendingStateMap])
 
   const actions = useMemo(
     () => ({
@@ -656,7 +659,7 @@ export const Provider: React.FC = ({ children }) => {
         })
       },
       read: <Value>(state: State, atom: Atom<Value>) =>
-        readAtom(state, atom, setState, readPendingMap, atomStateCache),
+        readAtom(state, atom, setState, pendingStateMap, atomStateCache),
       write: <Value, Update>(
         atom: WritableAtom<Value, Update>,
         update: Update
@@ -668,10 +671,11 @@ export const Provider: React.FC = ({ children }) => {
           atomStateCache,
           (thunk: WriteThunk) => {
             writeThunkQueueRef.current.push(thunk)
-            if (lastStateRef.current) {
+            if (isLastStateValidRef.current) {
               runWriteThunk(
                 lastStateRef,
-                pendingStateRef,
+                isLastStateValidRef,
+                pendingStateMap,
                 setState,
                 contextUpdateRef.current as ContextUpdate,
                 writeThunkQueueRef.current
@@ -683,7 +687,7 @@ export const Provider: React.FC = ({ children }) => {
           }
         ),
     }),
-    [readPendingMap, atomStateCache, setState]
+    [pendingStateMap, atomStateCache, setState]
   )
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -37,8 +37,10 @@ import {
   mToPrintable,
 } from './immutableMap'
 
-// guessing if it react experimental channel
-const isReactExperimental = !!(React as any).unstable_useMutableSource
+// guessing if it's react experimental channel
+const isReactExperimental =
+  !!process.env.IS_REACT_EXPERIMENTAL ||
+  !!(React as any).unstable_useMutableSource
 
 const warningObject = new Proxy(
   {},

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -275,6 +275,10 @@ it('works with async get', async () => {
   fireEvent.click(getByText('button'))
   await findByText('loading')
   await findByText('commits: 2, count: 1, delayedCount: 1')
+
+  fireEvent.click(getByText('button'))
+  await findByText('loading')
+  await findByText('commits: 3, count: 2, delayedCount: 2')
 })
 
 it('works with async get without setTimeout', async () => {

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,4 +1,4 @@
-import React, { StrictMode, useEffect, useRef } from 'react'
+import React, { StrictMode, Suspense, useEffect, useRef } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import {
   Provider,
@@ -263,9 +263,9 @@ it('works with async get', async () => {
 
   const { getByText, findByText } = render(
     <Provider>
-      <React.Suspense fallback="loading">
+      <Suspense fallback="loading">
         <Counter />
-      </React.Suspense>
+      </Suspense>
     </Provider>
   )
 
@@ -298,9 +298,9 @@ it('works with async get without setTimeout', async () => {
 
   const { getByText, findByText } = render(
     <Provider>
-      <React.Suspense fallback="loading">
+      <Suspense fallback="loading">
         <Counter />
-      </React.Suspense>
+      </Suspense>
     </Provider>
   )
 
@@ -342,9 +342,9 @@ it('shows loading with async set', async () => {
 
   const { getByText, findByText } = render(
     <Provider>
-      <React.Suspense fallback="loading">
+      <Suspense fallback="loading">
         <Counter />
-      </React.Suspense>
+      </Suspense>
     </Provider>
   )
 
@@ -386,9 +386,9 @@ it('uses atoms with tree dependencies', async () => {
 
   const { getByText, findByText } = render(
     <Provider>
-      <React.Suspense fallback="loading">
+      <Suspense fallback="loading">
         <Counter />
-      </React.Suspense>
+      </Suspense>
     </Provider>
   )
 
@@ -469,9 +469,9 @@ it('uses an async write-only atom', async () => {
 
   const { getByText, findByText } = render(
     <Provider>
-      <React.Suspense fallback="loading">
+      <Suspense fallback="loading">
         <Counter />
-      </React.Suspense>
+      </Suspense>
     </Provider>
   )
 
@@ -504,9 +504,9 @@ it('uses a writable atom without read function', async () => {
 
   const { getByText, findByText } = render(
     <Provider>
-      <React.Suspense fallback="loading">
+      <Suspense fallback="loading">
         <Counter />
-      </React.Suspense>
+      </Suspense>
     </Provider>
   )
 

--- a/tests/error.test.tsx
+++ b/tests/error.test.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useState, useEffect } from 'react'
-import { fireEvent, cleanup, render } from '@testing-library/react'
+import { fireEvent, cleanup, render, act } from '@testing-library/react'
 import { Provider, atom, useAtom } from '../src/index'
 
 const consoleError = console.error
@@ -306,8 +306,10 @@ it('can throw an error in async write function', async () => {
 
   await findByText('no error')
 
-  fireEvent.click(getByText('button'))
-  await new Promise((r) => setTimeout(r, 10))
+  await act(async () => {
+    fireEvent.click(getByText('button'))
+    await new Promise((r) => setTimeout(r, 10))
+  })
   expect(console.error).toHaveBeenCalledTimes(1)
 })
 

--- a/tests/setReactExperimental.ts
+++ b/tests/setReactExperimental.ts
@@ -1,0 +1,1 @@
+process.env.IS_REACT_EXPERIMENTAL = 'true'


### PR DESCRIPTION
close #156 

The behavior introduced with use-context-selector v1.2 is confusing developers.
As it would only be required for experimental concurrent mode support,
this adds a detection and changes the behavior in legacy mode.

It revealed some bugs around pending state, and they are fixed.