### PR TITLE
RFC: allow to specify equalityFn for atoms

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -28,8 +28,12 @@ export type OnMount<Update> = <S extends SetAtom<Update>>(
   setAtom: S
 ) => OnUnmount | void
 
+export type EqualityFn<Value> = (a: Value, b: Value) => boolean
+
 export type Atom<Value> = {
   toString: () => string
+  // This crashes TypeScript compiler...
+  //equalityFn?: EqualityFn<Value>
   debugLabel?: string
   scope?: Scope
   read: Read<Value>

--- a/src/core/vanilla.ts
+++ b/src/core/vanilla.ts
@@ -127,7 +127,18 @@ const setAtomValue = <Value>(
   delete atomState.e // read error
   delete atomState.p // read promise
   delete atomState.i // invalidated revision
-  if (!('v' in atomState) || !Object.is(atomState.v, value)) {
+  let areEqual: boolean
+  // @ts-ignore
+  if (atom.equalityFn != null) {
+    // @ts-ignore
+    let equalityFn = atom.equalityFn as any
+    areEqual =
+      'v' in atomState &&
+      (Object.is(atomState.v, value) || equalityFn(atomState.v, value))
+  } else {
+    areEqual = 'v' in atomState && Object.is(atomState.v, value)
+  }
+  if (!areEqual) {
     atomState.v = value
     ++atomState.r // increment revision
   }


### PR DESCRIPTION
This allows to define `equalityFn` for atoms:

    let v = atom(...)
    v.equalityFn = (a, b) => {
      ...
      return areAandBequal
    }

In case `equalityFn` returns `true` then it will bail out from updating
dependent atoms and subscribed components if any.

The main use case I have in mind is to be able to define derived atoms which
compute some non trivial structures. An example from my app:

    let $cellState = atomFamily((id: CellID) => {
      let a = atom((get) => {
        let state = get($editorState(id.notebookID));
        return {
          focus: state.focus?.cellID === id.cellID ? state.focus : null,
          result: state.notebook.cell_results[id.cellID],
          input: state.notebook.cell_inputs[id.cellID],
          inputRemoteVersion: state.cellInputRemoteVersions[id.cellID],
        };
      });
      a.debugLabel = "cellState";
      a.equalityFn = (a, b) => {
        return (
          a.focus === b.focus &&
          a.result === b.result &&
          a.input === b.input &&
          a.inputRemoteVersion === b.inputRemoteVersion
        );
      };
      return a;
    });

The alternative is to define those pieces (focus, result, input, ...) as
separate atoms but this is tedious as they are usually needed at once in my
case.

There's some weird thing with `tsc` which made thing spur `@ts-ignore`, needs to
be resolved before merging (if we agree on this).
