### PR TITLE
chore: refactor with single context

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.module.js": {
-    "bundled": 19486,
-    "minified": 8754,
-    "gzipped": 3061,
+    "bundled": 19580,
+    "minified": 8706,
+    "gzipped": 3037,
     "treeshaked": {
       "rollup": {
         "code": 139,
@@ -70,9 +70,9 @@
     }
   },
   "index.js": {
-    "bundled": 23748,
-    "minified": 10885,
-    "gzipped": 3664
+    "bundled": 23894,
+    "minified": 10847,
+    "gzipped": 3639
   },
   "utils.js": {
     "bundled": 7256,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.module.js": {
-    "bundled": 19911,
-    "minified": 8941,
-    "gzipped": 3105,
+    "bundled": 19486,
+    "minified": 8754,
+    "gzipped": 3061,
     "treeshaked": {
       "rollup": {
         "code": 139,
@@ -70,9 +70,9 @@
     }
   },
   "index.js": {
-    "bundled": 24560,
-    "minified": 11194,
-    "gzipped": 3761
+    "bundled": 23748,
+    "minified": 10885,
+    "gzipped": 3664
   },
   "utils.js": {
     "bundled": 7256,

--- a/src/core/Bridge.ts
+++ b/src/core/Bridge.ts
@@ -1,32 +1,22 @@
-import React, { createElement, useMemo } from 'react'
+import React, { createElement } from 'react'
 import { BridgeProvider, useBridgeValue } from 'use-context-selector'
 
-import { getContexts } from './contexts'
+import { getStoreContext } from './contexts'
 import { Scope } from './types'
 
 export const useBridge = (scope?: Scope) => {
-  const [ActionsContext, StateContext] = getContexts(scope)
-  const actions = useBridgeValue(ActionsContext)
-  const state = useBridgeValue(StateContext)
-  return useMemo(() => [actions, state], [actions, state]) as [
-    typeof actions,
-    typeof state
-  ]
+  const StoreContext = getStoreContext(scope)
+  return useBridgeValue(StoreContext)
 }
 
 export const Bridge: React.FC<{
   value: ReturnType<typeof useBridge>
   scope?: Scope
 }> = ({ value, scope, children }) => {
-  const [actions, state] = value
-  const [ActionsContext, StateContext] = getContexts(scope)
+  const StoreContext = getStoreContext(scope)
   return createElement(
     BridgeProvider,
-    { context: ActionsContext, value: actions },
-    createElement(
-      BridgeProvider,
-      { context: StateContext, value: state },
-      children
-    )
+    { context: StoreContext, value },
+    children
   )
 }

--- a/src/core/contexts.ts
+++ b/src/core/contexts.ts
@@ -1,35 +1,19 @@
 import { createContext } from 'use-context-selector'
 
-import { Atom, WritableAtom, Scope } from './types'
-import { AtomState, State } from './vanilla'
+import { Scope } from './types'
+import { State, UpdateState } from './vanilla'
 
-export type Actions = {
-  add: <Value>(atom: Atom<Value>, id: symbol) => void
-  del: <Value>(atom: Atom<Value>, id: symbol) => void
-  read: <Value>(state: State, atom: Atom<Value>) => AtomState<Value>
-  write: <Value, Update>(
-    atom: WritableAtom<Value, Update>,
-    update: Update
-  ) => void | Promise<void>
-}
+export type Store = readonly [State, UpdateState]
 
-// dummy function for typing
-const createContexts = () =>
-  [
-    createContext<Actions | null>(null),
-    createContext<State | null>(null),
-  ] as const
+const createStoreContext = () => createContext<Store | null>(null)
 
-type Contexts = ReturnType<typeof createContexts>
+type StoreContext = ReturnType<typeof createStoreContext>
 
-const ContextsMap = new Map<Scope | undefined, Contexts>()
+const StoreContextMap = new Map<Scope | undefined, StoreContext>()
 
-export const getContexts = (scope?: Scope) => {
-  if (!ContextsMap.has(scope)) {
-    ContextsMap.set(scope, [
-      createContext<Actions | null>(null),
-      createContext<State | null>(null),
-    ])
+export const getStoreContext = (scope?: Scope) => {
+  if (!StoreContextMap.has(scope)) {
+    StoreContextMap.set(scope, createStoreContext())
   }
-  return ContextsMap.get(scope) as Contexts
+  return StoreContextMap.get(scope) as StoreContext
 }


### PR DESCRIPTION
Having two contexts was somewhat for performance for the future.
But, if react supports use-context-selector natively in the future, we might not need this, furthermore, it doesn't improve performance as of now.
Having a single context simplifies code and possibly has room for improvements.
