### PR TITLE
export RESET symbol and add tests (#217)

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -24,9 +24,9 @@
     "gzipped": 3706
   },
   "utils.js": {
-    "bundled": 4296,
-    "minified": 1994,
-    "gzipped": 859,
+    "bundled": 4303,
+    "minified": 2000,
+    "gzipped": 861,
     "treeshaked": {
       "rollup": {
         "code": 28,
@@ -38,9 +38,9 @@
     }
   },
   "utils.cjs.js": {
-    "bundled": 7232,
-    "minified": 3888,
-    "gzipped": 1482
+    "bundled": 7255,
+    "minified": 3908,
+    "gzipped": 1488
   },
   "devtools.js": {
     "bundled": 2320,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 export { useUpdateAtom } from './utils/useUpdateAtom'
 export { useAtomValue } from './utils/useAtomValue'
-export { atomWithReset, useResetAtom } from './utils/useResetAtom'
+export { atomWithReset, useResetAtom, RESET } from './utils/useResetAtom'
 export { useReducerAtom } from './utils/useReducerAtom'
 export { atomWithReducer } from './utils/atomWithReducer'
 export { atomFamily } from './utils/atomFamily'

--- a/src/utils/useResetAtom.ts
+++ b/src/utils/useResetAtom.ts
@@ -3,7 +3,7 @@ import { atom, useAtom, WritableAtom } from 'jotai'
 
 import type { SetStateAction } from '../core/types'
 
-const RESET = Symbol()
+export const RESET = Symbol()
 
 export function atomWithReset<Value>(initialValue: Value) {
   type Update = SetStateAction<Value> | typeof RESET

--- a/tests/utils/useResetAtom.test.tsx
+++ b/tests/utils/useResetAtom.test.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Provider, useAtom } from '../../src/index'
-import { useResetAtom, atomWithReset } from '../../src/utils'
+import { atom, Provider, useAtom } from '../../src/index'
+import {
+  useResetAtom,
+  atomWithReducer,
+  atomWithReset,
+  RESET,
+} from '../../src/utils'
 
 it('atomWithReset resets to its first value', async () => {
   const countAtom = atomWithReset(0)
@@ -48,4 +53,81 @@ it('atomWithReset resets to its first value', async () => {
   await findByText('count: 12')
   fireEvent.click(getByText('increment'))
   await findByText('count: 13')
+})
+
+it('atomWithReset through read-write atom', async () => {
+  const primitiveAtom = atomWithReset(0)
+  const countAtom = atom(
+    (get) => get(primitiveAtom),
+    (get, set, newValue: number | typeof RESET) => set(primitiveAtom, newValue)
+  )
+
+  const Parent: React.FC = () => {
+    const [count, setValue] = useAtom(countAtom)
+    const resetAtom = useResetAtom(countAtom)
+    return (
+      <>
+        <div>count: {count}</div>
+        <button onClick={resetAtom}>reset</button>
+        <button onClick={() => setValue(10)}>set to 10</button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Parent />
+    </Provider>
+  )
+
+  await findByText('count: 0')
+
+  fireEvent.click(getByText('set to 10'))
+  await findByText('count: 10')
+
+  fireEvent.click(getByText('reset'))
+  await findByText('count: 0')
+})
+
+it('useResetAtom with custom atom', async () => {
+  const reducer = (state: number, action: 'INCREASE' | typeof RESET) => {
+    switch (action) {
+      case 'INCREASE':
+        return state + 1
+      case RESET:
+        return 0
+    }
+  }
+
+  const countAtom = atomWithReducer(0, reducer)
+
+  const Parent: React.FC = () => {
+    const [count, dispatch] = useAtom(countAtom)
+    const resetAtom = useResetAtom(countAtom)
+    return (
+      <>
+        <div>count: {count}</div>
+        <button onClick={resetAtom}>reset</button>
+        <button onClick={() => dispatch('INCREASE')}>increment</button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Parent />
+    </Provider>
+  )
+
+  await findByText('count: 0')
+
+  fireEvent.click(getByText('increment'))
+  await findByText('count: 1')
+  fireEvent.click(getByText('increment'))
+  await findByText('count: 2')
+  fireEvent.click(getByText('increment'))
+  await findByText('count: 3')
+
+  fireEvent.click(getByText('reset'))
+  await findByText('count: 0')
 })


### PR DESCRIPTION
To continue the discussion in https://github.com/pmndrs/jotai/issues/217 I'm adding PR that will allow you to use `useResetAtom` in more cases.

* this exports `RESET` symbol, so bundle becomes slightly bigger
* add tests to cover:
  * resetting read-write atom (but it does nothing special, I could have added `+1` or `* 2` to illustrate the point more)
  * writing custom atom that could use `RESET` value just as a regular value or action (thus `atomWithReducer`, but I don't know if that's ok to create a test that tests both `atomWithReducer` and `useResetAtom`, in some sense this particular tests could be in either `useResetAtom.test.tsx` or `atomWithReducer.test.tsx`)