### PR TITLE
revert PrimitiveAtom type

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 18666,
-    "minified": 8241,
-    "gzipped": 2859,
+    "bundled": 18722,
+    "minified": 8242,
+    "gzipped": 2861,
     "treeshaked": {
       "rollup": {
         "code": 143,
@@ -14,14 +14,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 23239,
-    "minified": 10540,
-    "gzipped": 3552
+    "bundled": 23351,
+    "minified": 10565,
+    "gzipped": 3556
   },
   "index.iife.js": {
-    "bundled": 24672,
-    "minified": 8715,
-    "gzipped": 3230
+    "bundled": 24794,
+    "minified": 8685,
+    "gzipped": 3229
   },
   "utils.js": {
     "bundled": 4304,

--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -38,7 +38,7 @@ export function atom<Value, Update>(read: Function): never
 // primitive atom
 export function atom<Value, Update extends never = never>(
   initialValue: Value
-): PrimitiveAtom<Value>
+): PrimitiveAtom<Value> & WithInitialValue<Value>
 
 export function atom<Value, Update>(
   read: Value | ((get: Getter) => Value | Promise<Value>),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -20,12 +20,12 @@ export type WritableAtom<Value, Update> = Atom<Value> & {
   write: (get: Getter, set: Setter, update: Update) => void | Promise<void>
 }
 
+// This is an internal type and subjects to change.
 export type WithInitialValue<Value> = {
   init: Value
 }
 
-export type PrimitiveAtom<Value> = WritableAtom<Value, SetStateAction<Value>> &
-  WithInitialValue<Value>
+export type PrimitiveAtom<Value> = WritableAtom<Value, SetStateAction<Value>>
 
 export type AnyAtom = Atom<unknown>
 export type AnyWritableAtom = WritableAtom<unknown, unknown>

--- a/src/core/vanilla.ts
+++ b/src/core/vanilla.ts
@@ -1,13 +1,18 @@
 import {
   Atom,
   WritableAtom,
+  WithInitialValue,
   AnyAtom,
   AnyWritableAtom,
   Getter,
   Setter,
 } from './types'
 
-const INIT = 'init'
+const hasInitialValue = <T extends Atom<unknown>>(
+  atom: T
+): atom is T &
+  (T extends Atom<infer Value> ? WithInitialValue<Value> : never) =>
+  'init' in atom
 
 type Revision = number
 type ReadDependencies = Map<AnyAtom, Revision>
@@ -87,8 +92,8 @@ const wipAtomState = <Value>(
     atomState = { ...atomState } // copy
   } else {
     atomState = { r: 0, d: new Map() }
-    if (INIT in atom) {
-      atomState.v = (atom as { init?: Value }).init
+    if (hasInitialValue(atom)) {
+      atomState.v = atom.init
     }
   }
   const nextState = {
@@ -257,8 +262,8 @@ const readAtomState = <Value>(
         }
         return aState.v // value
       }
-      if (INIT in a) {
-        return (a as { init?: unknown }).init
+      if (hasInitialValue(a)) {
+        return a.init
       }
       throw new Error('no atom init')
     }) as Getter)

--- a/src/optics/focusAtom.ts
+++ b/src/optics/focusAtom.ts
@@ -1,26 +1,26 @@
 import { atom } from 'jotai'
 import * as O from 'optics-ts'
-import type { SetStateAction, WritableAtom } from '../core/types'
+import type { WritableAtom, SetStateAction, PrimitiveAtom } from '../core/types'
 
 export function focusAtom<S, A>(
-  atom: WritableAtom<S, SetStateAction<S>>,
+  atom: PrimitiveAtom<S>,
   callback: (optic: O.OpticFor<S>) => O.Prism<S, any, A>
 ): WritableAtom<A | undefined, SetStateAction<A>>
 
 export function focusAtom<S, A>(
-  atom: WritableAtom<S, SetStateAction<S>>,
+  atom: PrimitiveAtom<S>,
   callback: (optic: O.OpticFor<S>) => O.Traversal<S, any, A>
 ): WritableAtom<Array<A>, SetStateAction<A>>
 
 export function focusAtom<S, A>(
-  atom: WritableAtom<S, SetStateAction<S>>,
+  atom: PrimitiveAtom<S>,
   callback: (
     optic: O.OpticFor<S>
   ) => O.Lens<S, any, A> | O.Equivalence<S, any, A> | O.Iso<S, any, A>
 ): WritableAtom<A, SetStateAction<A>>
 
 export function focusAtom<S, A>(
-  baseAtom: WritableAtom<S, SetStateAction<S>>,
+  baseAtom: PrimitiveAtom<S>,
   callback: (
     optic: O.OpticFor<S>
   ) =>
@@ -32,7 +32,7 @@ export function focusAtom<S, A>(
 ):
   | WritableAtom<A | undefined, SetStateAction<A>>
   | WritableAtom<Array<A>, SetStateAction<A>>
-  | WritableAtom<A, SetStateAction<A>> {
+  | PrimitiveAtom<S> {
   const focus = callback(O.optic<S>())
   return atom<A, SetStateAction<A>>(
     (get) => {


### PR DESCRIPTION
As discussed in https://github.com/pmndrs/jotai/issues/238#issuecomment-745081350,

It was my bad in #233 to work around #235.
This PR reverts it to the previous version (of v0.11.3), still taking care of the issue discussed in #235 (and assuming #231 is a bug at least for now.)