### PR TITLE
refactor: implement mForEach

### DIFF
--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -132,8 +132,7 @@ const replaceDependencies = (
 ) => {
   const dependencies = new Set(dependenciesToReplace)
   let nextState = prevState
-  mForEach(nextState, (a) => {
-    const aState = mGet(nextState, a) as AtomState<unknown>
+  mForEach(nextState, (aState, a) => {
     if (aState.deps.has(atom)) {
       if (dependencies.has(a)) {
         // not changed
@@ -609,8 +608,7 @@ export const Provider: React.FC<{
     let deleted: boolean
     do {
       deleted = false
-      mForEach(nextState, (a) => {
-        const aState = mGet(nextState, a) as AtomState<unknown>
+      mForEach(nextState, (aState, a) => {
         // do not delete while promises are not resolved
         if (aState.writeP || aState.readP) return
         const depsSize = aState.deps.size

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -32,9 +32,9 @@ import {
   mGet,
   mSet,
   mDel,
-  mKeys,
   mMerge,
   mToPrintable,
+  mForEach,
 } from './immutableMap'
 
 // guessing if it's react experimental channel
@@ -132,7 +132,7 @@ const replaceDependencies = (
 ) => {
   const dependencies = new Set(dependenciesToReplace)
   let nextState = prevState
-  mKeys(nextState).forEach((a) => {
+  mForEach(nextState, (a) => {
     const aState = mGet(nextState, a) as AtomState<unknown>
     if (aState.deps.has(atom)) {
       if (dependencies.has(a)) {
@@ -609,7 +609,7 @@ export const Provider: React.FC<{
     let deleted: boolean
     do {
       deleted = false
-      mKeys(nextState).forEach((a) => {
+      mForEach(nextState, (a) => {
         const aState = mGet(nextState, a) as AtomState<unknown>
         // do not delete while promises are not resolved
         if (aState.writeP || aState.readP) return

--- a/src/core/immutableMap.ts
+++ b/src/core/immutableMap.ts
@@ -10,7 +10,7 @@ type MSet = <K, V>(m: ImmutableMap<K, V>, k: K, v: V) => ImmutableMap<K, V>
 type MDel = <K, V>(m: ImmutableMap<K, V>, k: K) => ImmutableMap<K, V>
 type MForEach = <K extends object, V>(
   m: ImmutableMap<K, V>,
-  cb: (value: V, key: K, map: Map<K, V>) => void
+  cb: (value: V, key: K) => void
 ) => void
 type MMerge = <K, V>(
   m: ImmutableMap<K, V>,
@@ -66,14 +66,13 @@ export const mDel: MDel = <K, V>(m: ImmutableMap<K, V>, k: K) => {
 
 export const mForEach: MForEach = <K extends object, V>(
   map: ImmutableMap<K, V>,
-  cb: (value: V, key: K, map: Map<K, V>) => void
+  cb: (value: V, key: K) => void
 ) => {
   const seen = new WeakSet()
   map.forEach((m) => {
-    m.forEach((...args) => {
-      const [, k] = args
+    m.forEach((v, k) => {
       if (!seen.has(k)) {
-        cb(...args)
+        cb(v, k)
         seen.add(k)
       }
     })

--- a/src/core/immutableMap.ts
+++ b/src/core/immutableMap.ts
@@ -9,6 +9,7 @@ type MGet = <K, V>(m: ImmutableMap<K, V>, k: K) => V | undefined
 type MSet = <K, V>(m: ImmutableMap<K, V>, k: K, v: V) => ImmutableMap<K, V>
 type MDel = <K, V>(m: ImmutableMap<K, V>, k: K) => ImmutableMap<K, V>
 type MKeys = <K, V>(m: ImmutableMap<K, V>) => Set<K>
+type MForEach = <K, V>(m: ImmutableMap<K, V>, cb: (k: K) => void) => void
 type MMerge = <K, V>(
   m: ImmutableMap<K, V>,
   newM: ImmutableMap<K, V>
@@ -69,6 +70,21 @@ export const mKeys: MKeys = <K, V>(m: ImmutableMap<K, V>) => {
     }
   })
   return keys
+}
+
+export const mForEach: MForEach = <K, V>(
+  map: ImmutableMap<K, V>,
+  cb: (a: K) => void
+) => {
+  const cache = new Map()
+  map.forEach((m) => {
+    m.forEach((_, a) => {
+      if (!cache.has(a)) {
+        cb(a)
+        cache.set(a, true)
+      }
+    })
+  })
 }
 
 export const mMerge: MMerge = <K, V>(

--- a/src/core/immutableMap.ts
+++ b/src/core/immutableMap.ts
@@ -9,7 +9,10 @@ type MGet = <K, V>(m: ImmutableMap<K, V>, k: K) => V | undefined
 type MSet = <K, V>(m: ImmutableMap<K, V>, k: K, v: V) => ImmutableMap<K, V>
 type MDel = <K, V>(m: ImmutableMap<K, V>, k: K) => ImmutableMap<K, V>
 type MKeys = <K, V>(m: ImmutableMap<K, V>) => Set<K>
-type MForEach = <K, V>(m: ImmutableMap<K, V>, cb: (k: K) => void) => void
+type MForEach = <K, V>(
+  m: ImmutableMap<K, V>,
+  cb: (value: V, key: K, map: Map<K, V>) => void
+) => void
 type MMerge = <K, V>(
   m: ImmutableMap<K, V>,
   newM: ImmutableMap<K, V>
@@ -74,14 +77,15 @@ export const mKeys: MKeys = <K, V>(m: ImmutableMap<K, V>) => {
 
 export const mForEach: MForEach = <K, V>(
   map: ImmutableMap<K, V>,
-  cb: (a: K) => void
+  cb: (value: V, key: K, map: Map<K, V>) => void
 ) => {
-  const cache = new Map()
+  const seen = new Set()
   map.forEach((m) => {
-    m.forEach((_, k) => {
-      if (!cache.has(k)) {
-        cb(k)
-        cache.set(k, true)
+    m.forEach((...args) => {
+      const [, k] = args
+      if (!seen.has(k)) {
+        cb(...args)
+        seen.add(k)
       }
     })
   })

--- a/src/core/immutableMap.ts
+++ b/src/core/immutableMap.ts
@@ -8,7 +8,7 @@ type MCreate = <K, V>() => ImmutableMap<K, V>
 type MGet = <K, V>(m: ImmutableMap<K, V>, k: K) => V | undefined
 type MSet = <K, V>(m: ImmutableMap<K, V>, k: K, v: V) => ImmutableMap<K, V>
 type MDel = <K, V>(m: ImmutableMap<K, V>, k: K) => ImmutableMap<K, V>
-type MForEach = <K, V>(
+type MForEach = <K extends object, V>(
   m: ImmutableMap<K, V>,
   cb: (value: V, key: K, map: Map<K, V>) => void
 ) => void
@@ -64,11 +64,11 @@ export const mDel: MDel = <K, V>(m: ImmutableMap<K, V>, k: K) => {
   return [map]
 }
 
-export const mForEach: MForEach = <K, V>(
+export const mForEach: MForEach = <K extends object, V>(
   map: ImmutableMap<K, V>,
   cb: (value: V, key: K, map: Map<K, V>) => void
 ) => {
-  const seen = new Set()
+  const seen = new WeakSet()
   map.forEach((m) => {
     m.forEach((...args) => {
       const [, k] = args

--- a/src/core/immutableMap.ts
+++ b/src/core/immutableMap.ts
@@ -8,7 +8,6 @@ type MCreate = <K, V>() => ImmutableMap<K, V>
 type MGet = <K, V>(m: ImmutableMap<K, V>, k: K) => V | undefined
 type MSet = <K, V>(m: ImmutableMap<K, V>, k: K, v: V) => ImmutableMap<K, V>
 type MDel = <K, V>(m: ImmutableMap<K, V>, k: K) => ImmutableMap<K, V>
-type MKeys = <K, V>(m: ImmutableMap<K, V>) => Set<K>
 type MForEach = <K, V>(
   m: ImmutableMap<K, V>,
   cb: (value: V, key: K, map: Map<K, V>) => void
@@ -63,16 +62,6 @@ export const mDel: MDel = <K, V>(m: ImmutableMap<K, V>, k: K) => {
   const map = new Map(m[0])
   map.delete(k)
   return [map]
-}
-
-export const mKeys: MKeys = <K, V>(m: ImmutableMap<K, V>) => {
-  const keys = new Set<K>()
-  m.forEach((map) => {
-    for (const key of map.keys()) {
-      keys.add(key)
-    }
-  })
-  return keys
 }
 
 export const mForEach: MForEach = <K, V>(

--- a/src/core/immutableMap.ts
+++ b/src/core/immutableMap.ts
@@ -78,10 +78,10 @@ export const mForEach: MForEach = <K, V>(
 ) => {
   const cache = new Map()
   map.forEach((m) => {
-    m.forEach((_, a) => {
-      if (!cache.has(a)) {
-        cb(a)
-        cache.set(a, true)
+    m.forEach((_, k) => {
+      if (!cache.has(k)) {
+        cb(k)
+        cache.set(k, true)
       }
     })
   })

--- a/src/core/immutableMap.ts
+++ b/src/core/immutableMap.ts
@@ -68,7 +68,7 @@ export const mForEach: MForEach = <K extends object, V>(
   map: ImmutableMap<K, V>,
   cb: (value: V, key: K) => void
 ) => {
-  const seen = new WeakSet()
+  const seen = new WeakSet<K>()
   map.forEach((m) => {
     m.forEach((v, k) => {
       if (!seen.has(k)) {


### PR DESCRIPTION
closes #172 

@dai-shi Is this what you had in mind for this refactor?
Basically removes the need for the extra loop for the unique keys.