### PR TITLE
format md with prettier for more consistent code examples

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -37,7 +37,7 @@ Zustand is an external store and the hook is to connect the external world to th
 - If you want to make use of Suspense, jotai is the one.
 - If you need a global store to bridge between two react reconcilers, zustand will only work.
 
-----
+---
 
 # How is jotai different from recoil?
 

--- a/docs/core.md
+++ b/docs/core.md
@@ -87,9 +87,7 @@ const Component = ({ children }) => {
   const brigeValue = useBridge()
   return (
     <AnotherRerender>
-      <Bridge value={bridgeValue}>
-        {children}
-      </Bridge>
+      <Bridge value={bridgeValue}>{children}</Bridge>
     </AnotherRerender>
   )
 }
@@ -102,7 +100,7 @@ A working example: https://codesandbox.io/s/jotai-r3f-fri9d
 To begin with, let's explain this. In the current implementation, every time we invoke the "read" function, we refresh dependencies. For example, If A depends on B, it means that B is a dependency of A, and A is a dependent of B.
 
 ```js
-const uppercaseAtom = atom(get => get(textAtom).toUpperCase())
+const uppercaseAtom = atom((get) => get(textAtom).toUpperCase())
 ```
 
 The read function is the first parameter of the atom.
@@ -124,7 +122,7 @@ You can create an atom and store it wth `useState` or even in another atom.
 See an example in [issue #5](https://github.com/pmndrs/jotai/issues/5).
 
 You can cache atoms somewhere globally.
-See [this example](https://twitter.com/dai_shi/status/1317653548314718208) or 
+See [this example](https://twitter.com/dai_shi/status/1317653548314718208) or
 [that example](https://github.com/pmndrs/jotai/issues/119#issuecomment-706046321).
 
 Check [atomFamily](https://github.com/pmndrs/jotai/blob/master/docs/utils.md#atomfamily) in utils too.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -24,7 +24,6 @@ if (process.env.NODE_ENV !== 'production') {
 
 `useAtomDevtools` is a React hook that manages ReduxDevTools integration for a particular atom.
 
-
 ### Call Signature:
 
 ```typescript
@@ -44,8 +43,8 @@ import { useAtomDevtools } from 'jotai/devtools'
 
 // The interface for the type stored in the atom.
 export interface Task {
-    label: string
-    complete: boolean
+  label: string
+  complete: boolean
 }
 
 // The atom to debug.
@@ -55,16 +54,15 @@ export const tasksAtom = atom<Task[]>([])
 tasksAtom.debugLabel = 'Tasks'
 
 export const useTasksDevtools = () => {
+  // The hook can be called simply by passing an atom for debugging.
+  useAtomDevtools(tasksAtom)
 
-    // The hook can be called simply by passing an atom for debugging.
-    useAtomDevtools(tasksAtom)
+  // Specify a custom type parameter
+  useAtomDevtools<Task[]>(tasksAtom)
 
-    // Specify a custom type parameter
-    useAtomDevtools<Task[]>(tasksAtom)
-
-    // You can attach two devtools instances to the same atom and differentiate them with custom names.
-    useAtomDevtools(tasksAtom, 'Tasks (Instance 1)')
-    useAtomDevtools(tasksAtom, 'Tasks (Instance 2)')
+  // You can attach two devtools instances to the same atom and differentiate them with custom names.
+  useAtomDevtools(tasksAtom, 'Tasks (Instance 1)')
+  useAtomDevtools(tasksAtom, 'Tasks (Instance 2)')
 }
 ```
 

--- a/docs/immer.md
+++ b/docs/immer.md
@@ -1,4 +1,4 @@
-This doc describes `jotai/immer` bundle. 
+This doc describes `jotai/immer` bundle.
 
 ## Install
 
@@ -6,14 +6,14 @@ You have to install `immer` to access this bundle and its functions.
 
 ```
 npm install immer
-# or 
+# or
 yarn add immer
 ```
 
 ## atomWithImmer
 
-`atomWithImmer` creates a new atom similar to the regular [atom](https://github.com/pmndrs/jotai/blob/master/docs/core.md#atom) with a different `writeFunction`. In this bundle, we don't have read-only atoms, because the point of these functions is the immer produce(mutability) function. 
-The signature of writeFunction is `(get, set, update: (draft: Draft<Value>) => void) => void`. 
+`atomWithImmer` creates a new atom similar to the regular [atom](https://github.com/pmndrs/jotai/blob/master/docs/core.md#atom) with a different `writeFunction`. In this bundle, we don't have read-only atoms, because the point of these functions is the immer produce(mutability) function.
+The signature of writeFunction is `(get, set, update: (draft: Draft<Value>) => void) => void`.
 
 ```js
 import { useAtom } from 'jotai'
@@ -29,7 +29,7 @@ const Counter = () => {
 const Controls = () => {
   const [, setCount] = useAtom(setCountAtom)
   // setCount === update : (draft: Draft<Value>) => void
-  const inc = () => setCount(c => (c = c + 1))
+  const inc = () => setCount((c) => (c = c + 1))
   return <button onClick={inc}>+1</button>
 }
 ```
@@ -59,7 +59,7 @@ const Counter = () => {
 const Controls = () => {
   const [, setCount] = useAtom(setCountAtom)
   // setCount === update : (draft: Draft<Value>) => void
-  const inc = () => setCount(c => (c = c + 1))
+  const inc = () => setCount((c) => (c = c + 1))
   return <button onClick={inc}>+1</button>
 }
 ```
@@ -69,12 +69,10 @@ const Controls = () => {
 This hook takes an atom and replaces the atom's `writeFunction` with the new immer-like `writeFunction` like the previous helpers.
 
 ```jsx
-
 import { useAtom } from 'jotai'
 import { useImmerAtom } from 'jotai/immer'
 
 const primitiveAtom = atom(0)
-
 
 const Counter = () => {
   const [count] = useImmerAtom(primitiveAtom)
@@ -84,7 +82,7 @@ const Counter = () => {
 const Controls = () => {
   const [, setCount] = useImmerAtom(primitiveAtom)
   // setCount === update : (draft: Draft<Value>) => void
-  const inc = () => setCount(c => (c = c + 1))
+  const inc = () => setCount((c) => (c = c + 1))
   return <button onClick={inc}>+1</button>
 }
 ```

--- a/docs/nextjs.md
+++ b/docs/nextjs.md
@@ -14,7 +14,7 @@ import { useUpdateAtom } from 'jotai/utils.cjs'
 const postData = atom((get) => {
   const id = get(postId)
   if (isSSR || prefetchedPostData[id]) {
-    return prefetchedPostData[id] || EMPTY_POST_DATA;
+    return prefetchedPostData[id] || EMPTY_POST_DATA
   }
   return fetchData(id) // returns a promise
 })

--- a/docs/optics.md
+++ b/docs/optics.md
@@ -1,4 +1,4 @@
-This doc describes `jotai/optics` bundle. 
+This doc describes `jotai/optics` bundle.
 
 ## Install
 
@@ -6,30 +6,29 @@ You have to install `optics-ts` to access this bundle and its functions.
 
 ```
 npm install optics-ts
-# or 
+# or
 yarn add optics-ts
 ```
 
 ## focusAtom
 
-`focusAtom` creates a new atom, based on the focus that you pass to it. This creates a derived atom that will focus on the specified part of the atom, 
+`focusAtom` creates a new atom, based on the focus that you pass to it. This creates a derived atom that will focus on the specified part of the atom,
 and when the derived atom is updated, the derivee is notified of the update, and the equivalent update is done on the derivee.
 
-See this: 
+See this:
 
 ```typescript
-const baseAtom = atom({a: 5}) // PrimitiveAtom<{a: number}>
-const derivedAtom = focusAtom(baseAtom, optic => optic.prop('a')) // PrimitiveAtom<number>
+const baseAtom = atom({ a: 5 }) // PrimitiveAtom<{a: number}>
+const derivedAtom = focusAtom(baseAtom, (optic) => optic.prop('a')) // PrimitiveAtom<number>
 ```
 
-So basically, we started with a `PrimitiveAtom<{a: number}>`, which has a getter and a setter, and then used `focusAtom` to zoom in on the `a`-property of 
+So basically, we started with a `PrimitiveAtom<{a: number}>`, which has a getter and a setter, and then used `focusAtom` to zoom in on the `a`-property of
 the `baseAtom`, and got a `PrimitiveAtom<number>`. What is noteworthy here is that this `derivedAtom` is not only a getter, it is also a setter. If `derivedAtom` is updated, then
-then equivalent update is done on the `baseAtom`. 
+then equivalent update is done on the `baseAtom`.
 
 The example below is simple, but it's a starting point. `focusAtom` supports many kinds of optics, including `Lens`, `Prism`, `Isomorphism`.
 
 To see more advanced optics, please see the example at: https://github.com/akheron/optics-ts
-
 
 ### Example
 
@@ -37,24 +36,20 @@ To see more advanced optics, please see the example at: https://github.com/akher
 import { atom } from 'jotai'
 import { focusAtom } from 'jotai/optics'
 
-const objectAtom = atom({a: 5, b: 10})
-const aAtom = focusAtom(objectAtom, optic => optic.prop('a'))
-const bAtom = focusAtom(objectAtom, optic => optic.prop('b'))
+const objectAtom = atom({ a: 5, b: 10 })
+const aAtom = focusAtom(objectAtom, (optic) => optic.prop('a'))
+const bAtom = focusAtom(objectAtom, (optic) => optic.prop('b'))
 
 const Controls = () => {
   const [a, setA] = useAtom(aAtom)
   const [b, setB] = useAtom(aAtom)
   return (
     <div>
-      <span>
-        Value of a: {a}
-      </span>
-      <span>
-        Value of b: {b}
-      </span>
-      <button onClick={() => setA(oldA => oldA + 1)}>Increment a</button>
-      <button onClick={() => setA(oldB => oldB + 1)}>Increment b</button>
-    </div> 
+      <span>Value of a: {a}</span>
+      <span>Value of b: {b}</span>
+      <button onClick={() => setA((oldA) => oldA + 1)}>Increment a</button>
+      <button onClick={() => setA((oldB) => oldB + 1)}>Increment b</button>
+    </div>
   )
 }
 ```

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -9,7 +9,7 @@ There are some patterns for persistence depending on requirements.
 const strAtom = atom(localStorage.getItem('myKey') ?? 'foo')
 
 const strAtomWithPersistence = atom(
-  get => get(strAtom),
+  (get) => get(strAtom),
   (get, set, newStr) => {
     set(strAtom, newStr)
     localStorage.setItem('myKey', newStr)
@@ -23,7 +23,7 @@ const strAtomWithPersistence = atom(
 const langAtom = atom(
   localStorage.getItem('lang') || 'es',
   (get, set, newLang) => {
-    localStorage.setItem('lang', newLang);
+    localStorage.setItem('lang', newLang)
     set(langAtom, newLang)
   }
 )
@@ -85,47 +85,47 @@ const createPersistAtom = (anAtom, key, serialize, deserialize) => atom(
 ```tsx
 const serializeAtom = atom<
   null,
-  | { type: "serialize"; callback: (value: string) => void }
-  | { type: "deserialize"; value: string }
+  | { type: 'serialize'; callback: (value: string) => void }
+  | { type: 'deserialize'; value: string }
 >(null, (get, set, action) => {
-  if (action.type === "serialize") {
+  if (action.type === 'serialize') {
     const obj = {
-      todos: get(todosAtom).map(get)
-    };
-    action.callback(JSON.stringify(obj));
-  } else if (action.type === "deserialize") {
-    const obj = JSON.parse(action.value);
+      todos: get(todosAtom).map(get),
+    }
+    action.callback(JSON.stringify(obj))
+  } else if (action.type === 'deserialize') {
+    const obj = JSON.parse(action.value)
     // needs error handling and type checking
     set(
       todosAtom,
       obj.todos.map((todo: Todo) => atom(todo))
-    );
+    )
   }
-});
+})
 
 const Persist: React.FC = () => {
-  const [, dispatch] = useAtom(serializeAtom);
+  const [, dispatch] = useAtom(serializeAtom)
   const save = () => {
     dispatch({
-      type: "serialize",
+      type: 'serialize',
       callback: (value) => {
-        localStorage.setItem("serializedTodos", value);
-      }
-    });
-  };
+        localStorage.setItem('serializedTodos', value)
+      },
+    })
+  }
   const load = () => {
-    const value = localStorage.getItem("serializedTodos");
+    const value = localStorage.getItem('serializedTodos')
     if (value) {
-      dispatch({ type: "deserialize", value });
+      dispatch({ type: 'deserialize', value })
     }
-  };
+  }
   return (
     <div>
       <button onClick={save}>Save to localStorage</button>
       <button onClick={load}>Load from localStorage</button>
     </div>
-  );
-};
+  )
+}
 ```
 
 ### Examples
@@ -137,56 +137,56 @@ https://codesandbox.io/s/jotai-todos-ijyxm
 ```tsx
 const serializeAtom = atom<
   null,
-  | { type: "serialize"; callback: (value: string) => void }
-  | { type: "deserialize"; value: string }
+  | { type: 'serialize'; callback: (value: string) => void }
+  | { type: 'deserialize'; value: string }
 >(null, (get, set, action) => {
-  if (action.type === "serialize") {
-    const todos = get(todosAtom);
-    const todoMap: Record<string, { title: string; completed: boolean }> = {};
+  if (action.type === 'serialize') {
+    const todos = get(todosAtom)
+    const todoMap: Record<string, { title: string; completed: boolean }> = {}
     todos.forEach((id) => {
-      todoMap[id] = get(todoAtomFamily({ id }));
-    });
+      todoMap[id] = get(todoAtomFamily({ id }))
+    })
     const obj = {
       todos,
       todoMap,
-      filter: get(filterAtom)
-    };
-    action.callback(JSON.stringify(obj));
-  } else if (action.type === "deserialize") {
-    const obj = JSON.parse(action.value);
+      filter: get(filterAtom),
+    }
+    action.callback(JSON.stringify(obj))
+  } else if (action.type === 'deserialize') {
+    const obj = JSON.parse(action.value)
     // needs error handling and type checking
-    set(filterAtom, obj.filter);
+    set(filterAtom, obj.filter)
     obj.todos.forEach((id: string) => {
-      const todo = obj.todoMap[id];
-      set(todoAtomFamily({ id, ...todo }), todo);
-    });
-    set(todosAtom, obj.todos);
+      const todo = obj.todoMap[id]
+      set(todoAtomFamily({ id, ...todo }), todo)
+    })
+    set(todosAtom, obj.todos)
   }
-});
+})
 
 const Persist: React.FC = () => {
-  const [, dispatch] = useAtom(serializeAtom);
+  const [, dispatch] = useAtom(serializeAtom)
   const save = () => {
     dispatch({
-      type: "serialize",
+      type: 'serialize',
       callback: (value) => {
-        localStorage.setItem("serializedTodos", value);
-      }
-    });
-  };
+        localStorage.setItem('serializedTodos', value)
+      },
+    })
+  }
   const load = () => {
-    const value = localStorage.getItem("serializedTodos");
+    const value = localStorage.getItem('serializedTodos')
     if (value) {
-      dispatch({ type: "deserialize", value });
+      dispatch({ type: 'deserialize', value })
     }
-  };
+  }
   return (
     <div>
       <button onClick={save}>Save to localStorage</button>
       <button onClick={load}>Load from localStorage</button>
     </div>
-  );
-};
+  )
+}
 ```
 
 ### Examples

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -2,22 +2,22 @@
 
 ## Official examples
 
-* Text Length example [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://githubbox.com/pmndrs/jotai/tree/master/examples/text_length)
+- Text Length example [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://githubbox.com/pmndrs/jotai/tree/master/examples/text_length)
 
   Count the length and show the uppercase of any text.
 
-* Hacker News example [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://githubbox.com/pmndrs/jotai/tree/master/examples/hacker_news)
+- Hacker News example [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://githubbox.com/pmndrs/jotai/tree/master/examples/hacker_news)
 
   Demonstrate a news articles with jotai, hit next to see more articles.
 
-* Todos example [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://githubbox.com/pmndrs/jotai/tree/master/examples/todos)
+- Todos example [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://githubbox.com/pmndrs/jotai/tree/master/examples/todos)
 
   Record your todo list by typing them into this app, check them if you have completed the task, and switch between `Completed` and `Incompleted` to see the status of your task.
 
-* Todos example with atomFamily and localStorage [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://githubbox.com/pmndrs/jotai/tree/master/examples/todos_with_atomFamily)
+- Todos example with atomFamily and localStorage [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://githubbox.com/pmndrs/jotai/tree/master/examples/todos_with_atomFamily)
 
   Implement a todo list using atomFamily and localStorage, you can store your todo list to localStorage by click `Save to localStorage`, then remove your todo list and restore them by click `Load from localStorage`.
 
-* Clock with Next.js [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://codesandbox.io/s/nextjs-with-jotai-5ylrj)
+- Clock with Next.js [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://codesandbox.io/s/nextjs-with-jotai-5ylrj)
 
   An UTC time eletronic clock implement using Next.js and jotai.

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -17,19 +17,20 @@ const Counter = () => {
 
 const Controls = () => {
   const setCount = useUpdateAtom(countAtom)
-  const inc = () => setCount(c => c + 1)
+  const inc = () => setCount((c) => c + 1)
   return <button onClick={inc}>+1</button>
 }
 ```
 
 https://codesandbox.io/s/react-typescript-forked-3q11k
+
 ## useAtomValue
 
 Ref: https://github.com/pmndrs/jotai/issues/212
 
 ```js
-import { atom, Provider, useAtom } from "jotai"
-import { useAtomValue } from "jotai/utils"
+import { atom, Provider, useAtom } from 'jotai'
+import { useAtomValue } from 'jotai/utils'
 
 const countAtom = atom(0)
 
@@ -55,10 +56,12 @@ Ref: https://github.com/react-spring/jotai/issues/41
 import { useAtom } from 'jotai'
 import { atomWithReset, useResetAtom } from 'jotai/utils'
 
-const todoListAtom = atomWithReset([{
-  description: "Add a todo",
-  checked: false
-}])
+const todoListAtom = atomWithReset([
+  {
+    description: 'Add a todo',
+    checked: false,
+  },
+])
 
 const TodoList = () => {
   const [todoList, setTodoList] = useAtom(todoListAtom)
@@ -73,11 +76,15 @@ const TodoList = () => {
       </ul>
 
       <button
-        onClick={() => setTodoList((l) => [ ...l, {
-          description: `New todo ${new Date().toDateString()}`,
-          checked: false
-        }])}
-      >
+        onClick={() =>
+          setTodoList((l) => [
+            ...l,
+            {
+              description: `New todo ${new Date().toDateString()}`,
+              checked: false,
+            },
+          ])
+        }>
         Add todo
       </button>
       <button onClick={resetTodoList}>Reset</button>
@@ -103,15 +110,15 @@ const countReducer = (prev, action) => {
 const countAtom = atom(0)
 
 const Counter = () => {
-  const [count, dispatch] = useReducerAtom(countAtom, countReducer);
+  const [count, dispatch] = useReducerAtom(countAtom, countReducer)
   return (
     <div>
       {count}
-      <button onClick={() => dispatch({ type: "inc" })}>+1</button>
-      <button onClick={() => dispatch({ type: "dec" })}>-1</button>
+      <button onClick={() => dispatch({ type: 'inc' })}>+1</button>
+      <button onClick={() => dispatch({ type: 'dec' })}>-1</button>
     </div>
-  );
-};
+  )
+}
 ```
 
 https://codesandbox.io/s/react-typescript-forked-eg0mw
@@ -168,8 +175,8 @@ import { atomFamily } from 'jotai/utils'
 
 const todoFamily = atomFamily((name) => name)
 
-  todoFamily('foo')
-  // this will create a new atom('foo'), or return the one if already created
+todoFamily('foo')
+// this will create a new atom('foo'), or return the one if already created
 ```
 
 ```js
@@ -214,53 +221,53 @@ The equalityFn is optional.
 ### Examples
 
 ```js
-import { Provider } from "jotai";
-import { useSelector, atomWithReducer, useUpdateAtom } from "jotai/utils";
+import { Provider } from 'jotai'
+import { useSelector, atomWithReducer, useUpdateAtom } from 'jotai/utils'
 
 const initialState = {
   count: 0,
-  text: "hello"
-};
+  text: 'hello',
+}
 
 const reducer = (state, action) => {
-  if (action.type === "INC") {
-    return { ...state, count: state.count + 1 };
-  } else if (action.type === "SET_TEXT") {
-    return { ...state, text: action.text };
+  if (action.type === 'INC') {
+    return { ...state, count: state.count + 1 }
+  } else if (action.type === 'SET_TEXT') {
+    return { ...state, text: action.text }
   } else {
-    throw Error("no such action");
+    throw Error('no such action')
   }
-};
+}
 
-const stateAtom = atomWithReducer(initialState, reducer);
+const stateAtom = atomWithReducer(initialState, reducer)
 
-const selectCount = (state: State) => state.count;
+const selectCount = (state: State) => state.count
 
 const Counter = () => {
-  const dispatch = useUpdateAtom(stateAtom);
-  const count = useSelector(stateAtom, selectCount);
+  const dispatch = useUpdateAtom(stateAtom)
+  const count = useSelector(stateAtom, selectCount)
   return (
     <div>
-      {count} <button onClick={() => dispatch({ type: "INC" })}>+1</button>
+      {count} <button onClick={() => dispatch({ type: 'INC' })}>+1</button>
     </div>
-  );
-};
+  )
+}
 
-const selectText = (state: State) => state.text;
+const selectText = (state: State) => state.text
 
 const TextBox = () => {
-  const dispatch = useUpdateAtom(stateAtom);
-  const text = useSelector(stateAtom, selectText);
+  const dispatch = useUpdateAtom(stateAtom)
+  const text = useSelector(stateAtom, selectText)
   return (
     <div>
-      {text}{" "}
+      {text}{' '}
       <input
         value={text}
-        onChange={(e) => dispatch({ type: "SET_TEXT", text: e.target.value })}
+        onChange={(e) => dispatch({ type: 'SET_TEXT', text: e.target.value })}
       />
     </div>
-  );
-};
+  )
+}
 ```
 
 ### Codesandbox
@@ -288,40 +295,40 @@ The callback to pass in the hook must be stable (should be wrapped with useCallb
 ### Examples
 
 ```js
-import { useEffect, useState, useCallback } from "react";
-import { Provider, atom, useAtom } from "jotai";
-import { useAtomCallback } from "jotai/utils";
+import { useEffect, useState, useCallback } from 'react'
+import { Provider, atom, useAtom } from 'jotai'
+import { useAtomCallback } from 'jotai/utils'
 
-const countAtom = atom(0);
+const countAtom = atom(0)
 
 const Counter = () => {
-  const [count, setCount] = useAtom(countAtom);
+  const [count, setCount] = useAtom(countAtom)
   return (
     <>
       {count} <button onClick={() => setCount((c) => c + 1)}>+1</button>
     </>
-  );
-};
+  )
+}
 
 const Monitor = () => {
-  const [count, setCount] = useState(0);
+  const [count, setCount] = useState(0)
   const readCount = useAtomCallback(
     useCallback((get) => {
-      const currCount = get(countAtom);
-      setCount(currCount);
-      return currCount;
+      const currCount = get(countAtom)
+      setCount(currCount)
+      return currCount
     }, [])
-  );
+  )
   useEffect(() => {
     const timer = setInterval(async () => {
-      console.log(await readCount());
-    }, 1000);
+      console.log(await readCount())
+    }, 1000)
     return () => {
-      clearInterval(timer);
-    };
-  }, [readCount]);
-  return <div>current count: {count}</div>;
-};
+      clearInterval(timer)
+    }
+  }, [readCount])
+  return <div>current count: {count}</div>
+}
 ```
 
 ### Codesandbox

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "printWidth": 80
   },
   "lint-staged": {
-    "*.{js,ts,tsx}": [
+    "*.{js,ts,tsx,md}": [
       "prettier --write"
     ]
   },

--- a/readme.md
+++ b/readme.md
@@ -17,9 +17,9 @@ You can try live demos in the following: [Demo 1](https://codesandbox.io/s/jotai
 
 #### How does Jotai differ from Recoil?
 
-* Minimalistic API
-* No string keys
-* TypeScript oriented
+- Minimalistic API
+- No string keys
+- TypeScript oriented
 
 <a id="firstcreateaprimitiveatom" href="#firstcreateaprimitiveatom"><img src="img/doc.01.svg" alt="First create a primitive atom" /></a>
 
@@ -29,9 +29,9 @@ An atom represents a piece of state. All you need is to specify an initial value
 import { atom } from 'jotai'
 
 const countAtom = atom(0)
-const countryAtom = atom("Japan")
-const citiesAtom = atom(["Tokyo", "Kyoto", "Osaka"])
-const mangaAtom = atom({ "Dragon Ball": 1984, "One Piece": 1997, "Naruto": 1999 })
+const countryAtom = atom('Japan')
+const citiesAtom = atom(['Tokyo', 'Kyoto', 'Osaka'])
+const mangaAtom = atom({ 'Dragon Ball': 1984, 'One Piece': 1997, Naruto: 1999 })
 ```
 
 <a id="wrapyourcomponenttree" href="#wrapyourcomponenttree"><img src="img/doc.02.svg" alt="Wrap your component tree with Jotai's Provider" /></a>
@@ -86,14 +86,14 @@ const count1 = atom(1)
 const count2 = atom(2)
 const count3 = atom(3)
 
-const sum = atom(get => get(count1) + get(count2) + get(count3))
+const sum = atom((get) => get(count1) + get(count2) + get(count3))
 ```
 
-Or if you like fp patterns ... 
+Or if you like fp patterns ...
 
 ```jsx
 const atoms = [count1, count2, count3, ...otherAtoms]
-const sum = atom(get => atoms.map(get).reduce((acc, count) => acc + count))
+const sum = atom((get) => atoms.map(get).reduce((acc, count) => acc + count))
 ```
 
 <a id="derivedasyncatoms" href="#derivedasyncatoms"><img src="img/rec.02.svg" alt="Derived async atoms (needs suspense)" /></a>
@@ -162,7 +162,7 @@ function Controls() {
   return <button onClick={() => compute("http://count.host.com")}>compute</button>
 ```
 
-----
+---
 
 ## Installation notes
 


### PR DESCRIPTION
* prettier is only running when files are committed, there probably more files that need to be formatted, I did `yarn prettier --write docs/*.md readme.md`
* it might be possible to set different code style for `md` files then for code. I tried for example with `semi: true` and `singleQuote: false`, but the amount of changes seemed about the same, as half of the code in docs is in one style and the other in other :)