### PR TITLE
Refactor uMS to avoid extra re-renders

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.module.js": {
-    "bundled": 20600,
-    "minified": 8542,
-    "gzipped": 2886,
+    "bundled": 20922,
+    "minified": 8600,
+    "gzipped": 2901,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -98,9 +98,9 @@
     }
   },
   "index.js": {
-    "bundled": 24045,
-    "minified": 10330,
-    "gzipped": 3467
+    "bundled": 24367,
+    "minified": 10388,
+    "gzipped": 3483
   },
   "utils.js": {
     "bundled": 11093,

--- a/src/core/useMutableSource.ts
+++ b/src/core/useMutableSource.ts
@@ -38,11 +38,22 @@ export const useMutableSource = (
   if (
     state[0] !== source ||
     state[1] !== getSnapshot ||
-    state[2] !== subscribe ||
-    (currentVersion !== state[3] && currentVersion !== lastVersion.current)
+    state[2] !== subscribe
   ) {
     currentSnapshot = getSnapshot(source[TARGET])
-    if (currentSnapshot !== state[4]) {
+    setState([
+      /* [0] */ source,
+      /* [1] */ getSnapshot,
+      /* [2] */ subscribe,
+      /* [3] */ currentVersion,
+      /* [4] */ currentSnapshot,
+    ])
+  } else if (
+    currentVersion !== state[3] &&
+    currentVersion !== lastVersion.current
+  ) {
+    currentSnapshot = getSnapshot(source[TARGET])
+    if (!Object.is(currentSnapshot, state[4])) {
       setState([
         /* [0] */ source,
         /* [1] */ getSnapshot,
@@ -70,7 +81,7 @@ export const useMutableSource = (
           ) {
             return prev
           }
-          if (prev[4] === nextSnapshot) {
+          if (Object.is(prev[4], nextSnapshot)) {
             return prev
           }
           return [

--- a/src/core/useMutableSource.ts
+++ b/src/core/useMutableSource.ts
@@ -42,13 +42,15 @@ export const useMutableSource = (
     (currentVersion !== state[3] && currentVersion !== lastVersion.current)
   ) {
     currentSnapshot = getSnapshot(source[TARGET])
-    setState([
-      /* [0] */ source,
-      /* [1] */ getSnapshot,
-      /* [2] */ subscribe,
-      /* [3] */ currentVersion,
-      /* [4] */ currentSnapshot,
-    ])
+    if (currentSnapshot !== state[4]) {
+      setState([
+        /* [0] */ source,
+        /* [1] */ getSnapshot,
+        /* [2] */ subscribe,
+        /* [3] */ currentVersion,
+        /* [4] */ currentSnapshot,
+      ])
+    }
   }
   useEffect(() => {
     let didUnsubscribe = false

--- a/tests/optimization.test.tsx
+++ b/tests/optimization.test.tsx
@@ -61,42 +61,6 @@ it('only relevant render function called (#156)', async () => {
   })
 })
 
-it('useless re-renders with static atoms', async () => {
-  // check out https://codesandbox.io/s/setatom-bail-failure-forked-m82r5?file=/src/App.tsx to see the expected re-renders
-  const countAtom = atom(0)
-  const unrelatedAtom = atom(0)
-
-  const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(countAtom)
-    useAtom(unrelatedAtom)
-    const renderCount = useRef(0)
-    ++renderCount.current
-
-    return (
-      <>
-        <div>
-          <p>
-            count: {count} ({renderCount.current})
-          </p>
-        </div>
-        <button onClick={() => setCount((c) => c + 1)}>button</button>
-      </>
-    )
-  }
-
-  const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
-  )
-
-  await findByText('count: 0 (1)')
-  fireEvent.click(getByText('button'))
-  await findByText('count: 1 (2)')
-  fireEvent.click(getByText('button'))
-  await findByText('count: 2 (3)')
-})
-
 it('only render once using atoms with write-only atom', async () => {
   const count1Atom = atom(0)
   const count2Atom = atom(0)
@@ -136,4 +100,40 @@ it('only render once using atoms with write-only atom', async () => {
 
   fireEvent.click(getByText('button'))
   await findByText('count1: 2, count2: 2 (3)')
+})
+
+it('useless re-renders with static atoms (#355)', async () => {
+  // check out https://codesandbox.io/s/m82r5 to see the expected re-renders
+  const countAtom = atom(0)
+  const unrelatedAtom = atom(0)
+
+  const Counter: React.FC = () => {
+    const [count, setCount] = useAtom(countAtom)
+    useAtom(unrelatedAtom)
+    const renderCount = useRef(0)
+    ++renderCount.current
+
+    return (
+      <>
+        <div>
+          <p>
+            count: {count} ({renderCount.current})
+          </p>
+        </div>
+        <button onClick={() => setCount((c) => c + 1)}>button</button>
+      </>
+    )
+  }
+
+  const { getByText, findByText } = render(
+    <Provider>
+      <Counter />
+    </Provider>
+  )
+
+  await findByText('count: 0 (1)')
+  fireEvent.click(getByText('button'))
+  await findByText('count: 1 (2)')
+  fireEvent.click(getByText('button'))
+  await findByText('count: 2 (3)')
 })

--- a/tests/optimization.test.tsx
+++ b/tests/optimization.test.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from '../src/index'
 
-it('useless re-renders with static atoms', async () => {
+it('only relevant render function called (#156)', async () => {
   // check out https://codesandbox.io/s/setatom-bail-failure-forked-m82r5?file=/src/App.tsx to see the expected re-renders
   const countAtom = atom(0)
   const unrelatedAtom = atom(0)

--- a/tests/optimization.test.tsx
+++ b/tests/optimization.test.tsx
@@ -84,7 +84,11 @@ it('useless re-renders with static atoms', async () => {
     )
   }
 
-  const { getByText, findByText } = render(<Counter />)
+  const { getByText, findByText } = render(
+    <Provider>
+      <Counter />
+    </Provider>
+  )
 
   await findByText('count: 0 (1)')
   fireEvent.click(getByText('button'))

--- a/tests/optimization.test.tsx
+++ b/tests/optimization.test.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from '../src/index'
 
-it('only relevant render function called (#156)', async () => {
+it('useless re-renders with static atoms', async () => {
   // check out https://codesandbox.io/s/setatom-bail-failure-forked-m82r5?file=/src/App.tsx to see the expected re-renders
   const countAtom = atom(0)
   const unrelatedAtom = atom(0)
@@ -10,14 +10,15 @@ it('only relevant render function called (#156)', async () => {
   const Counter: React.FC = () => {
     const [count, setCount] = useAtom(countAtom)
     useAtom(unrelatedAtom)
-    const commits = useRef(0)
-    ++commits.current
+    const renderCount = useRef(0)
+    ++renderCount.current
 
     return (
       <>
         <div>
-          <p>commits: {commits.current}</p>
-          <p>count: {count}</p>
+          <p>
+            count: {count} ({renderCount.current})
+          </p>
         </div>
         <button onClick={() => setCount((c) => c + 1)}>button</button>
       </>
@@ -26,18 +27,9 @@ it('only relevant render function called (#156)', async () => {
 
   const { getByText, findByText } = render(<Counter />)
 
-  await waitFor(() => {
-    getByText('count: 0')
-    getByText('commits: 1')
-  })
+  await findByText('count: 0 (1)')
   fireEvent.click(getByText('button'))
-  await waitFor(() => {
-    getByText('count: 1')
-    getByText('commits: 2')
-  })
+  await findByText('count: 1 (2)')
   fireEvent.click(getByText('button'))
-  await waitFor(() => {
-    getByText('count: 2')
-    getByText('commits: 3')
-  })
+  await findByText('count: 2 (3)')
 })

--- a/tests/optimization.test.tsx
+++ b/tests/optimization.test.tsx
@@ -1,0 +1,43 @@
+import React, { useRef } from 'react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { atom, useAtom } from '../src/index'
+
+it('useless re-renders with static atoms', async () => {
+  // check out https://codesandbox.io/s/setatom-bail-failure-forked-m82r5?file=/src/App.tsx to see the expected re-renders
+  const countAtom = atom(0)
+  const unrelatedAtom = atom(0)
+
+  const Counter: React.FC = () => {
+    const [count, setCount] = useAtom(countAtom)
+    useAtom(unrelatedAtom)
+    const commits = useRef(0)
+    ++commits.current
+
+    return (
+      <>
+        <div>
+          <p>commits: {commits.current}</p>
+          <p>count: {count}</p>
+        </div>
+        <button onClick={() => setCount((c) => c + 1)}>button</button>
+      </>
+    )
+  }
+
+  const { getByText, findByText } = render(<Counter />)
+
+  await waitFor(() => {
+    getByText('count: 0')
+    getByText('commits: 1')
+  })
+  fireEvent.click(getByText('button'))
+  await waitFor(() => {
+    getByText('count: 1')
+    getByText('commits: 2')
+  })
+  fireEvent.click(getByText('button'))
+  await waitFor(() => {
+    getByText('count: 2')
+    getByText('commits: 3')
+  })
+})


### PR DESCRIPTION
This PR fixes #355. Actually, when we call the write function on an atom, it will change it correctly. Still, as we use uMS emulation, for now, it causes an unexpected extra re-render for some atoms that hold the previous value, and they don't change, but uMS cause a re-render for that. 