### PR TITLE
fix: proper/better warning message in write function

### DIFF
--- a/src/core/vanilla.ts
+++ b/src/core/vanilla.ts
@@ -418,16 +418,19 @@ const writeAtomState = <Value, Update>(
       ((a: AnyAtom) => {
         const aState = getAtomState(nextState, a)
         if (!aState) {
+          if (hasInitialValue(a)) {
+            return a.init
+          }
           if (
             typeof process === 'object' &&
             process.env.NODE_ENV !== 'production'
           ) {
             console.warn(
-              'Trying to read an atom value that is never used. This may not behave as expected.',
+              'Unable to read the atom without initial value in write function. Please useAtom in advance.',
               a
             )
           }
-          return (a as { init?: unknown }).init
+          throw new Error('uninitialized atom')
         }
         if (
           aState.rp &&


### PR DESCRIPTION
> Trying to read an atom value that is never used. This may not behave as expected. 

This warning message was something I wasn't sure how to deal with, when we read the atom value in `write` that is not initialized.

It turns out there is use case for this path.
So, it now does two things:
1. if the atom has the initial value, return it,
2. otherwise throw an error with a debug warning message.

