### PR TITLE
Refactor useResetAtom with secret internals

### DIFF
--- a/src/utils/useResetAtom.ts
+++ b/src/utils/useResetAtom.ts
@@ -6,8 +6,7 @@ import { RESET } from './atomWithReset'
 export function useResetAtom<Value>(anAtom: WritableAtom<Value, typeof RESET>) {
   const StoreContext = getStoreContext(anAtom.scope)
   const [, updateAtom] = useContext(StoreContext)
-  // FIXME Remove _update before v1, stays to not introduce breaking change
-  const setAtom = useCallback((_update) => updateAtom(anAtom, RESET), [
+  const setAtom = useCallback(() => updateAtom(anAtom, RESET), [
     updateAtom,
     anAtom,
   ])

--- a/src/utils/useResetAtom.ts
+++ b/src/utils/useResetAtom.ts
@@ -1,12 +1,15 @@
-import { useMemo } from 'react'
-import { atom, useAtom, WritableAtom } from 'jotai'
+import { useCallback, useContext } from 'react'
+import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
+import type { WritableAtom } from 'jotai'
 import { RESET } from './atomWithReset'
 
 export function useResetAtom<Value>(anAtom: WritableAtom<Value, typeof RESET>) {
-  const writeOnlyAtom = useMemo(
-    () => atom(null, (_get, set, _update) => set(anAtom, RESET)),
-    [anAtom]
-  )
-  writeOnlyAtom.scope = anAtom.scope
-  return useAtom(writeOnlyAtom)[1]
+  const StoreContext = getStoreContext(anAtom.scope)
+  const [, updateAtom] = useContext(StoreContext)
+  // FIXME Remove _update before v1, stays to not introduce breaking change
+  const setAtom = useCallback((_update) => updateAtom(anAtom, RESET), [
+    updateAtom,
+    anAtom,
+  ])
+  return setAtom
 }


### PR DESCRIPTION
This refactors `useResetAtom` with almost identical implementation as `useUpdateAtom` - This saves an atom creation.

As commented, `_update` stays for compatibility changes, but I propose removing it before v1.