### PR TITLE
fix: dist mjs files in modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,28 +3,29 @@
   "private": true,
   "version": "0.13.0",
   "description": "👻 Next gen state management that will spook you",
+  "type": "commonjs",
   "main": "index.js",
-  "module": "index.mjs",
+  "module": "modules/index.mjs",
   "types": "index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./index.mjs",
+      "import": "./modules/index.mjs",
       "require": "./index.js",
       "types": "./index.d.ts"
     },
     "./utils": {
-      "import": "./utils.mjs",
+      "import": "./modules/utils.mjs",
       "require": "./utils.js",
       "types": "./utils.d.ts"
     },
     "./immer": {
-      "import": "./immer.mjs",
+      "import": "./modules/immer.mjs",
       "require": "./immer.js",
       "types": "./immer.d.ts"
     },
     "./optics": {
-      "import": "./optics.mjs",
+      "import": "./modules/optics.mjs",
       "require": "./optics.js",
       "types": "./optics.d.ts"
     }
@@ -44,7 +45,7 @@
     "test": "jest && jest --setupFiles ./tests/setReactExperimental.ts",
     "test:dev": "jest --watch --no-coverage",
     "test:coverage:watch": "jest --watch",
-    "copy": "shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && copyfiles -f package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.husky=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\""
+    "copy": "shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && shx mv dist/modules/src/* dist/modules && shx rm -rf dist/modules/{src,tests} && copyfiles -f package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.husky=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\""
   },
   "husky": {
     "hooks": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,27 +53,6 @@ function createCommonJSConfig(input, output) {
   }
 }
 
-function createIIFEConfig(input, output, globalName) {
-  return {
-    input,
-    output: {
-      file: output,
-      format: 'iife',
-      exports: 'named',
-      name: globalName,
-      globals: {
-        react: 'React',
-      },
-    },
-    external,
-    plugins: [
-      resolve({ extensions }),
-      typescript(),
-      babel(getBabelOptions({ ie: 11 })),
-      sizeSnapshot(),
-    ],
-  }
-}
 export default (args) =>
   args['config-cjs']
     ? [
@@ -85,10 +64,10 @@ export default (args) =>
         createCommonJSConfig('src/optics.ts', 'dist/optics.js'),
       ]
     : [
-        createIIFEConfig('src/index.ts', 'dist/index.iife.js', 'jotai'),
-        createESMConfig('src/index.ts', 'dist/index.mjs'),
-        createESMConfig('src/utils.ts', 'dist/utils.mjs'),
-        createESMConfig('src/devtools.ts', 'dist/devtools.mjs'),
-        createESMConfig('src/immer.ts', 'dist/immer.mjs'),
-        createESMConfig('src/optics.ts', 'dist/optics.mjs'),
+        createDeclarationConfig('src/index.ts', 'dist/modules'),
+        createESMConfig('src/index.ts', 'dist/modules/index.mjs'),
+        createESMConfig('src/utils.ts', 'dist/modules/utils.mjs'),
+        createESMConfig('src/devtools.ts', 'dist/modules/devtools.mjs'),
+        createESMConfig('src/immer.ts', 'dist/modules/immer.mjs'),
+        createESMConfig('src/optics.ts', 'dist/modules/optics.mjs'),
       ]


### PR DESCRIPTION
Looks like having cjs files and mjs files in the same directory is troublesome with webpack.
It's unfortunate, but put mjs files in `modules`.
Also drop iife.js assuming it's never used.