### PR TITLE
[Types] Add Read & Write types, reduce duplicate type declaration

### DIFF
--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -1,6 +1,6 @@
 import {
-  Getter,
-  Setter,
+  Read,
+  Write,
   Atom,
   WritableAtom,
   WithInitialValue,
@@ -13,22 +13,20 @@ let keyCount = 0 // global key count for all atoms
 
 // writable derived atom
 export function atom<Value, Update>(
-  read: (get: Getter) => Value | Promise<Value>,
-  write: (get: Getter, set: Setter, update: Update) => void | Promise<void>
+  read: Read<Value>,
+  write: Write<Update>
 ): WritableAtom<Value, Update>
 
 // write-only derived atom
 export function atom<Value, Update>(
   read: Value,
-  write: (get: Getter, set: Setter, update: Update) => void | Promise<void>
+  write: Write<Update>
 ): Value extends AnyFunction
   ? never
   : WritableAtom<Value, Update> & WithInitialValue<Value>
 
 // read-only derived atom
-export function atom<Value>(
-  read: (get: Getter) => Value | Promise<Value>
-): Atom<Value>
+export function atom<Value>(read: Read<Value>): Atom<Value>
 
 // invalid read-only derived atom
 export function atom(read: AnyFunction): never
@@ -39,19 +37,19 @@ export function atom<Value>(
 ): PrimitiveAtom<Value> & WithInitialValue<Value>
 
 export function atom<Value, Update>(
-  read: Value | ((get: Getter) => Value | Promise<Value>),
-  write?: (get: Getter, set: Setter, update: Update) => void | Promise<void>
+  read: Value | Read<Value>,
+  write?: Write<Update>
 ) {
   const key = `atom${++keyCount}`
   const config = {
     toString: () => key,
   } as WritableAtom<Value, Update> & { init?: Value }
   if (typeof read === 'function') {
-    config.read = read as (get: Getter) => Value | Promise<Value>
+    config.read = read as Read<Value>
   } else {
     config.init = read
-    config.read = (get: Getter) => get(config)
-    config.write = (get: Getter, set: Setter, update: Update) => {
+    config.read = (get) => get(config)
+    config.write = (get, set, update) => {
       set(config, typeof update === 'function' ? update(get(config)) : update)
     }
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,11 +1,17 @@
 export type SetStateAction<Value> = Value | ((prev: Value) => Value)
 
 export type Getter = <Value>(atom: Atom<Value>) => Value
+export type Read<Value> = (get: Getter) => Value | Promise<Value>
 
 export type Setter = <Value, Update>(
   atom: WritableAtom<Value, Update>,
   update: Update
 ) => void
+export type Write<Update> = (
+  get: Getter,
+  set: Setter,
+  update: Update
+) => void | Promise<void>
 
 export type Scope = symbol | string | number
 
@@ -22,11 +28,11 @@ export type Atom<Value> = {
   toString: () => string
   debugLabel?: string
   scope?: Scope
-  read: (get: Getter) => Value | Promise<Value>
+  read: Read<Value>
 }
 
 export type WritableAtom<Value, Update> = Atom<Value> & {
-  write: (get: Getter, set: Setter, update: Update) => void | Promise<void>
+  write: Write<Update>
   onMount?: OnMount<Update>
 }
 


### PR DESCRIPTION
We can avoid a little bit of repetition by declaring Read and Write types.