### PR TITLE
fix: improve types without NonFunction in atom()

### DIFF
--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -5,7 +5,6 @@ import {
   WritableAtom,
   WithInitialValue,
   PrimitiveAtom,
-  NonFunction,
 } from './types'
 
 let keyCount = 0 // global key count for all atoms
@@ -18,17 +17,21 @@ export function atom<Value, Update>(
 
 // write-only derived atom
 export function atom<Value, Update>(
-  read: NonFunction<Value>,
+  initialValue: Value,
   write: Write<Update>
-): WritableAtom<Value, Update> & WithInitialValue<Value>
+): [Value] extends [Function]
+  ? never
+  : WritableAtom<Value, Update> & WithInitialValue<Value>
 
 // read-only derived atom
 export function atom<Value>(read: Read<Value>): Atom<Value>
 
 // primitive atom
-export function atom<Value>(
-  initialValue: NonFunction<Value>
-): PrimitiveAtom<Value> & WithInitialValue<Value>
+export function atom<Value extends unknown>(
+  initialValue: Value
+): [Value] extends [Function]
+  ? never
+  : PrimitiveAtom<Value> & WithInitialValue<Value>
 
 export function atom<Value, Update>(
   read: Value | Read<Value>,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,9 +1,5 @@
 export type SetStateAction<Value> = Value | ((prev: Value) => Value)
 
-export type NonFunction<Value> = Value extends (...args: any[]) => any
-  ? never
-  : Value
-
 export type Getter = <Value>(atom: Atom<Value>) => Value
 export type Read<Value> = (get: Getter) => Value | Promise<Value>
 

--- a/src/immer/atomWithImmer.ts
+++ b/src/immer/atomWithImmer.ts
@@ -2,10 +2,8 @@
 import { produce, Draft } from 'immer'
 import { atom, WritableAtom } from 'jotai'
 
-import type { NonFunction } from '../core/types'
-
 export function atomWithImmer<Value>(
-  initialValue: NonFunction<Value>
+  initialValue: Value
 ): WritableAtom<Value, (draft: Draft<Value>) => void> {
   const anAtom: any = atom(
     initialValue,

--- a/src/optics/focusAtom.ts
+++ b/src/optics/focusAtom.ts
@@ -5,11 +5,13 @@ import {
   setWeakCacheItem,
   WeakCache,
 } from '../utils/weakCache'
-import type { WritableAtom, SetStateAction, NonFunction } from '../core/types'
+import type { WritableAtom, SetStateAction } from '../core/types'
 
 const focusAtomCache: WeakCache<WritableAtom<any, any>> = new WeakMap()
 
 const isFunction = <T>(x: T): x is T & Function => typeof x === 'function'
+
+type NonFunction<T> = [T] extends [Function] ? never : T
 
 export function focusAtom<S, A>(
   baseAtom: WritableAtom<S, NonFunction<S>>,

--- a/src/redux/atomWithStore.ts
+++ b/src/redux/atomWithStore.ts
@@ -1,11 +1,10 @@
 import type { Store, Action, AnyAction } from 'redux'
 import { atom } from 'jotai'
-import type { NonFunction } from '../core/types'
 
 export function atomWithStore<State, A extends Action = AnyAction>(
   store: Store<State, A>
 ) {
-  const baseAtom = atom(store.getState() as NonFunction<State>)
+  const baseAtom = atom(store.getState())
   baseAtom.onMount = (setValue) =>
     store.subscribe(() => {
       setValue(store.getState())

--- a/src/utils/atomWithReducer.ts
+++ b/src/utils/atomWithReducer.ts
@@ -1,19 +1,17 @@
 import { atom, WritableAtom } from 'jotai'
 
-import type { NonFunction } from '../core/types'
-
 export function atomWithReducer<Value, Action>(
-  initialValue: NonFunction<Value>,
+  initialValue: Value,
   reducer: (v: Value, a?: Action) => Value
 ): WritableAtom<Value, Action | undefined>
 
 export function atomWithReducer<Value, Action>(
-  initialValue: NonFunction<Value>,
+  initialValue: Value,
   reducer: (v: Value, a: Action) => Value
 ): WritableAtom<Value, Action>
 
 export function atomWithReducer<Value, Action>(
-  initialValue: NonFunction<Value>,
+  initialValue: Value,
   reducer: (v: Value, a: Action) => Value
 ) {
   const anAtom: any = atom<Value, Action>(initialValue, (get, set, action) =>

--- a/src/utils/atomWithReset.ts
+++ b/src/utils/atomWithReset.ts
@@ -1,10 +1,10 @@
 import { atom, WritableAtom } from 'jotai'
 
-import type { SetStateAction, NonFunction } from '../core/types'
+import type { SetStateAction } from '../core/types'
 
 export const RESET = Symbol()
 
-export function atomWithReset<Value>(initialValue: NonFunction<Value>) {
+export function atomWithReset<Value>(initialValue: Value) {
   type Update = SetStateAction<Value> | typeof RESET
   const anAtom = atom<Value, Update>(initialValue, (get, set, update) => {
     if (update === RESET) {

--- a/src/valtio/atomWithProxy.ts
+++ b/src/valtio/atomWithProxy.ts
@@ -24,20 +24,22 @@ const applyChanges = <T extends object>(proxyObject: T, prev: T, next: T) => {
   })
 }
 
+// No support for promises in proxy as it's not symmetric
+// Should we type it precisely?
 export function atomWithProxy<Value extends object>(proxyObject: Value) {
-  const baseAtom = atom(snapshot(proxyObject) as Value)
+  const baseAtom = atom(snapshot(proxyObject))
   baseAtom.onMount = (setValue) =>
     subscribe(proxyObject, () => {
-      setValue(snapshot(proxyObject) as Value)
+      setValue(snapshot(proxyObject))
     })
   const derivedAtom = atom(
     (get) => get(baseAtom) as Value,
     (get, _set, update: SetStateAction<Value>) => {
       const newValue =
         typeof update === 'function'
-          ? (update as (prev: Value) => Value)(get(baseAtom) as Value)
+          ? (update as Function)(get(baseAtom))
           : update
-      applyChanges(proxyObject, snapshot(proxyObject) as Value, newValue)
+      applyChanges(proxyObject, snapshot(proxyObject), newValue)
     }
   )
   return derivedAtom

--- a/src/valtio/atomWithProxy.ts
+++ b/src/valtio/atomWithProxy.ts
@@ -1,6 +1,6 @@
 import { subscribe, snapshot } from 'valtio/vanilla'
 import { atom } from 'jotai'
-import type { SetStateAction, NonFunction } from '../core/types'
+import type { SetStateAction } from '../core/types'
 
 const isObject = (x: unknown): x is object =>
   typeof x === 'object' && x !== null
@@ -25,17 +25,17 @@ const applyChanges = <T extends object>(proxyObject: T, prev: T, next: T) => {
 }
 
 export function atomWithProxy<Value extends object>(proxyObject: Value) {
-  const baseAtom = atom(snapshot(proxyObject) as NonFunction<Value>)
+  const baseAtom = atom(snapshot(proxyObject) as Value)
   baseAtom.onMount = (setValue) =>
     subscribe(proxyObject, () => {
       setValue(snapshot(proxyObject) as Value)
     })
   const derivedAtom = atom(
-    (get) => get(baseAtom),
+    (get) => get(baseAtom) as Value,
     (get, _set, update: SetStateAction<Value>) => {
       const newValue =
         typeof update === 'function'
-          ? (update as (prev: Value) => Value)(get(baseAtom))
+          ? (update as (prev: Value) => Value)(get(baseAtom) as Value)
           : update
       applyChanges(proxyObject, snapshot(proxyObject) as Value, newValue)
     }

--- a/src/zustand/atomWithStore.ts
+++ b/src/zustand/atomWithStore.ts
@@ -1,9 +1,9 @@
 import type { State, StoreApi } from 'zustand/vanilla'
 import { atom } from 'jotai'
-import type { SetStateAction, NonFunction } from '../core/types'
+import type { SetStateAction } from '../core/types'
 
 export function atomWithStore<T extends State>(store: StoreApi<T>) {
-  const baseAtom = atom(store.getState() as NonFunction<T>)
+  const baseAtom = atom(store.getState())
   baseAtom.onMount = (setValue) =>
     store.subscribe(() => {
       setValue(store.getState())
@@ -13,7 +13,7 @@ export function atomWithStore<T extends State>(store: StoreApi<T>) {
     (get, _set, update: SetStateAction<T>) => {
       const newState =
         typeof update === 'function'
-          ? (update as (prev: T) => T)(get(baseAtom))
+          ? (update as Function)(get(baseAtom))
           : update
       store.setState(newState, true /* replace */)
     }

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -417,7 +417,7 @@ it('async get with another dep and useEffect on parent', async () => {
 })
 
 it('set promise atom value on write (#304)', async () => {
-  const countAtom = atom<any>(Promise.resolve(0))
+  const countAtom = atom(Promise.resolve(0))
   countAtom.debugLabel = 'countAtom'
   const asyncAtom = atom(null, (get, set, _arg) => {
     set(
@@ -429,7 +429,7 @@ it('set promise atom value on write (#304)', async () => {
 
   const Counter: React.FC = () => {
     const [count] = useAtom(countAtom)
-    return <div>count: {count}</div>
+    return <div>count: {(count as /* FIXME */ any) * 1}</div>
   }
 
   const Parent: React.FC = () => {


### PR DESCRIPTION
https://github.com/pmndrs/jotai/discussions/433#discussioncomment-631065

> v0.16.1 introduces `NonFunction` which seems proper in types, but not good in DX. We'd like to improve it.

Here it is.