### PR TITLE
Fix useUpdateAtom for write-only atoms

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { Provider } from './core/Provider'
 export { atom } from './core/atom'
 export { useAtom } from './core/useAtom'
-export type { Atom, WritableAtom, PrimitiveAtom } from './core/types'
+export type { Atom, WritableAtom, PrimitiveAtom, SetAtom } from './core/types'
 
 /**
  * This is exported for internal use only.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { Provider } from './core/Provider'
 export { atom } from './core/atom'
 export { useAtom } from './core/useAtom'
-export type { Atom, WritableAtom, PrimitiveAtom, SetAtom } from './core/types'
+export type { Atom, WritableAtom, PrimitiveAtom } from './core/types'
 
 /**
  * This is exported for internal use only.

--- a/src/utils/useUpdateAtom.ts
+++ b/src/utils/useUpdateAtom.ts
@@ -1,6 +1,7 @@
 import { useCallback, useContext } from 'react'
 import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
-import type { WritableAtom, SetAtom } from 'jotai'
+import type { WritableAtom } from 'jotai'
+import type { SetAtom } from '../core/types'
 
 export function useUpdateAtom<Value, Update>(
   anAtom: WritableAtom<Value, Update>

--- a/src/utils/useUpdateAtom.ts
+++ b/src/utils/useUpdateAtom.ts
@@ -1,6 +1,6 @@
 import { useCallback, useContext } from 'react'
 import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
-import type { WritableAtom } from 'jotai'
+import type { WritableAtom, SetAtom } from 'jotai'
 
 export function useUpdateAtom<Value, Update>(
   anAtom: WritableAtom<Value, Update>
@@ -11,5 +11,5 @@ export function useUpdateAtom<Value, Update>(
     updateAtom,
     anAtom,
   ])
-  return setAtom
+  return setAtom as SetAtom<Update>
 }

--- a/tests/utils/useUpdateAtom.test.tsx
+++ b/tests/utils/useUpdateAtom.test.tsx
@@ -119,3 +119,48 @@ it('useUpdateAtom with scope', async () => {
     getByText('count: 1')
   })
 })
+
+it('useUpdateAtom with write-only atom', async () => {
+  const countAtom = atom(0)
+  const incrementCountAtom = atom(null, (get, set) =>
+    set(countAtom, get(countAtom) + 1)
+  )
+
+  const Button: React.FC<{ cb: () => void }> = ({ cb, children }) => (
+    <button onClick={cb}>{children}</button>
+  )
+
+  const Displayer: React.FC = () => {
+    const [count] = useAtom(countAtom)
+    return <div>count: {count}</div>
+  }
+
+  const Updater: React.FC = () => {
+    const setCount = useUpdateAtom(incrementCountAtom)
+    return <Button cb={setCount}>increment</Button>
+  }
+
+  const Parent: React.FC = () => {
+    return (
+      <>
+        <Displayer />
+        <Updater />
+      </>
+    )
+  }
+  const { getByText } = render(
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
+  )
+
+  await waitFor(() => {
+    getByText('count: 0')
+  })
+  fireEvent.click(getByText('increment'))
+  await waitFor(() => {
+    getByText('count: 1')
+  })
+})

--- a/tests/utils/useUpdateAtom.test.tsx
+++ b/tests/utils/useUpdateAtom.test.tsx
@@ -120,7 +120,7 @@ it('useUpdateAtom with scope', async () => {
   })
 })
 
-it('useUpdateAtom with write-only atom', async () => {
+it('useUpdateAtom with write without an argument', async () => {
   const countAtom = atom(0)
   const incrementCountAtom = atom(null, (get, set) =>
     set(countAtom, get(countAtom) + 1)


### PR DESCRIPTION
This fixes `useUpdateAtom` for write without argument.

I'm not sure about the export of `SetAtom`, but I couldn't see any other way.