### PR TITLE
fix: useEffect not called if another setState bails out

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     ]
   },
   "dependencies": {
-    "use-context-selector": "1.2.11"
+    "use-context-selector": "1.2.12"
   },
   "devDependencies": {
     "@babel/core": "^7.12.7",

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -213,7 +213,7 @@ it('updates an async atom in child useEffect on remount without setTimeout', asy
   const countAtom = atom(0)
   const asyncCountAtom = atom(
     async (get) => get(countAtom),
-    async (get, set) => set(countAtom, (get(countAtom) as number) + 1)
+    async (get, set) => set(countAtom, get(countAtom) + 1)
   )
 
   const Counter: React.FC = () => {
@@ -263,7 +263,7 @@ it('updates an async atom in child useEffect on remount', async () => {
     },
     async (get, set) => {
       await new Promise((r) => setTimeout(r, 10))
-      set(countAtom, (get(countAtom) as number) + 1)
+      set(countAtom, get(countAtom) + 1)
     }
   )
 

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -751,7 +751,7 @@ it('set atom right after useEffect (#208)', async () => {
     }
     useEffect(() => {
       effectFn(count)
-      setState(null) // this is important to repro
+      setState(null) // this is important to repro (set something stable)
     }, [count, setState])
     return <div>count: {count}</div>
   }

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -877,7 +877,7 @@ it('only relevant render function called (#156)', async () => {
 
   fireEvent.click(getByText('button1'))
   await waitFor(() => {
-    getByText('count1: 1 (3)')
+    getByText('count1: 1 (3)') // use-context-selector v1.2 triggers double renders
     getByText('count2: 0 (1)')
   })
 

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,5 +1,5 @@
 import React, { StrictMode, Suspense, useEffect, useRef, useState } from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import {
   Provider,
   atom,
@@ -826,4 +826,64 @@ it('works with Brige', async () => {
   fireEvent.click(getByText('child'))
   await findByText('count: 2')
   await findByText('child: 2')
+})
+
+it('only relevant render function called (#156)', async () => {
+  if (process.env.IS_REACT_EXPERIMENTAL) {
+    return // skip this test
+  }
+  const count1Atom = atom(0)
+  const count2Atom = atom(0)
+
+  const Counter1: React.FC = () => {
+    const [count, setCount] = useAtom(count1Atom)
+    const renderCount = useRef(0)
+    ++renderCount.current
+    return (
+      <>
+        <div>
+          count1: {count} ({renderCount.current})
+        </div>
+        <button onClick={() => setCount((c) => c + 1)}>button1</button>
+      </>
+    )
+  }
+
+  const Counter2: React.FC = () => {
+    const [count, setCount] = useAtom(count2Atom)
+    const renderCount = useRef(0)
+    ++renderCount.current
+    return (
+      <>
+        <div>
+          count2: {count} ({renderCount.current})
+        </div>
+        <button onClick={() => setCount((c) => c + 1)}>button2</button>
+      </>
+    )
+  }
+
+  const { getByText } = render(
+    <Provider>
+      <Counter1 />
+      <Counter2 />
+    </Provider>
+  )
+
+  await waitFor(() => {
+    getByText('count1: 0 (1)')
+    getByText('count2: 0 (1)')
+  })
+
+  fireEvent.click(getByText('button1'))
+  await waitFor(() => {
+    getByText('count1: 1 (3)')
+    getByText('count2: 0 (1)')
+  })
+
+  fireEvent.click(getByText('button2'))
+  await waitFor(() => {
+    getByText('count1: 1 (3)')
+    getByText('count2: 1 (3)')
+  })
 })

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -877,7 +877,7 @@ it('only relevant render function called (#156)', async () => {
 
   fireEvent.click(getByText('button1'))
   await waitFor(() => {
-    getByText('count1: 1 (3)') // use-context-selector v1.2 triggers double renders
+    getByText('count1: 1 (3)') // use-context-selector v1.2.12 triggers double renders
     getByText('count2: 0 (1)')
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7037,10 +7037,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-context-selector@1.2.11:
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/use-context-selector/-/use-context-selector-1.2.11.tgz#2b7dd6ed045e4594c1936134f1465d46d01267e7"
-  integrity sha512-roElSNplrQSxUV3dM4ouCVC8xnLAIvh4ulF16Wgsyb+b7Gd23rUughZKkL0DvH48FI4mewwmwqVCU+z5PUEfAg==
+use-context-selector@1.2.12:
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/use-context-selector/-/use-context-selector-1.2.12.tgz#2f5f57dfb1d49d8f20bad7db33189ba0faab63d5"
+  integrity sha512-jw7jpOF/WESMx1dzuKDGD8l/sg+P+tnz5O2t6C4hKOHbTMyjsI6lV5SmGvEGfuQLFFgSrOt6heH6tw9/o3+fZA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Close #208 
It's an edge case which had to dealt with upstream use-context-selector.