### PR TITLE
feat: add equality fn to atomWithQuery

### DIFF
--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -30,7 +30,8 @@ export function atomWithQuery<
     | AtomQueryOptions<TQueryFnData, TError, TData, TQueryData>
     | ((
         get: Getter
-      ) => AtomQueryOptions<TQueryFnData, TError, TData, TQueryData>)
+      ) => AtomQueryOptions<TQueryFnData, TError, TData, TQueryData>),
+  equalityFn: (a: TData, b: TData) => boolean = Object.is
 ): WritableAtom<TData, ResultActions> {
   const pendingAtom = atom(createPending<TData>())
   const dataAtom = atom<TData | null>(null)
@@ -60,7 +61,10 @@ export function atomWithQuery<
             }
             action.initializer(getQueryClient(get, set))
           } else if (action.type === 'data') {
-            set(dataAtom, action.data)
+            const data = get(dataAtom)
+            if (!data || !equalityFn(data, action.data)) {
+              set(dataAtom, action.data)
+            }
             const pending = get(pendingAtom)
             if (!pending.fulfilled) {
               pending.resolve(action.data)

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -62,12 +62,12 @@ export function atomWithQuery<
             action.initializer(getQueryClient(get, set))
           } else if (action.type === 'data') {
             const data = get(dataAtom)
-            if (!data || !equalityFn(data, action.data)) {
+            if (data === null || !equalityFn(data, action.data)) {
               set(dataAtom, action.data)
-            }
-            const pending = get(pendingAtom)
-            if (!pending.fulfilled) {
-              pending.resolve(action.data)
+              const pending = get(pendingAtom)
+              if (!pending.fulfilled) {
+                pending.resolve(action.data)
+              }
             }
           }
         }


### PR DESCRIPTION
This takes the same `equalityFn` signature from `selectAtom` and adds it to the `atomWithQuery` helper. I have found this very helpful in my apps to help control rerenders while the query revalidates. Currently, if the query is set to refetch on an interval, when it sets the data atom again it will cause any component that uses the data to rerender even if nothing in the data has changed.

Happy to explore other options, but this works for me currently. 