### PR TITLE
chore: useAtomDevtools typing

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -62,9 +62,9 @@
     "gzipped": 310
   },
   "devtools.js": {
-    "bundled": 2289,
-    "minified": 1076,
-    "gzipped": 618,
+    "bundled": 2337,
+    "minified": 1123,
+    "gzipped": 626,
     "treeshaked": {
       "rollup": {
         "code": 28,
@@ -76,8 +76,8 @@
     }
   },
   "devtools.cjs.js": {
-    "bundled": 2462,
-    "minified": 1206,
-    "gzipped": 660
+    "bundled": 2537,
+    "minified": 1259,
+    "gzipped": 673
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -62,9 +62,9 @@
     "gzipped": 310
   },
   "devtools.js": {
-    "bundled": 2337,
-    "minified": 1123,
-    "gzipped": 626,
+    "bundled": 2289,
+    "minified": 1076,
+    "gzipped": 618,
     "treeshaked": {
       "rollup": {
         "code": 28,
@@ -76,8 +76,8 @@
     }
   },
   "devtools.cjs.js": {
-    "bundled": 2537,
-    "minified": 1259,
-    "gzipped": 673
+    "bundled": 2462,
+    "minified": 1206,
+    "gzipped": 660
   }
 }

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -29,21 +29,21 @@ type Extension = {
   connect: (options?: Config) => ConnectionResult
 }
 
-type UseAtomDevtools = <Value>(
+export function useAtomDevtools<Value>(
   anAtom: WritableAtom<Value, Value>,
   name?: string
-) => void
-
-const useAtomDevtoolsImpl: UseAtomDevtools = <Value>(
-  anAtom: WritableAtom<Value, Value>,
-  name?: string
-) => {
+) {
   let extension: Extension | undefined
   try {
     extension = (window as any).__REDUX_DEVTOOLS_EXTENSION__ as Extension
   } catch {}
   if (!extension) {
-    console.warn('Please install/enable Redux devtools extension')
+    if (
+      process.env.NODE_ENV === 'development' &&
+      typeof window !== 'undefined'
+    ) {
+      console.warn('Please install/enable Redux devtools extension')
+    }
   }
 
   const [value, setValue] = useAtom(anAtom)
@@ -95,8 +95,3 @@ const useAtomDevtoolsImpl: UseAtomDevtools = <Value>(
     }
   }, [anAtom, extension, atomName, value])
 }
-
-export const useAtomDevtools: UseAtomDevtools =
-  process.env.NODE_ENV === 'development' && typeof window !== 'undefined'
-    ? useAtomDevtoolsImpl
-    : () => {}


### PR DESCRIPTION
How about enabling devtools only in development mode? It would be a little bit better in production mode.

