### PR TITLE
we can now split atomWithReset and useResetAtom

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -24,7 +24,7 @@
     "gzipped": 3706
   },
   "utils.js": {
-    "bundled": 4303,
+    "bundled": 4304,
     "minified": 2000,
     "gzipped": 861,
     "treeshaked": {
@@ -38,7 +38,7 @@
     }
   },
   "utils.cjs.js": {
-    "bundled": 7255,
+    "bundled": 7256,
     "minified": 3908,
     "gzipped": 1488
   },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 export { useUpdateAtom } from './utils/useUpdateAtom'
 export { useAtomValue } from './utils/useAtomValue'
-export { atomWithReset, useResetAtom, RESET } from './utils/useResetAtom'
+export { atomWithReset, RESET } from './utils/atomWithReset'
+export { useResetAtom } from './utils/useResetAtom'
 export { useReducerAtom } from './utils/useReducerAtom'
 export { atomWithReducer } from './utils/atomWithReducer'
 export { atomFamily } from './utils/atomFamily'

--- a/src/utils/atomWithReset.ts
+++ b/src/utils/atomWithReset.ts
@@ -1,0 +1,22 @@
+import { atom, WritableAtom } from 'jotai'
+
+import type { SetStateAction } from '../core/types'
+
+export const RESET = Symbol()
+
+export function atomWithReset<Value>(initialValue: Value) {
+  type Update = SetStateAction<Value> | typeof RESET
+  const anAtom: any = atom<Value, Update>(initialValue, (get, set, update) => {
+    if (update === RESET) {
+      set(anAtom, initialValue)
+    } else {
+      set(
+        anAtom,
+        typeof update === 'function'
+          ? (update as (prev: Value) => Value)(get(anAtom))
+          : update
+      )
+    }
+  })
+  return anAtom as WritableAtom<Value, Update>
+}

--- a/src/utils/useResetAtom.ts
+++ b/src/utils/useResetAtom.ts
@@ -1,26 +1,6 @@
 import { useMemo } from 'react'
 import { atom, useAtom, WritableAtom } from 'jotai'
-
-import type { SetStateAction } from '../core/types'
-
-export const RESET = Symbol()
-
-export function atomWithReset<Value>(initialValue: Value) {
-  type Update = SetStateAction<Value> | typeof RESET
-  const anAtom: any = atom<Value, Update>(initialValue, (get, set, update) => {
-    if (update === RESET) {
-      set(anAtom, initialValue)
-    } else {
-      set(
-        anAtom,
-        typeof update === 'function'
-          ? (update as (prev: Value) => Value)(get(anAtom))
-          : update
-      )
-    }
-  })
-  return anAtom as WritableAtom<Value, Update>
-}
+import { RESET } from './atomWithReset'
 
 export function useResetAtom<Value>(anAtom: WritableAtom<Value, typeof RESET>) {
   const writeOnlyAtom = useMemo(


### PR DESCRIPTION
* it wasn't possible before since RESET wasn't exported
* there's probably some good reason why we can put `RESET` symbol in its own file or in `useResetAtom`, but I don't know it
* this continues #221 