### PR TITLE
feat: jotai/redux

### DIFF
--- a/docs/api/redux.md
+++ b/docs/api/redux.md
@@ -15,7 +15,7 @@ npm install redux
 yarn add redux
 ```
 
-## atomWithProxy
+## atomWithStore
 
 `atomWithStore` creates a new atom with redux store.
 It's two-way binding and you can change the value from both ends.

--- a/docs/api/redux.md
+++ b/docs/api/redux.md
@@ -49,4 +49,4 @@ const Counter: React.FC = () => {
 
 ### Examples
 
-TODO
+https://codesandbox.io/s/react-typescript-forked-cmlu5

--- a/docs/api/redux.md
+++ b/docs/api/redux.md
@@ -1,0 +1,52 @@
+This doc describes `jotai/redux` bundle.
+
+Jotai's state resides in React, but sometimes it would be nice
+to intract with the world outside React.
+Redux provides a store interface that can be used to store some values
+and sync with atoms in jotai.
+
+## Install
+
+You have to install `redux` to access this bundle and its functions.
+
+```
+npm install redux
+# or
+yarn add redux
+```
+
+## atomWithProxy
+
+`atomWithStore` creates a new atom with redux store.
+It's two-way binding and you can change the value from both ends.
+
+```js
+import { useAtom } from 'jotai'
+import { atomWithStore } from 'jotai/redux'
+import { createStore } from 'redux'
+
+const initialState = { count: 0 }
+const reducer = (state = initialState, action: { type: 'INC' }) => {
+  if (action.type === 'INC') {
+    return { ...state, count: state.count + 1 }
+  }
+  return state
+}
+const store = createStore(reducer)
+const storeAtom = atomWithStore(store)
+
+const Counter: React.FC = () => {
+  const [state, dispatch] = useAtom(storeAtom)
+
+  return (
+    <>
+      count: {state.count}
+      <button onClick={() => dispatch({ type: 'INC' })}>button</button>
+    </>
+  )
+}
+```
+
+### Examples
+
+TODO

--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
       "types": "./valtio.d.ts",
       "module": "./esm/valtio.js",
       "default": "./valtio.js"
+    },
+    "./redux": {
+      "types": "./redux.d.ts",
+      "module": "./esm/redux.js",
+      "default": "./redux.js"
     }
   },
   "files": [
@@ -74,6 +79,7 @@
     "build:query": "rollup -c --config-query",
     "build:xstate": "rollup -c --config-xstate",
     "build:valtio": "rollup -c --config-valtio",
+    "build:redux": "rollup -c --config-redux",
     "postbuild": "yarn copy",
     "eslint": "eslint --fix '{src,tests}/**/*.{js,ts,jsx,tsx}'",
     "eslint:ci": "eslint '{src,tests}/**/*.{js,ts,jsx,tsx}'",

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-query": "^3.13.2",
+    "redux": "^4.0.5",
     "rollup": "^2.44.0",
     "rollup-plugin-esbuild": "^3.0.2",
     "rollup-plugin-size-snapshot": "^0.12.0",

--- a/src/redux.ts
+++ b/src/redux.ts
@@ -1,0 +1,1 @@
+export { atomWithStore } from './redux/atomWithStore'

--- a/src/redux/atomWithStore.ts
+++ b/src/redux/atomWithStore.ts
@@ -1,0 +1,20 @@
+import type { Store, Action, AnyAction } from 'redux'
+import { atom } from 'jotai'
+import type { NonFunction } from '../core/types'
+
+export function atomWithStore<State, A extends Action = AnyAction>(
+  store: Store<State, A>
+) {
+  const baseAtom = atom(store.getState() as NonFunction<State>)
+  baseAtom.onMount = (setValue) =>
+    store.subscribe(() => {
+      setValue(store.getState())
+    })
+  const derivedAtom = atom(
+    (get) => get(baseAtom),
+    (_get, _set, action: A) => {
+      store.dispatch(action)
+    }
+  )
+  return derivedAtom
+}

--- a/tests/redux/atomWithStore.test.tsx
+++ b/tests/redux/atomWithStore.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { fireEvent, render, act } from '@testing-library/react'
+import { createStore } from 'redux'
+import { Provider, useAtom } from '../../src/index'
+import { atomWithStore } from '../../src/redux'
+
+it('count state', async () => {
+  const initialState = { count: 0 }
+  const reducer = (state = initialState, action: { type: 'INC' }) => {
+    if (action.type === 'INC') {
+      return { ...state, count: state.count + 1 }
+    }
+    return state
+  }
+  const store = createStore(reducer)
+  const storeAtom = atomWithStore(store)
+  const Counter: React.FC = () => {
+    const [state, dispatch] = useAtom(storeAtom)
+
+    return (
+      <>
+        count: {state.count}
+        <button onClick={() => dispatch({ type: 'INC' })}>button</button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Counter />
+    </Provider>
+  )
+
+  await findByText('count: 0')
+
+  fireEvent.click(getByText('button'))
+  await findByText('count: 1')
+  expect(store.getState().count).toBe(1)
+
+  act(() => {
+    store.dispatch({ type: 'INC' })
+  })
+  await findByText('count: 2')
+  expect(store.getState().count).toBe(2)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6062,6 +6062,14 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+redux@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
+
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz#e5de7111d655e7ba60c057dbe9ff37c87e65cdec"
@@ -6889,6 +6897,11 @@ supports-hyperlinks@^2.0.0:
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
+
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
If jotai/zustand #419 is a thing, why not `jotai/redux` ?

But then my question comes again. what should be in and out.
There could be a real use case though. Applying jotai gracefully to existing redux apps.