### PR TITLE
Fix Provider crash when not having any children

### DIFF
--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,5 +1,4 @@
 import React, {
-  Fragment,
   MutableRefObject,
   ReactElement,
   createElement,
@@ -41,7 +40,7 @@ const InnerProvider: React.FC<{
   if (isReactExperimental && r.current === defaultContextUpdate) {
     r.current = (f) => contextUpdate(f)
   }
-  return createElement(Fragment, {}, children)
+  return (children as ReactElement) ?? null
 }
 
 export const Provider: React.FC<{

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -40,7 +40,7 @@ const InnerProvider: React.FC<{
   if (isReactExperimental && r.current === defaultContextUpdate) {
     r.current = (f) => contextUpdate(f)
   }
-  return children as ReactElement
+  return <>{children}</>
 }
 
 export const Provider: React.FC<{

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,4 +1,5 @@
 import React, {
+  Fragment,
   MutableRefObject,
   ReactElement,
   createElement,
@@ -40,7 +41,7 @@ const InnerProvider: React.FC<{
   if (isReactExperimental && r.current === defaultContextUpdate) {
     r.current = (f) => contextUpdate(f)
   }
-  return <>{children}</>
+  return createElement(Fragment, {}, children)
 }
 
 export const Provider: React.FC<{

--- a/tests/provider.test.tsx
+++ b/tests/provider.test.tsx
@@ -61,3 +61,7 @@ it('only uses initial value from provider for specific atom', async () => {
     getByText('pet: dog')
   })
 })
+
+it('renders correctly without children', () => {
+  render(<Provider />)
+})


### PR DESCRIPTION
## Problem

Currently `<Provider />` crashes as `InnerProvider` returns `undefined` when it has no children. React components may not return `undefined` so you get an error.

### Real world use-case

I know this is an edge case but imagine a component that conditionally renders something that uses `Provider`, like:
```tsx
return <Provider>{someCondition ? <ChildThatUsesJotai /> : undefined}</Provider>
```

I hit it in a unit test where I wanted to test jotai-based persistence of a component by unmounting the child (while keeping `Provider` alive) then remounting it and seeing if it retains the values.

## Alternative solutions

Instead of the cast (which hides the bug), wrapping `children` in a Fragment makes sure this doesn't happen. The alternative would be to make it `children ?? null`, I don't have a strong opinion, I just picked one.
