### PR TITLE
feat: Provider initialValues prop

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 19414,
-    "minified": 8714,
-    "gzipped": 3232,
+    "bundled": 19645,
+    "minified": 8810,
+    "gzipped": 3270,
     "treeshaked": {
       "rollup": {
         "code": 274,
@@ -14,14 +14,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 23240,
-    "minified": 10876,
-    "gzipped": 3784
+    "bundled": 23683,
+    "minified": 11054,
+    "gzipped": 3832
   },
   "index.iife.js": {
-    "bundled": 24677,
-    "minified": 8909,
-    "gzipped": 3452
+    "bundled": 25150,
+    "minified": 9054,
+    "gzipped": 3508
   },
   "utils.js": {
     "bundled": 3196,

--- a/docs/core.md
+++ b/docs/core.md
@@ -36,6 +36,18 @@ const Root = () => (
 )
 ```
 
+A Provider accepts an optional prop `initialValues` which you can specify
+some initial atom values.
+The use cases of this are testing and server side rendering.
+
+```js
+const TestRoot = () => (
+  <Provider initialValues=[[atom1, 1], [atom2, 'b']]>
+    <Component />
+  </Provider>
+)
+```
+
 ## useAtom
 
 The useAtom hook is to read an atom value stored in the Provider. It returns the atom value and an updating function as a tuple, just like useState. It takes an atom config created with `atom()`. Initially, there is no value stored in the Provider. The first time the atom is used via `useAtom`, it will add an initial value in the Provider. If the atom is a derived atom, the read function is executed to compute an initial value. When an atom is no longer used, meaning all the components using it is unmounted, and the atom config no longer exists, the value is removed from the Provider.

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -551,7 +551,7 @@ const InnerProvider: React.FC<{
 }
 
 export const Provider: React.FC<{
-  initialValues?: Iterable<[AnyAtom, unknown]>
+  initialValues?: Iterable<readonly [AnyAtom, unknown]>
 }> = ({ initialValues, children }) => {
   const contextUpdateRef = useRef<ContextUpdate>()
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -550,14 +550,24 @@ const InnerProvider: React.FC<{
   return children as ReactElement
 }
 
-export const Provider: React.FC = ({ children }) => {
+export const Provider: React.FC<{
+  initialValues?: Iterable<[AnyAtom, unknown]>
+}> = ({ initialValues, children }) => {
   const contextUpdateRef = useRef<ContextUpdate>()
 
   const pendingStateMap = useWeakMapRef<PendingStateMap>()
 
   const atomStateCache = useWeakMapRef<AtomStateCache>()
 
-  const [state, setStateOrig] = useState(initialState)
+  const [state, setStateOrig] = useState(() => {
+    let s = initialState
+    if (initialValues) {
+      for (const [atom, value] of initialValues) {
+        s = mSet(s, atom, { value, deps: new Set() })
+      }
+    }
+    return s
+  })
   const lastStateRef = useRef<State>(state)
   const isLastStateValidRef = useRef(false)
   const setState = useCallback(


### PR DESCRIPTION
We have some discussions in discord, and found that this is missing.

The use cases of `initialValues` are:
- testing
- server side rendering
