### PR TITLE
fix: atom creator types

### DIFF
--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -5,9 +5,8 @@ import {
   WritableAtom,
   WithInitialValue,
   PrimitiveAtom,
+  NonFunction,
 } from './types'
-
-type AnyFunction = (...args: any[]) => any
 
 let keyCount = 0 // global key count for all atoms
 
@@ -19,21 +18,16 @@ export function atom<Value, Update>(
 
 // write-only derived atom
 export function atom<Value, Update>(
-  read: Value,
+  read: NonFunction<Value>,
   write: Write<Update>
-): Value extends AnyFunction
-  ? never
-  : WritableAtom<Value, Update> & WithInitialValue<Value>
+): WritableAtom<Value, Update> & WithInitialValue<Value>
 
 // read-only derived atom
 export function atom<Value>(read: Read<Value>): Atom<Value>
 
-// invalid read-only derived atom
-export function atom(read: AnyFunction): never
-
 // primitive atom
 export function atom<Value>(
-  initialValue: Value
+  initialValue: NonFunction<Value>
 ): PrimitiveAtom<Value> & WithInitialValue<Value>
 
 export function atom<Value, Update>(

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,9 @@
 export type SetStateAction<Value> = Value | ((prev: Value) => Value)
 
+export type NonFunction<Value> = Value extends (...args: any[]) => any
+  ? never
+  : Value
+
 export type Getter = <Value>(atom: Atom<Value>) => Value
 export type Read<Value> = (get: Getter) => Value | Promise<Value>
 

--- a/src/immer/atomWithImmer.ts
+++ b/src/immer/atomWithImmer.ts
@@ -2,8 +2,10 @@
 import { produce, Draft } from 'immer'
 import { atom, WritableAtom } from 'jotai'
 
+import type { NonFunction } from '../core/types'
+
 export function atomWithImmer<Value>(
-  initialValue: Value
+  initialValue: NonFunction<Value>
 ): WritableAtom<Value, (draft: Draft<Value>) => void> {
   const anAtom: any = atom(
     initialValue,

--- a/src/utils/atomWithReducer.ts
+++ b/src/utils/atomWithReducer.ts
@@ -1,17 +1,19 @@
 import { atom, WritableAtom } from 'jotai'
 
+import type { NonFunction } from '../core/types'
+
 export function atomWithReducer<Value, Action>(
-  initialValue: Value,
+  initialValue: NonFunction<Value>,
   reducer: (v: Value, a?: Action) => Value
 ): WritableAtom<Value, Action | undefined>
 
 export function atomWithReducer<Value, Action>(
-  initialValue: Value,
+  initialValue: NonFunction<Value>,
   reducer: (v: Value, a: Action) => Value
 ): WritableAtom<Value, Action>
 
 export function atomWithReducer<Value, Action>(
-  initialValue: Value,
+  initialValue: NonFunction<Value>,
   reducer: (v: Value, a: Action) => Value
 ) {
   const anAtom: any = atom<Value, Action>(initialValue, (get, set, action) =>

--- a/src/utils/atomWithReset.ts
+++ b/src/utils/atomWithReset.ts
@@ -1,10 +1,10 @@
 import { atom, WritableAtom } from 'jotai'
 
-import type { SetStateAction } from '../core/types'
+import type { SetStateAction, NonFunction } from '../core/types'
 
 export const RESET = Symbol()
 
-export function atomWithReset<Value>(initialValue: Value) {
+export function atomWithReset<Value>(initialValue: NonFunction<Value>) {
   type Update = SetStateAction<Value> | typeof RESET
   const anAtom = atom<Value, Update>(initialValue, (get, set, update) => {
     if (update === RESET) {


### PR DESCRIPTION
Avoids having `never` on function return type.