### PR TITLE
feat: preact support

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     ]
   },
   "dependencies": {
-    "use-context-selector": "1.3.4"
+    "use-context-selector": "1.3.5"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7029,10 +7029,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-context-selector@1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/use-context-selector/-/use-context-selector-1.3.4.tgz#918dde11a8303485e9046c95713936424f04da8e"
-  integrity sha512-grPPE71izEavAv39WF1r1QPZ6Ya41rnjTeLQGMP5yz3VShGQKMDThKXMRUdrDE71pOoaD4pvhFTsDbTjBqxdWg==
+use-context-selector@1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/use-context-selector/-/use-context-selector-1.3.5.tgz#ae1acc14fd504d93c42cbebd4636bf282480aea4"
+  integrity sha512-pYHLEuY3VzboKmHVpT2AABUbzhgKvKUVr7HpDtsRZ9BOJo0dF2U/AS2IEySl6cEKL5RFZP99Fp825dl0SBeqHA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Issue reported in https://github.com/dai-shi/use-context-selector/issues/35

This will allow preact users to use jotai with aliases:
```json
  "alias": {
    "react": "preact/compat",
    "react-dom": "preact/compat",
    "scheduler": false
  }
```