### PR TITLE
feat: weak cache to avoid infinite loop without useMemo

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "index.module.js": {
-    "bundled": 19453,
+    "bundled": 19949,
     "minified": 8342,
     "gzipped": 2804,
     "treeshaked": {
@@ -14,16 +14,16 @@
     }
   },
   "utils.module.js": {
-    "bundled": 6903,
-    "minified": 3015,
-    "gzipped": 1276,
+    "bundled": 7958,
+    "minified": 3528,
+    "gzipped": 1427,
     "treeshaked": {
       "rollup": {
         "code": 28,
         "import_statements": 28
       },
       "webpack": {
-        "code": 1067
+        "code": 1091
       }
     }
   },
@@ -42,30 +42,30 @@
     }
   },
   "immer.module.js": {
-    "bundled": 868,
-    "minified": 426,
-    "gzipped": 235,
+    "bundled": 1626,
+    "minified": 797,
+    "gzipped": 388,
     "treeshaked": {
       "rollup": {
         "code": 42,
         "import_statements": 42
       },
       "webpack": {
-        "code": 1092
+        "code": 1104
       }
     }
   },
   "optics.module.js": {
-    "bundled": 912,
-    "minified": 458,
-    "gzipped": 271,
+    "bundled": 1683,
+    "minified": 825,
+    "gzipped": 429,
     "treeshaked": {
       "rollup": {
         "code": 32,
         "import_statements": 32
       },
       "webpack": {
-        "code": 1049
+        "code": 1061
       }
     }
   },
@@ -98,14 +98,14 @@
     }
   },
   "index.js": {
-    "bundled": 22896,
+    "bundled": 23392,
     "minified": 10132,
     "gzipped": 3391
   },
   "utils.js": {
-    "bundled": 9976,
-    "minified": 4915,
-    "gzipped": 1888
+    "bundled": 11093,
+    "minified": 5420,
+    "gzipped": 2040
   },
   "devtools.js": {
     "bundled": 2394,
@@ -113,14 +113,14 @@
     "gzipped": 651
   },
   "immer.js": {
-    "bundled": 1239,
-    "minified": 697,
-    "gzipped": 316
+    "bundled": 2065,
+    "minified": 1062,
+    "gzipped": 467
   },
   "optics.js": {
-    "bundled": 1028,
-    "minified": 527,
-    "gzipped": 317
+    "bundled": 1867,
+    "minified": 890,
+    "gzipped": 468
   },
   "query.js": {
     "bundled": 3423,

--- a/src/immer/withImmer.ts
+++ b/src/immer/withImmer.ts
@@ -2,6 +2,10 @@
 import { produce, Draft } from 'immer'
 import { PrimitiveAtom, WritableAtom, atom } from 'jotai'
 
+import { getWeakCacheItem, setWeakCacheItem } from '../utils/weakCache'
+
+const withImmerCache = new WeakMap()
+
 export function withImmer<Value>(
   anAtom: PrimitiveAtom<Value>
 ): WritableAtom<Value, (draft: Draft<Value>) => void>
@@ -11,6 +15,11 @@ export function withImmer<Value>(
 ): WritableAtom<Value, (draft: Draft<Value>) => void>
 
 export function withImmer<Value>(anAtom: WritableAtom<Value, Value>) {
+  const deps: object[] = [anAtom]
+  const cachedAtom = getWeakCacheItem(withImmerCache, deps)
+  if (cachedAtom) {
+    return cachedAtom
+  }
   const derivedAtom = atom(
     (get) => get(anAtom),
     (get, set, fn: (draft: Draft<Value>) => void) =>
@@ -20,5 +29,6 @@ export function withImmer<Value>(anAtom: WritableAtom<Value, Value>) {
       )
   )
   derivedAtom.scope = anAtom.scope
+  setWeakCacheItem(withImmerCache, deps, derivedAtom)
   return derivedAtom
 }

--- a/src/optics/focusAtom.ts
+++ b/src/optics/focusAtom.ts
@@ -1,10 +1,9 @@
 import { atom } from 'jotai'
 import * as O from 'optics-ts'
-
-import { getWeakCacheItem, setWeakCacheItem } from '../utils/weakCache'
+import { getWeakCacheItem, setWeakCacheItem, Cache } from '../utils/weakCache'
 import type { WritableAtom, SetStateAction, PrimitiveAtom } from '../core/types'
 
-const focusAtomCache = new WeakMap()
+const focusAtomCache: Cache<WritableAtom<any, any>> = new WeakMap()
 
 const isFunction = <T>(x: T): x is T & Function => typeof x === 'function'
 
@@ -39,13 +38,13 @@ export function focusAtom<S, A>(
   | WritableAtom<A | undefined, SetStateAction<A>>
   | WritableAtom<Array<A>, SetStateAction<A>>
   | PrimitiveAtom<S> {
-  const deps: object[] = [baseAtom, callback]
-  const cachedAtom: any = getWeakCacheItem(focusAtomCache, deps)
+  const deps = [baseAtom, callback] as const
+  const cachedAtom = getWeakCacheItem(focusAtomCache, deps)
   if (cachedAtom) {
     return cachedAtom
   }
   const focus = callback(O.optic<S>())
-  const derivedAtom: any = atom<A, SetStateAction<A>>(
+  const derivedAtom = atom<A, SetStateAction<A>>(
     (get) => {
       const newValue = getValueUsingOptic(focus, get(baseAtom))
       return newValue as any

--- a/src/optics/focusAtom.ts
+++ b/src/optics/focusAtom.ts
@@ -1,9 +1,13 @@
 import { atom } from 'jotai'
 import * as O from 'optics-ts'
-import { getWeakCacheItem, setWeakCacheItem, Cache } from '../utils/weakCache'
+import {
+  getWeakCacheItem,
+  setWeakCacheItem,
+  WeakCache,
+} from '../utils/weakCache'
 import type { WritableAtom, SetStateAction, PrimitiveAtom } from '../core/types'
 
-const focusAtomCache: Cache<WritableAtom<any, any>> = new WeakMap()
+const focusAtomCache: WeakCache<WritableAtom<any, any>> = new WeakMap()
 
 const isFunction = <T>(x: T): x is T & Function => typeof x === 'function'
 

--- a/src/utils/selectAtom.ts
+++ b/src/utils/selectAtom.ts
@@ -1,10 +1,19 @@
 import { atom, Atom } from 'jotai'
 
+import { getWeakCacheItem, setWeakCacheItem } from './weakCache'
+
+const selectAtomCache = new WeakMap()
+
 export function selectAtom<Value, Slice>(
   anAtom: Atom<Value>,
   selector: (v: Value) => Slice,
   equalityFn: (a: Slice, b: Slice) => boolean = Object.is
 ): Atom<Slice> {
+  const deps: object[] = [anAtom, selector, equalityFn]
+  const cachedAtom = getWeakCacheItem(selectAtomCache, deps)
+  if (cachedAtom) {
+    return cachedAtom as Atom<Slice>
+  }
   let initialized = false
   let prevSlice: Slice
   const derivedAtom = atom((get) => {
@@ -17,5 +26,6 @@ export function selectAtom<Value, Slice>(
     return slice
   })
   derivedAtom.scope = anAtom.scope
+  setWeakCacheItem(selectAtomCache, deps, derivedAtom)
   return derivedAtom
 }

--- a/src/utils/weakCache.ts
+++ b/src/utils/weakCache.ts
@@ -1,8 +1,8 @@
-type Cache<T> = WeakMap<object, [Cache<T>] | [Cache<T>, T | undefined]>
+export type Cache<T> = WeakMap<object, [Cache<T>] | [Cache<T>, T | undefined]>
 
 export const getWeakCacheItem = <T>(
   cache: Cache<T>,
-  deps: object[]
+  deps: readonly object[]
 ): T | undefined => {
   const [dep, ...rest] = deps
   const entry = cache.get(dep)
@@ -18,7 +18,7 @@ export const getWeakCacheItem = <T>(
 
 export const setWeakCacheItem = <T>(
   cache: Cache<T>,
-  deps: object[],
+  deps: readonly object[],
   item: T
 ): void => {
   const [dep, ...rest] = deps

--- a/src/utils/weakCache.ts
+++ b/src/utils/weakCache.ts
@@ -1,0 +1,35 @@
+type Cache<T> = WeakMap<object, [Cache<T>] | [Cache<T>, T | undefined]>
+
+export const getWeakCacheItem = <T>(
+  cache: Cache<T>,
+  deps: object[]
+): T | undefined => {
+  const [dep, ...rest] = deps
+  const entry = cache.get(dep)
+  if (!entry) {
+    return
+  }
+  const [nextCache, derivedAtom] = entry
+  if (!rest.length) {
+    return derivedAtom
+  }
+  return getWeakCacheItem(nextCache, rest)
+}
+
+export const setWeakCacheItem = <T>(
+  cache: Cache<T>,
+  deps: object[],
+  item: T
+): void => {
+  const [dep, ...rest] = deps
+  let entry = cache.get(dep)
+  if (!entry) {
+    entry = [new WeakMap()]
+    cache.set(dep, entry)
+  }
+  if (!rest.length) {
+    entry[1] = item
+    return
+  }
+  setWeakCacheItem(entry[0], rest, item)
+}

--- a/src/utils/weakCache.ts
+++ b/src/utils/weakCache.ts
@@ -1,7 +1,7 @@
-export type Cache<T> = WeakMap<object, [Cache<T>] | [Cache<T>, T | undefined]>
+export type WeakCache<T> = WeakMap<object, [WeakCache<T>] | [WeakCache<T>, T]>
 
 export const getWeakCacheItem = <T>(
-  cache: Cache<T>,
+  cache: WeakCache<T>,
   deps: readonly object[]
 ): T | undefined => {
   const [dep, ...rest] = deps
@@ -9,15 +9,14 @@ export const getWeakCacheItem = <T>(
   if (!entry) {
     return
   }
-  const [nextCache, derivedAtom] = entry
   if (!rest.length) {
-    return derivedAtom
+    return entry[1]
   }
-  return getWeakCacheItem(nextCache, rest)
+  return getWeakCacheItem(entry[0], rest)
 }
 
 export const setWeakCacheItem = <T>(
-  cache: Cache<T>,
+  cache: WeakCache<T>,
   deps: readonly object[],
   item: T
 ): void => {

--- a/tests/immer/withImmer.test.tsx
+++ b/tests/immer/withImmer.test.tsx
@@ -7,10 +7,9 @@ const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
 
 it('withImmer derived atom with useAtom', async () => {
   const regularCountAtom = atom(0)
-  const countAtom = withImmer(regularCountAtom)
 
   const Parent: React.FC = () => {
-    const [count, setCount] = useAtom(countAtom)
+    const [count, setCount] = useAtom(withImmer(regularCountAtom))
     return (
       <>
         <div>count: {count}</div>
@@ -44,11 +43,9 @@ it('withImmer derived atom with useAtom + scope', async () => {
   const regularCountAtom = atom(0)
   regularCountAtom.scope = scope
 
-  const countAtom = withImmer(regularCountAtom)
-
   const Parent: React.FC = () => {
     const [regularCount] = useAtom(regularCountAtom)
-    const [count, setCount] = useAtom(countAtom)
+    const [count, setCount] = useAtom(withImmer(regularCountAtom))
     return (
       <>
         <div>

--- a/tests/optics/focus-lens.test.tsx
+++ b/tests/optics/focus-lens.test.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment, Suspense } from 'react'
 import { Provider as ProviderOrig, atom, useAtom } from 'jotai'
+import * as O from 'optics-ts'
 import * as rtl from '@testing-library/react'
 import { focusAtom } from '../../src/optics/focusAtom'
 import type { SetStateAction } from '../../src/core/types'
@@ -10,10 +11,10 @@ const succ = (input: number) => input + 1
 
 it('basic derivation using focus works', async () => {
   const bigAtom = atom({ a: 0 })
-  const aAtom = focusAtom(bigAtom, (optic) => optic.prop('a'))
+  const propA = (optic: O.OpticFor<{ a: number }>) => optic.prop('a')
 
   const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(aAtom)
+    const [count, setCount] = useAtom(focusAtom(bigAtom, propA))
     const [bigAtomValue] = useAtom(bigAtom)
     return (
       <>
@@ -49,10 +50,10 @@ it('basic derivation using focus works', async () => {
 
 it('focus on an atom works', async () => {
   const bigAtom = atom({ a: 0 })
-  const aAtom = focusAtom(bigAtom, (optic) => optic.prop('a'))
+  const propA = (optic: O.OpticFor<{ a: number }>) => optic.prop('a')
 
   const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(aAtom)
+    const [count, setCount] = useAtom(focusAtom(bigAtom, propA))
     const [bigAtomValue] = useAtom(bigAtom)
     return (
       <>
@@ -136,10 +137,11 @@ it('focus on async atom works', async () => {
       set(baseAtom, param)
     }
   )
-  const focusedAtom = focusAtom(asyncAtom, (optic) => optic.prop('count'))
+  const propCount = (optic: O.OpticFor<{ count: number }>) =>
+    optic.prop('count')
 
   const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(focusedAtom)
+    const [count, setCount] = useAtom(focusAtom(asyncAtom, propCount))
     const [asyncValue, setAsync] = useAtom(asyncAtom)
     const [baseValue, setBase] = useAtom(baseAtom)
     return (
@@ -190,10 +192,10 @@ it('basic derivation using focus with scope works', async () => {
   const scope = Symbol()
   const bigAtom = atom({ a: 0 })
   bigAtom.scope = scope
-  const aAtom = focusAtom(bigAtom, (optic) => optic.prop('a'))
+  const propA = (optic: O.OpticFor<{ a: number }>) => optic.prop('a')
 
   const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(aAtom)
+    const [count, setCount] = useAtom(focusAtom(bigAtom, propA))
     const [bigAtomValue] = useAtom(bigAtom)
     return (
       <>

--- a/tests/optics/focus-lens.test.tsx
+++ b/tests/optics/focus-lens.test.tsx
@@ -11,10 +11,10 @@ const succ = (input: number) => input + 1
 
 it('basic derivation using focus works', async () => {
   const bigAtom = atom({ a: 0 })
-  const propA = (optic: O.OpticFor<{ a: number }>) => optic.prop('a')
+  const focusFunction = (optic: O.OpticFor<{ a: number }>) => optic.prop('a')
 
   const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(focusAtom(bigAtom, propA))
+    const [count, setCount] = useAtom(focusAtom(bigAtom, focusFunction))
     const [bigAtomValue] = useAtom(bigAtom)
     return (
       <>
@@ -50,10 +50,10 @@ it('basic derivation using focus works', async () => {
 
 it('focus on an atom works', async () => {
   const bigAtom = atom({ a: 0 })
-  const propA = (optic: O.OpticFor<{ a: number }>) => optic.prop('a')
+  const focusFunction = (optic: O.OpticFor<{ a: number }>) => optic.prop('a')
 
   const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(focusAtom(bigAtom, propA))
+    const [count, setCount] = useAtom(focusAtom(bigAtom, focusFunction))
     const [bigAtomValue] = useAtom(bigAtom)
     return (
       <>
@@ -137,11 +137,11 @@ it('focus on async atom works', async () => {
       set(baseAtom, param)
     }
   )
-  const propCount = (optic: O.OpticFor<{ count: number }>) =>
+  const focusFunction = (optic: O.OpticFor<{ count: number }>) =>
     optic.prop('count')
 
   const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(focusAtom(asyncAtom, propCount))
+    const [count, setCount] = useAtom(focusAtom(asyncAtom, focusFunction))
     const [asyncValue, setAsync] = useAtom(asyncAtom)
     const [baseValue, setBase] = useAtom(baseAtom)
     return (
@@ -192,10 +192,10 @@ it('basic derivation using focus with scope works', async () => {
   const scope = Symbol()
   const bigAtom = atom({ a: 0 })
   bigAtom.scope = scope
-  const propA = (optic: O.OpticFor<{ a: number }>) => optic.prop('a')
+  const focusFunction = (optic: O.OpticFor<{ a: number }>) => optic.prop('a')
 
   const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(focusAtom(bigAtom, propA))
+    const [count, setCount] = useAtom(focusAtom(bigAtom, focusFunction))
     const [bigAtomValue] = useAtom(bigAtom)
     return (
       <>

--- a/tests/optics/focus-prism.test.tsx
+++ b/tests/optics/focus-prism.test.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react'
 import { Provider as ProviderOrig, atom, useAtom } from 'jotai'
+import * as O from 'optics-ts'
 import * as rtl from '@testing-library/react'
 import { focusAtom } from '../../src/optics'
 
@@ -7,10 +8,11 @@ const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
 
 it('updates prisms', async () => {
   const bigAtom = atom<{ a?: number }>({ a: 5 })
-  const aAtom = focusAtom(bigAtom, (optic) => optic.prop('a').optional())
+  const propAOptional = (optic: O.OpticFor<{ a?: number }>) =>
+    optic.prop('a').optional()
 
   const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(aAtom)
+    const [count, setCount] = useAtom(focusAtom(bigAtom, propAOptional))
     const [bigAtomValue] = useAtom(bigAtom)
     return (
       <>
@@ -37,10 +39,11 @@ it('updates prisms', async () => {
 
 it('atoms that focus on no values are not updated', async () => {
   const bigAtom = atom<{ a?: number }>({})
-  const aAtom = focusAtom(bigAtom, (optic) => optic.prop('a').optional())
+  const propAOptional = (optic: O.OpticFor<{ a?: number }>) =>
+    optic.prop('a').optional()
 
   const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(aAtom)
+    const [count, setCount] = useAtom(focusAtom(bigAtom, propAOptional))
     const [bigAtomValue] = useAtom(bigAtom)
     return (
       <>

--- a/tests/optics/focus-prism.test.tsx
+++ b/tests/optics/focus-prism.test.tsx
@@ -8,11 +8,11 @@ const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
 
 it('updates prisms', async () => {
   const bigAtom = atom<{ a?: number }>({ a: 5 })
-  const propAOptional = (optic: O.OpticFor<{ a?: number }>) =>
+  const focusFunction = (optic: O.OpticFor<{ a?: number }>) =>
     optic.prop('a').optional()
 
   const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(focusAtom(bigAtom, propAOptional))
+    const [count, setCount] = useAtom(focusAtom(bigAtom, focusFunction))
     const [bigAtomValue] = useAtom(bigAtom)
     return (
       <>
@@ -39,11 +39,11 @@ it('updates prisms', async () => {
 
 it('atoms that focus on no values are not updated', async () => {
   const bigAtom = atom<{ a?: number }>({})
-  const propAOptional = (optic: O.OpticFor<{ a?: number }>) =>
+  const focusFunction = (optic: O.OpticFor<{ a?: number }>) =>
     optic.prop('a').optional()
 
   const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(focusAtom(bigAtom, propAOptional))
+    const [count, setCount] = useAtom(focusAtom(bigAtom, focusFunction))
     const [bigAtomValue] = useAtom(bigAtom)
     return (
       <>

--- a/tests/optics/focus-traversal.test.tsx
+++ b/tests/optics/focus-traversal.test.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react'
 import { Provider as ProviderOrig, atom, useAtom } from 'jotai'
+import * as O from 'optics-ts'
 import * as rtl from '@testing-library/react'
 import { focusAtom } from '../../src/optics/focusAtom'
 
@@ -7,12 +8,11 @@ const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
 
 it('updates traversals', async () => {
   const bigAtom = atom<{ a?: number }[]>([{ a: 5 }, {}, { a: 6 }])
-  const aAtom = focusAtom(bigAtom, (optic) =>
+  const elemsPropAOptional = (optic: O.OpticFor<{ a?: number }[]>) =>
     optic.elems().prop('a').optional()
-  )
 
   const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(aAtom)
+    const [count, setCount] = useAtom(focusAtom(bigAtom, elemsPropAOptional))
     const [bigAtomValue] = useAtom(bigAtom)
     return (
       <>

--- a/tests/optics/focus-traversal.test.tsx
+++ b/tests/optics/focus-traversal.test.tsx
@@ -8,11 +8,11 @@ const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
 
 it('updates traversals', async () => {
   const bigAtom = atom<{ a?: number }[]>([{ a: 5 }, {}, { a: 6 }])
-  const elemsPropAOptional = (optic: O.OpticFor<{ a?: number }[]>) =>
+  const focusFunction = (optic: O.OpticFor<{ a?: number }[]>) =>
     optic.elems().prop('a').optional()
 
   const Counter: React.FC = () => {
-    const [count, setCount] = useAtom(focusAtom(bigAtom, elemsPropAOptional))
+    const [count, setCount] = useAtom(focusAtom(bigAtom, focusFunction))
     const [bigAtomValue] = useAtom(bigAtom)
     return (
       <>

--- a/tests/utils/selectAtom.test.tsx
+++ b/tests/utils/selectAtom.test.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useMemo, useRef } from 'react'
+import React, { Fragment, useEffect, useRef } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { Provider as ProviderOrig, atom } from '../../src/index'
 import { selectAtom, useAtomValue, useUpdateAtom } from '../../src/utils'
@@ -147,10 +147,9 @@ it('useSelector with scope', async () => {
     )
   }
 
+  const selectA = (value: { a: number }) => value.a
   const Selector = () => {
-    const a = useAtomValue(
-      useMemo(() => selectAtom(bigAtom, (value) => value.a), [])
-    )
+    const a = useAtomValue(selectAtom(bigAtom, selectA))
     return (
       <>
         <div>a: {a}</div>

--- a/tests/utils/splitAtom.test.tsx
+++ b/tests/utils/splitAtom.test.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { atom, Provider, useAtom, Atom, PrimitiveAtom } from 'jotai'
 import { render, fireEvent, waitFor } from '@testing-library/react'
 
@@ -21,9 +21,7 @@ it('no unneccesary updates when updating atoms', async () => {
   ])
 
   const TaskList: React.FC<{ listAtom: typeof todosAtom }> = ({ listAtom }) => {
-    const [atoms, remove] = useAtom(
-      useMemo(() => splitAtom(listAtom), [listAtom])
-    )
+    const [atoms, remove] = useAtom(splitAtom(listAtom))
     return (
       <>
         TaskListUpdates: {useCommitCount()}
@@ -111,9 +109,7 @@ it('removing atoms', async () => {
   ])
 
   const TaskList: React.FC<{ listAtom: typeof todosAtom }> = ({ listAtom }) => {
-    const [atoms, remove] = useAtom(
-      useMemo(() => splitAtom(listAtom), [listAtom])
-    )
+    const [atoms, remove] = useAtom(splitAtom(listAtom))
     return (
       <>
         {atoms.map((anAtom, index) => (
@@ -195,7 +191,7 @@ it('read-only array atom', async () => {
   ])
 
   const TaskList: React.FC<{ listAtom: typeof todosAtom }> = ({ listAtom }) => {
-    const [atoms] = useAtom(useMemo(() => splitAtom(listAtom), [listAtom]))
+    const [atoms] = useAtom(splitAtom(listAtom))
     return (
       <>
         {atoms.map((anAtom, index) => (


### PR DESCRIPTION
While discussing with @Thisen, I noticed that we can create useMemo alternative for derived atoms. @merisbahti said he wanted to use `splitAtom` in render without useMemo. So, here it is.

(I hope I didn't miss something fundamental...