### PR TITLE
fix types for 3-arg useAtomCallback

### DIFF
--- a/src/utils/useAtomCallback.ts
+++ b/src/utils/useAtomCallback.ts
@@ -3,16 +3,14 @@ import { atom, useAtom } from 'jotai'
 
 import type { Getter, Setter, Scope } from '../core/types'
 
-type UntypedArgError = {
-  error: 'you must manually assign type to the Arg argument'
-}
+type Callback<Result, Arg> = undefined extends Arg
+  ? (arg?: Arg) => Promise<Result>
+  : (arg: Arg) => Promise<Result>
 
-export function useAtomCallback<Result, Arg = UntypedArgError>(
+export function useAtomCallback<Result, Arg>(
   callback: (get: Getter, set: Setter, arg: Arg) => Result,
   scope?: Scope
-): [Arg] extends [UntypedArgError]
-  ? () => Promise<Result>
-  : (arg: Arg) => Promise<Result>
+): Callback<Result, Arg>
 
 export function useAtomCallback<Result, Arg>(
   callback: (get: Getter, set: Setter, arg: Arg) => Result,

--- a/src/utils/useAtomCallback.ts
+++ b/src/utils/useAtomCallback.ts
@@ -3,15 +3,16 @@ import { atom, useAtom } from 'jotai'
 
 import type { Getter, Setter, Scope } from '../core/types'
 
-export function useAtomCallback<Result>(
-  callback: (get: Getter, set: Setter) => Result,
-  scope?: Scope
-): () => Promise<Result>
+type UntypedArgError = {
+  error: 'you must manually assign type to the Arg argument'
+}
 
-export function useAtomCallback<Result, Arg>(
+export function useAtomCallback<Result, Arg = UntypedArgError>(
   callback: (get: Getter, set: Setter, arg: Arg) => Result,
   scope?: Scope
-): (arg: Arg) => Promise<Result>
+): Arg extends UntypedArgError
+  ? () => Promise<Result>
+  : (arg: Arg) => Promise<Result>
 
 export function useAtomCallback<Result, Arg>(
   callback: (get: Getter, set: Setter, arg: Arg) => Result,

--- a/src/utils/useAtomCallback.ts
+++ b/src/utils/useAtomCallback.ts
@@ -10,7 +10,7 @@ type UntypedArgError = {
 export function useAtomCallback<Result, Arg = UntypedArgError>(
   callback: (get: Getter, set: Setter, arg: Arg) => Result,
   scope?: Scope
-): Arg extends UntypedArgError
+): [Arg] extends [UntypedArgError]
   ? () => Promise<Result>
   : (arg: Arg) => Promise<Result>
 

--- a/tests/utils/useAtomCallback.test.tsx
+++ b/tests/utils/useAtomCallback.test.tsx
@@ -108,3 +108,36 @@ it('useAtomCallback with set and update', async () => {
     getByText('changeable count: 1')
   })
 })
+
+it('useAtomCallback with set and update and arg', async () => {
+  const countAtom = atom(0)
+
+  const App = () => {
+    const [count] = useAtom(countAtom)
+    const setCount = useAtomCallback(
+      useCallback((get, set, arg: number) => {
+        set(countAtom, arg)
+        return arg
+      }, [])
+    )
+
+    return (
+      <div>
+        <p>count: {count}</p>
+        <button onClick={() => setCount(42)}>dispatch</button>
+      </div>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <App />
+    </Provider>
+  )
+
+  await findByText('count: 0')
+  fireEvent.click(getByText('dispatch'))
+  await waitFor(() => {
+    getByText('count: 42')
+  })
+})


### PR DESCRIPTION
fix https://github.com/pmndrs/jotai/issues/398

It's a hack. I'm not exactly sure why the original overloads didn't work — that part TS (probably something to do with covariance/contravariance rules) is still something I haven't explored much.

This fix works, but it has bad UX. Could be improved by inlining the error type (right now the intellisense doesn't display the error message).

And of course, someone with more TS knowledge can probably make the overloads work properly. Feel free to close.