### PR TITLE
fix: provider debug state

### DIFF
--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -20,7 +20,7 @@ export const Provider: React.FC<{
   ) {
     /* eslint-disable react-hooks/rules-of-hooks */
     const atomsRef = useRef<AnyAtom[]>([])
-    if (storeRef.current == null) {
+    if (storeRef.current === null) {
       // lazy initialization
       storeRef.current = createStore(initialValues, (newAtom) => {
         atomsRef.current.push(newAtom)
@@ -32,7 +32,7 @@ export const Provider: React.FC<{
     )
     /* eslint-enable react-hooks/rules-of-hooks */
   } else {
-    if (storeRef.current == null) {
+    if (storeRef.current === null) {
       // lazy initialization
       storeRef.current = createStore(initialValues)
     }
@@ -71,12 +71,12 @@ const stateToPrintable = ([state, atoms]: [State, AnyAtom[]]) =>
 
 const getState = (state: State) => ({ ...state }) // shallow copy
 
-// This hook makes sure that we keep a reference to the atoms in dev mode, 
+// We keep a reference to the atoms in Provider's atomsRef in dev mode,
 // so atoms aren't garbage collected by the WeakMap of mounted atoms
 const useDebugState = (store: Store, atoms: AnyAtom[]) => {
   const subscribe = useCallback(
     (state: State, callback: () => void) => {
-      // FIXME we don't need to resubscribe, we just need to subscribe for new one
+      // FIXME we don't need to resubscribe, just need to subscribe for new one
       const unsubs = atoms.map((atom) => subscribeAtom(state, atom, callback))
       return () => {
         unsubs.forEach((unsub) => unsub())

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -71,6 +71,8 @@ const stateToPrintable = ([state, atoms]: [State, AnyAtom[]]) =>
 
 const getState = (state: State) => ({ ...state }) // shallow copy
 
+// This hook makes sure that we keep a reference to the atoms in dev mode, 
+// so atoms aren't garbage collected by the WeakMap of mounted atoms
 const useDebugState = (store: Store, atoms: AnyAtom[]) => {
   const subscribe = useCallback(
     (state: State, callback: () => void) => {

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,51 +1,87 @@
-import React, { createElement, useRef, useDebugValue } from 'react'
+import React, { createElement, useCallback, useRef, useDebugValue } from 'react'
 
 import type { AnyAtom, Scope } from './types'
+import { subscribeAtom } from './vanilla'
 import type { AtomState, State } from './vanilla'
 import { createStore, getStoreContext } from './contexts'
+import type { Store } from './contexts'
 import { useMutableSource } from './useMutableSource'
-
-const getState = (state: State) => state
-// TODO this doesn't trigger re-render so useDebugState can be stale.
-const subscribe = (_state: State, _callback: () => void) => () => {}
 
 export const Provider: React.FC<{
   initialValues?: Iterable<readonly [AnyAtom, unknown]>
   scope?: Scope
 }> = ({ initialValues, scope, children }) => {
   const storeRef = useRef<ReturnType<typeof createStore> | null>(null)
-  if (storeRef.current == null) {
-    // lazy initialization
-    storeRef.current = createStore(initialValues)
-  }
-  const store = storeRef.current as ReturnType<typeof createStore>
 
-  if (typeof process === 'object' && process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useDebugState(useMutableSource(store[0], getState, subscribe))
+  if (
+    typeof process === 'object' &&
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test'
+  ) {
+    /* eslint-disable react-hooks/rules-of-hooks */
+    const atomsRef = useRef<AnyAtom[]>([])
+    if (storeRef.current == null) {
+      // lazy initialization
+      storeRef.current = createStore(initialValues, (newAtom) => {
+        atomsRef.current.push(newAtom)
+      })
+    }
+    useDebugState(
+      storeRef.current as ReturnType<typeof createStore>,
+      atomsRef.current
+    )
+    /* eslint-enable react-hooks/rules-of-hooks */
+  } else {
+    if (storeRef.current == null) {
+      // lazy initialization
+      storeRef.current = createStore(initialValues)
+    }
   }
 
   const StoreContext = getStoreContext(scope)
-  return createElement(StoreContext.Provider, { value: store }, children)
+  return createElement(
+    StoreContext.Provider,
+    { value: storeRef.current as ReturnType<typeof createStore> },
+    children
+  )
 }
 
 const atomToPrintable = (atom: AnyAtom) => atom.debugLabel || atom.toString()
 
-const stateToPrintable = (state: State) =>
+const stateToPrintable = ([state, atoms]: [State, AnyAtom[]]) =>
   Object.fromEntries(
-    Array.from(state.m.entries()).map(([atom, mounted]) => {
+    atoms.flatMap((atom) => {
+      const mounted = state.m.get(atom)
+      if (!mounted) {
+        return []
+      }
       const dependents = mounted.d
       const atomState = state.a.get(atom) || ({} as AtomState)
       return [
-        atomToPrintable(atom),
-        {
-          value: atomState.e || atomState.p || atomState.w || atomState.v,
-          dependents: Array.from(dependents).map(atomToPrintable),
-        },
+        [
+          atomToPrintable(atom),
+          {
+            value: atomState.e || atomState.p || atomState.w || atomState.v,
+            dependents: Array.from(dependents).map(atomToPrintable),
+          },
+        ],
       ]
     })
   )
 
-const useDebugState = (state: State) => {
-  useDebugValue(state, stateToPrintable)
+const getState = (state: State) => state
+
+const useDebugState = (store: Store, atoms: AnyAtom[]) => {
+  const subscribe = useCallback(
+    (state: State, callback: () => void) => {
+      // FIXME we don't need to resubscribe, we just need to subscribe for new one
+      const unsubs = atoms.map((atom) => subscribeAtom(state, atom, callback))
+      return () => {
+        unsubs.forEach((unsub) => unsub())
+      }
+    },
+    [atoms]
+  )
+  const state = useMutableSource(store[0], getState, subscribe)
+  useDebugValue([state, atoms], stateToPrintable)
 }

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -69,7 +69,7 @@ const stateToPrintable = ([state, atoms]: [State, AnyAtom[]]) =>
     })
   )
 
-const getState = (state: State) => state
+const getState = (state: State) => ({ ...state }) // shallow copy
 
 const useDebugState = (store: Store, atoms: AnyAtom[]) => {
   const subscribe = useCallback(

--- a/src/core/contexts.ts
+++ b/src/core/contexts.ts
@@ -3,6 +3,7 @@ import type { Context } from 'react'
 
 import type { AnyAtom, WritableAtom, Scope } from './types'
 import { createState, writeAtom } from './vanilla'
+import type { NewAtomReceiver } from './vanilla'
 import { createMutableSource } from './useMutableSource'
 
 type MutableSource = ReturnType<typeof createMutableSource>
@@ -16,9 +17,10 @@ export type Store = [
 ]
 
 export const createStore = (
-  initialValues?: Iterable<readonly [AnyAtom, unknown]>
+  initialValues?: Iterable<readonly [AnyAtom, unknown]>,
+  newAtomReceiver?: NewAtomReceiver
 ): Store => {
-  const state = createState(initialValues)
+  const state = createState(initialValues, newAtomReceiver)
   const mutableSource = createMutableSource(state, () => state.v)
   const updateAtom = <Value, Update>(
     atom: WritableAtom<Value, Update>,


### PR DESCRIPTION
follow-up #326

state is really atomic, but this allows an opt-in listener so that we can see all atoms from outside. (for debug purpose only)