### PR TITLE
fix: avoid using proxy

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,27 +1,27 @@
 {
   "index.js": {
-    "bundled": 19439,
-    "minified": 8732,
-    "gzipped": 3243,
+    "bundled": 19414,
+    "minified": 8714,
+    "gzipped": 3232,
     "treeshaked": {
       "rollup": {
-        "code": 390,
+        "code": 274,
         "import_statements": 92
       },
       "webpack": {
-        "code": 1519
+        "code": 1407
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 23291,
-    "minified": 10914,
-    "gzipped": 3785
+    "bundled": 23240,
+    "minified": 10876,
+    "gzipped": 3784
   },
   "index.iife.js": {
-    "bundled": 24730,
-    "minified": 8962,
-    "gzipped": 3455
+    "bundled": 24677,
+    "minified": 8909,
+    "gzipped": 3452
   },
   "utils.js": {
     "bundled": 3196,

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -42,18 +42,6 @@ const isReactExperimental =
   !!process.env.IS_REACT_EXPERIMENTAL ||
   !!(React as any).unstable_useMutableSource
 
-const warningObject = new Proxy(
-  {},
-  {
-    get() {
-      throw new Error('Please use <Provider>')
-    },
-    apply() {
-      throw new Error('Please use <Provider>')
-    },
-  }
-)
-
 const useWeakMapRef = <T extends WeakMap<object, unknown>>() => {
   const ref = useRef<T>()
   if (!ref.current) {
@@ -539,8 +527,8 @@ const runWriteThunk = (
   }
 }
 
-export const ActionsContext = createContext(warningObject as Actions)
-export const StateContext = createContext(warningObject as State)
+export const ActionsContext = createContext<Actions | null>(null)
+export const StateContext = createContext<State | null>(null)
 
 const InnerProvider: React.FC<{
   r: MutableRefObject<ContextUpdate | undefined>

--- a/src/core/useAtom.ts
+++ b/src/core/useAtom.ts
@@ -4,6 +4,12 @@ import { useContext, useContextSelector } from 'use-context-selector'
 import { StateContext, ActionsContext } from './Provider'
 import { Atom, WritableAtom, AnyWritableAtom } from './types'
 
+function assertContextValue<T extends object>(x: T | null): asserts x is T {
+  if (!x) {
+    throw new Error('Please use <Provider>')
+  }
+}
+
 const isWritable = <Value, Update>(
   atom: Atom<Value> | WritableAtom<Value, Update>
 ): atom is WritableAtom<Value, Update> =>
@@ -23,11 +29,13 @@ export function useAtom<Value, Update>(
   atom: Atom<Value> | WritableAtom<Value, Update>
 ) {
   const actions = useContext(ActionsContext)
+  assertContextValue(actions)
 
   const value = useContextSelector(
     StateContext,
     useCallback(
       (state) => {
+        assertContextValue(state)
         const atomState = actions.read(state, atom)
         if (atomState.readE) {
           throw atomState.readE // read error


### PR DESCRIPTION
https://github.com/pmndrs/jotai/issues/159#issuecomment-720697657

It seems like some RN versions doesn't support Proxies.

https://github.com/pmndrs/jotai/issues/48#issuecomment-701025932

It's also reported before for IE11 compatibility.

This PR removes the usage of Proxies. It does reduce bundle size too.

@likern Would you please if this solves your use case? (Check codesandbox bot message how to install the bundle.)