### PR TITLE
fix: use array.from instead of spread operator for cjs

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 18722,
-    "minified": 8242,
-    "gzipped": 2861,
+    "bundled": 18750,
+    "minified": 8270,
+    "gzipped": 2866,
     "treeshaked": {
       "rollup": {
         "code": 143,
@@ -14,14 +14,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 23351,
-    "minified": 10565,
-    "gzipped": 3556
+    "bundled": 23355,
+    "minified": 10569,
+    "gzipped": 3554
   },
   "index.iife.js": {
-    "bundled": 24794,
-    "minified": 8685,
-    "gzipped": 3229
+    "bundled": 24798,
+    "minified": 8689,
+    "gzipped": 3226
   },
   "utils.js": {
     "bundled": 4304,

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -109,13 +109,15 @@ const isAtom = (x: AnyAtom | symbol): x is AnyAtom => typeof x !== 'symbol'
 
 const stateToPrintable = (state: State) =>
   Object.fromEntries(
-    [...state.m.entries()].map(([atom, dependents]) => {
+    Array.from(state.m.entries()).map(([atom, dependents]) => {
       const atomState = state.a.get(atom) || ({} as AtomState)
       return [
         atomToPrintable(atom),
         {
           value: atomState.re || atomState.rp || atomState.wp || atomState.v,
-          dependents: [...dependents].filter(isAtom).map(atomToPrintable),
+          dependents: Array.from(dependents)
+            .filter(isAtom)
+            .map(atomToPrintable),
         },
       ]
     })

--- a/src/core/vanilla.ts
+++ b/src/core/vanilla.ts
@@ -136,7 +136,7 @@ const replaceDependencies = (
 ): void => {
   if (dependencies) {
     atomState.d = new Map(
-      [...dependencies].map((a) => [a, getAtomState(state, a)?.r ?? 0])
+      Array.from(dependencies).map((a) => [a, getAtomState(state, a)?.r ?? 0])
     )
   }
 }
@@ -216,7 +216,7 @@ const readAtomState = <Value>(
     const atomState = getAtomState(state, atom)
     if (
       atomState &&
-      [...atomState.d.entries()].every(
+      Array.from(atomState.d.entries()).every(
         ([a, r]) => getAtomState(state, a)?.r === r
       )
     ) {


### PR DESCRIPTION
close #243 

The current config for cjs build doesn't transpile `[...<iterator>]` well. There might be a way to change the babel config, but this PR just changes it in the code to `Array.from(<iterator>)` for now.