### PR TITLE
use object instead of map for debug state

### DIFF
--- a/src/core/immutableMap.ts
+++ b/src/core/immutableMap.ts
@@ -18,9 +18,9 @@ type MMerge = <K, V>(
 ) => ImmutableMap<K, V>
 type MToPrintable = <K, V>(
   m: ImmutableMap<K, V>,
-  toPrintableK: (k: K) => unknown,
+  toPrintableK: (k: K) => string,
   toPrintableV: (v: V) => unknown
-) => unknown
+) => Record<string, unknown>
 
 export const mCreate: MCreate = <K, V>() => [new Map<K, V>()]
 
@@ -92,13 +92,13 @@ export const mMerge: MMerge = <K, V>(
 
 export const mToPrintable: MToPrintable = <K, V>(
   m: ImmutableMap<K, V>,
-  toPrintableK: (k: K) => unknown,
+  toPrintableK: (k: K) => string,
   toPrintableV: (v: V) => unknown
 ) => {
   if (m.length > 1) {
     m = squash(m)
   }
-  return new Map(
+  return Object.fromEntries(
     [...m[0].entries()].map(([k, v]) => [toPrintableK(k), toPrintableV(v)])
   )
 }

--- a/tests/immutableMap.test.ts
+++ b/tests/immutableMap.test.ts
@@ -116,12 +116,12 @@ describe('Printable', () => {
     let m = mCreate<object, unknown>()
     m = mSet(m, { id: 1, meta: 234 }, { v: 'c', otherStuff: 'notNeeded' })
 
-    const printableM: any = mToPrintable(
+    const printableM = mToPrintable(
       m,
       (k: any) => `${k.id}-debug-label`,
       (val: any) => val.v
     )
 
-    expect(printableM.get('1-debug-label')).toBe('c')
+    expect(printableM['1-debug-label']).toBe('c')
   })
 })


### PR DESCRIPTION
https://github.com/pmndrs/jotai/issues/184#issuecomment-725037679
Previously, the debug state is Map and not very easy to see in react devtools.
<img width="366" alt="image" src="https://user-images.githubusercontent.com/490574/98800126-501e9880-2453-11eb-8811-b9cf6bda9688.png">

This fixes it by using objects.
<img width="429" alt="image" src="https://user-images.githubusercontent.com/490574/98800181-64629580-2453-11eb-8d09-554a2d379951.png">
