### PR TITLE
fix(useSelector): do not call equalityFn before initialization

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -24,9 +24,9 @@
     "gzipped": 3582
   },
   "utils.js": {
-    "bundled": 3413,
-    "minified": 1477,
-    "gzipped": 653,
+    "bundled": 3483,
+    "minified": 1490,
+    "gzipped": 664,
     "treeshaked": {
       "rollup": {
         "code": 28,
@@ -38,9 +38,9 @@
     }
   },
   "utils.cjs.js": {
-    "bundled": 6061,
-    "minified": 3203,
-    "gzipped": 1266
+    "bundled": 6131,
+    "minified": 3216,
+    "gzipped": 1276
   },
   "immer.js": {
     "bundled": 797,

--- a/src/utils/useSelector.ts
+++ b/src/utils/useSelector.ts
@@ -7,12 +7,14 @@ export function useSelector<Value, Slice>(
   equalityFn: (a: Slice, b: Slice) => boolean = Object.is
 ): Slice {
   const sliceAtom = useMemo(() => {
+    let initialized = false
     let prevSlice: Slice
     const derivedAtom = atom((get) => {
       const slice = selector(get(anAtom))
-      if (equalityFn(prevSlice, slice)) {
+      if (initialized && equalityFn(prevSlice, slice)) {
         return prevSlice
       }
+      initialized = true
       prevSlice = slice // self contained mutation?
       return slice
     })


### PR DESCRIPTION
I noticed this while I was creating an example on codesandbox.

Would be nice if we can create a test to detect this. cc @Aslemammad 