### PR TITLE
chore: fix the NODE_ENV workaround in Provider

### DIFF
--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -13,11 +13,7 @@ export const Provider: React.FC<{
 }> = ({ initialValues, scope, children }) => {
   const storeRef = useRef<ReturnType<typeof createStore> | null>(null)
 
-  if (
-    typeof process === 'object' &&
-    process.env.NODE_ENV !== 'production' &&
-    process.env.NODE_ENV !== 'test'
-  ) {
+  if (typeof process === 'object' && process.env.NODE_ENV !== 'production') {
     /* eslint-disable react-hooks/rules-of-hooks */
     const atomsRef = useRef<AnyAtom[]>([])
     if (storeRef.current === null) {

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -1,8 +1,10 @@
-import React, { Fragment, StrictMode, Suspense, useRef, useEffect } from 'react'
+import React, { StrictMode, Suspense, useRef, useEffect } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Provider as ProviderOrig, atom, useAtom, Atom } from '../src/index'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 const useCommitCount = () => {
   const commitCountRef = useRef(1)

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -1,10 +1,9 @@
 import React, { StrictMode, Suspense, useRef, useEffect } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { Provider as ProviderOrig, atom, useAtom, Atom } from '../src/index'
+import { atom, useAtom, Atom } from '../src/index'
+import { getTestProvider } from './testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 const useCommitCount = () => {
   const commitCountRef = useRef(1)

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -7,16 +7,10 @@ import React, {
   useMemo,
 } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import {
-  Provider as ProviderOrig,
-  atom,
-  useAtom,
-  WritableAtom,
-} from '../src/index'
+import { atom, useAtom, WritableAtom } from '../src/index'
+import { getTestProvider } from './testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 const useCommitCount = () => {
   const commitCountRef = useRef(1)

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,5 +1,4 @@
 import React, {
-  Fragment,
   StrictMode,
   Suspense,
   useEffect,
@@ -15,7 +14,9 @@ import {
   WritableAtom,
 } from '../src/index'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 const useCommitCount = () => {
   const commitCountRef = useRef(1)

--- a/tests/dependency.test.tsx
+++ b/tests/dependency.test.tsx
@@ -1,10 +1,9 @@
 import React, { Suspense, useEffect, useRef, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { Provider as ProviderOrig, atom, useAtom } from '../src/index'
+import { atom, useAtom } from '../src/index'
+import { getTestProvider } from './testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 const useCommitCount = () => {
   const commitCountRef = useRef(1)

--- a/tests/dependency.test.tsx
+++ b/tests/dependency.test.tsx
@@ -1,8 +1,10 @@
-import React, { Fragment, Suspense, useEffect, useRef, useState } from 'react'
+import React, { Suspense, useEffect, useRef, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Provider as ProviderOrig, atom, useAtom } from '../src/index'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 const useCommitCount = () => {
   const commitCountRef = useRef(1)

--- a/tests/error.test.tsx
+++ b/tests/error.test.tsx
@@ -1,8 +1,10 @@
-import React, { Fragment, Suspense, useState, useEffect } from 'react'
+import React, { Suspense, useState, useEffect } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Provider as ProviderOrig, atom, useAtom } from '../src/index'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 const consoleError = console.error
 beforeEach(() => {

--- a/tests/error.test.tsx
+++ b/tests/error.test.tsx
@@ -1,10 +1,9 @@
 import React, { Suspense, useState, useEffect } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { Provider as ProviderOrig, atom, useAtom } from '../src/index'
+import { atom, useAtom } from '../src/index'
+import { getTestProvider } from './testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 const consoleError = console.error
 beforeEach(() => {

--- a/tests/immer/atomWithImmer.test.tsx
+++ b/tests/immer/atomWithImmer.test.tsx
@@ -1,9 +1,11 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { Provider as ProviderOrig, useAtom } from '../../src/index'
 import { atomWithImmer } from '../../src/immer'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('atomWithImmer with useAtom', async () => {
   const countAtom = atomWithImmer(0)

--- a/tests/immer/atomWithImmer.test.tsx
+++ b/tests/immer/atomWithImmer.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Provider as ProviderOrig, useAtom } from '../../src/index'
+import { useAtom } from '../../src/index'
 import { atomWithImmer } from '../../src/immer'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('atomWithImmer with useAtom', async () => {
   const countAtom = atomWithImmer(0)

--- a/tests/immer/useImmerAtom.test.tsx
+++ b/tests/immer/useImmerAtom.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Provider as ProviderOrig, atom } from '../../src/index'
+import { atom } from '../../src/index'
 import { atomWithImmer, useImmerAtom, withImmer } from '../../src/immer'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('useImmerAtom with regular atom', async () => {
   const countAtom = atom(0)

--- a/tests/immer/useImmerAtom.test.tsx
+++ b/tests/immer/useImmerAtom.test.tsx
@@ -1,9 +1,11 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { Provider as ProviderOrig, atom } from '../../src/index'
 import { atomWithImmer, useImmerAtom, withImmer } from '../../src/immer'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('useImmerAtom with regular atom', async () => {
   const countAtom = atom(0)

--- a/tests/immer/withImmer.test.tsx
+++ b/tests/immer/withImmer.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Provider as ProviderOrig, atom, useAtom } from '../../src/index'
+import { atom, useAtom } from '../../src/index'
 import { withImmer } from '../../src/immer'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('withImmer derived atom with useAtom', async () => {
   const regularCountAtom = atom(0)

--- a/tests/immer/withImmer.test.tsx
+++ b/tests/immer/withImmer.test.tsx
@@ -1,9 +1,11 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { Provider as ProviderOrig, atom, useAtom } from '../../src/index'
 import { withImmer } from '../../src/immer'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('withImmer derived atom with useAtom', async () => {
   const regularCountAtom = atom(0)

--- a/tests/items.test.tsx
+++ b/tests/items.test.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import {
   Provider as ProviderOrig,
@@ -7,7 +7,9 @@ import {
   PrimitiveAtom,
 } from '../src/index'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('remove an item, then add another', async () => {
   type Item = {

--- a/tests/items.test.tsx
+++ b/tests/items.test.tsx
@@ -1,15 +1,9 @@
 import React from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import {
-  Provider as ProviderOrig,
-  atom,
-  useAtom,
-  PrimitiveAtom,
-} from '../src/index'
+import { atom, useAtom, PrimitiveAtom } from '../src/index'
+import { getTestProvider } from './testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('remove an item, then add another', async () => {
   type Item = {

--- a/tests/onmount.test.tsx
+++ b/tests/onmount.test.tsx
@@ -1,8 +1,10 @@
-import React, { Fragment, Suspense } from 'react'
+import React, { Suspense } from 'react'
 import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import { Provider as ProviderOrig, atom, useAtom } from '../src/index'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 let savedNodeEnv: string | undefined
 beforeEach(() => {

--- a/tests/onmount.test.tsx
+++ b/tests/onmount.test.tsx
@@ -1,10 +1,9 @@
 import React, { Suspense } from 'react'
 import { act, fireEvent, render, waitFor } from '@testing-library/react'
-import { Provider as ProviderOrig, atom, useAtom } from '../src/index'
+import { atom, useAtom } from '../src/index'
+import { getTestProvider } from './testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 let savedNodeEnv: string | undefined
 beforeEach(() => {

--- a/tests/onmount.test.tsx
+++ b/tests/onmount.test.tsx
@@ -4,6 +4,15 @@ import { Provider as ProviderOrig, atom, useAtom } from '../src/index'
 
 const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
 
+let savedNodeEnv: string | undefined
+beforeEach(() => {
+  savedNodeEnv = process.env.NODE_ENV
+  process.env.NODE_ENV = 'production'
+})
+afterEach(() => {
+  process.env.NODE_ENV = savedNodeEnv
+})
+
 it('one atom, one effect', async () => {
   const countAtom = atom(1)
   const onMountFn = jest.fn()

--- a/tests/optics/focus-lens.test.tsx
+++ b/tests/optics/focus-lens.test.tsx
@@ -1,13 +1,12 @@
 import React, { Suspense } from 'react'
-import { Provider as ProviderOrig, atom, useAtom } from 'jotai'
+import { atom, useAtom } from 'jotai'
 import * as O from 'optics-ts'
 import * as rtl from '@testing-library/react'
 import { focusAtom } from '../../src/optics/focusAtom'
 import type { SetStateAction } from '../../src/core/types'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 const succ = (input: number) => input + 1
 

--- a/tests/optics/focus-lens.test.tsx
+++ b/tests/optics/focus-lens.test.tsx
@@ -1,11 +1,13 @@
-import React, { Fragment, Suspense } from 'react'
+import React, { Suspense } from 'react'
 import { Provider as ProviderOrig, atom, useAtom } from 'jotai'
 import * as O from 'optics-ts'
 import * as rtl from '@testing-library/react'
 import { focusAtom } from '../../src/optics/focusAtom'
 import type { SetStateAction } from '../../src/core/types'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 const succ = (input: number) => input + 1
 

--- a/tests/optics/focus-prism.test.tsx
+++ b/tests/optics/focus-prism.test.tsx
@@ -1,10 +1,12 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { Provider as ProviderOrig, atom, useAtom } from 'jotai'
 import * as O from 'optics-ts'
 import * as rtl from '@testing-library/react'
 import { focusAtom } from '../../src/optics'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('updates prisms', async () => {
   const bigAtom = atom<{ a?: number }>({ a: 5 })

--- a/tests/optics/focus-prism.test.tsx
+++ b/tests/optics/focus-prism.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
-import { Provider as ProviderOrig, atom, useAtom } from 'jotai'
+import { atom, useAtom } from 'jotai'
 import * as O from 'optics-ts'
 import * as rtl from '@testing-library/react'
 import { focusAtom } from '../../src/optics'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('updates prisms', async () => {
   const bigAtom = atom<{ a?: number }>({ a: 5 })

--- a/tests/optics/focus-traversal.test.tsx
+++ b/tests/optics/focus-traversal.test.tsx
@@ -1,10 +1,12 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { Provider as ProviderOrig, atom, useAtom } from 'jotai'
 import * as O from 'optics-ts'
 import * as rtl from '@testing-library/react'
 import { focusAtom } from '../../src/optics/focusAtom'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('updates traversals', async () => {
   const bigAtom = atom<{ a?: number }[]>([{ a: 5 }, {}, { a: 6 }])

--- a/tests/optics/focus-traversal.test.tsx
+++ b/tests/optics/focus-traversal.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
-import { Provider as ProviderOrig, atom, useAtom } from 'jotai'
+import { atom, useAtom } from 'jotai'
 import * as O from 'optics-ts'
 import * as rtl from '@testing-library/react'
 import { focusAtom } from '../../src/optics/focusAtom'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('updates traversals', async () => {
   const bigAtom = atom<{ a?: number }[]>([{ a: 5 }, {}, { a: 6 }])

--- a/tests/optimization.test.tsx
+++ b/tests/optimization.test.tsx
@@ -1,8 +1,10 @@
-import React, { Fragment, useRef } from 'react'
+import React, { useRef } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Provider as ProviderOrig, atom, useAtom } from '../src/index'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('only relevant render function called (#156)', async () => {
   const count1Atom = atom(0)

--- a/tests/optimization.test.tsx
+++ b/tests/optimization.test.tsx
@@ -1,10 +1,9 @@
 import React, { useRef } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { Provider as ProviderOrig, atom, useAtom } from '../src/index'
+import { atom, useAtom } from '../src/index'
+import { getTestProvider } from './testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('only relevant render function called (#156)', async () => {
   const count1Atom = atom(0)

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -1,8 +1,14 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Provider, atom, useAtom } from '../../src/'
+import { Provider as ProviderOrig, atom, useAtom } from '../../src/'
 import fakeFetch from './fakeFetch'
 import { atomWithQuery } from '../../src/query'
+
+// FIXME Provider-less mode fails
+// const Provider = process.env.PROVIDER_LESS_MODE
+//   ? (props: any) => props.children
+//   : ProviderOrig
+const Provider = ProviderOrig
 
 it('query basic test', async () => {
   const countAtom = atomWithQuery(() => ({

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -5,9 +5,7 @@ import fakeFetch from './fakeFetch'
 import { atomWithQuery } from '../../src/query'
 
 // FIXME Provider-less mode fails
-// const Provider = process.env.PROVIDER_LESS_MODE
-//   ? (props: any) => props.children
-//   : ProviderOrig
+// const Provider = getTestProvider()
 const Provider = ProviderOrig
 
 it('query basic test', async () => {

--- a/tests/redux/atomWithStore.test.tsx
+++ b/tests/redux/atomWithStore.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
 import { fireEvent, render, act } from '@testing-library/react'
 import { createStore } from 'redux'
-import { Provider as ProviderOrig, useAtom } from '../../src/index'
+import { useAtom } from '../../src/index'
 import { atomWithStore } from '../../src/redux'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('count state', async () => {
   const initialState = { count: 0 }

--- a/tests/redux/atomWithStore.test.tsx
+++ b/tests/redux/atomWithStore.test.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
 import { fireEvent, render, act } from '@testing-library/react'
 import { createStore } from 'redux'
-import { Provider, useAtom } from '../../src/index'
+import { Provider as ProviderOrig, useAtom } from '../../src/index'
 import { atomWithStore } from '../../src/redux'
+
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('count state', async () => {
   const initialState = { count: 0 }

--- a/tests/scope.test.tsx
+++ b/tests/scope.test.tsx
@@ -1,8 +1,10 @@
-import React, { Fragment, useState } from 'react'
+import React, { useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Provider as ProviderOrig, atom, useAtom } from '../src/index'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 const consoleError = console.error
 beforeEach(() => {

--- a/tests/scope.test.tsx
+++ b/tests/scope.test.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { Provider as ProviderOrig, atom, useAtom } from '../src/index'
+import { atom, useAtom } from '../src/index'
+import { getTestProvider } from './testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 const consoleError = console.error
 beforeEach(() => {

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -1,0 +1,7 @@
+import { Provider } from '../src/index'
+
+export function getTestProvider() {
+  return process.env.PROVIDER_LESS_MODE
+    ? (props: any) => props.children
+    : Provider
+}

--- a/tests/utils/atomFamily.test.tsx
+++ b/tests/utils/atomFamily.test.tsx
@@ -1,11 +1,4 @@
-import React, {
-  Fragment,
-  useState,
-  useRef,
-  useEffect,
-  StrictMode,
-  Suspense,
-} from 'react'
+import React, { useState, useRef, useEffect, StrictMode, Suspense } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import {
   Provider as ProviderOrig,
@@ -16,7 +9,9 @@ import {
 import { atomFamily } from '../../src/utils'
 import type { SetStateAction } from '../../src/core/types'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 const useCommitCount = () => {
   const commitCountRef = useRef(1)

--- a/tests/utils/atomFamily.test.tsx
+++ b/tests/utils/atomFamily.test.tsx
@@ -1,17 +1,11 @@
 import React, { useState, useRef, useEffect, StrictMode, Suspense } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import {
-  Provider as ProviderOrig,
-  atom,
-  useAtom,
-  WritableAtom,
-} from '../../src/index'
+import { atom, useAtom, WritableAtom } from '../../src/index'
 import { atomFamily } from '../../src/utils'
 import type { SetStateAction } from '../../src/core/types'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 const useCommitCount = () => {
   const commitCountRef = useRef(1)

--- a/tests/utils/atomWithDefault.test.tsx
+++ b/tests/utils/atomWithDefault.test.tsx
@@ -1,9 +1,11 @@
-import React, { Fragment, Suspense } from 'react'
+import React, { Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { Provider as ProviderOrig, atom, useAtom } from '../../src/index'
 import { atomWithDefault } from '../../src/utils'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('simple sync get default', async () => {
   const count1Atom = atom(1)

--- a/tests/utils/atomWithDefault.test.tsx
+++ b/tests/utils/atomWithDefault.test.tsx
@@ -1,11 +1,10 @@
 import React, { Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Provider as ProviderOrig, atom, useAtom } from '../../src/index'
+import { atom, useAtom } from '../../src/index'
 import { atomWithDefault } from '../../src/utils'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('simple sync get default', async () => {
   const count1Atom = atom(1)

--- a/tests/utils/atomWithReducer.test.tsx
+++ b/tests/utils/atomWithReducer.test.tsx
@@ -1,9 +1,11 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { Provider as ProviderOrig, useAtom } from '../../src/index'
 import { atomWithReducer } from '../../src/utils'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('atomWithReducer with optional action argument', async () => {
   const reducer = (state: number, action?: 'INCREASE' | 'DECREASE') => {

--- a/tests/utils/atomWithReducer.test.tsx
+++ b/tests/utils/atomWithReducer.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Provider as ProviderOrig, useAtom } from '../../src/index'
+import { useAtom } from '../../src/index'
 import { atomWithReducer } from '../../src/utils'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('atomWithReducer with optional action argument', async () => {
   const reducer = (state: number, action?: 'INCREASE' | 'DECREASE') => {

--- a/tests/utils/selectAtom.test.tsx
+++ b/tests/utils/selectAtom.test.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useRef } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Provider as ProviderOrig, atom } from '../../src/index'
+import { atom } from '../../src/index'
 import { selectAtom, useAtomValue, useUpdateAtom } from '../../src/utils'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('selectAtom works as expected', async () => {
   const bigAtom = atom({ a: 0, b: 'othervalue' })

--- a/tests/utils/selectAtom.test.tsx
+++ b/tests/utils/selectAtom.test.tsx
@@ -1,9 +1,11 @@
-import React, { Fragment, useEffect, useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { Provider as ProviderOrig, atom } from '../../src/index'
 import { selectAtom, useAtomValue, useUpdateAtom } from '../../src/utils'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('selectAtom works as expected', async () => {
   const bigAtom = atom({ a: 0, b: 'othervalue' })

--- a/tests/utils/splitAtom.test.tsx
+++ b/tests/utils/splitAtom.test.tsx
@@ -1,18 +1,10 @@
 import React, { useEffect, useRef } from 'react'
-import {
-  Atom,
-  PrimitiveAtom,
-  Provider as ProviderOrig,
-  atom,
-  useAtom,
-} from 'jotai'
+import { Atom, PrimitiveAtom, atom, useAtom } from 'jotai'
 import { render, fireEvent, waitFor } from '@testing-library/react'
-
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
-
+import { getTestProvider } from '../testUtils'
 import { splitAtom } from '../../src/utils/splitAtom'
+
+const Provider = getTestProvider()
 
 type TodoItem = { task: string; checked?: boolean }
 

--- a/tests/utils/splitAtom.test.tsx
+++ b/tests/utils/splitAtom.test.tsx
@@ -1,6 +1,16 @@
 import React, { useEffect, useRef } from 'react'
-import { atom, Provider, useAtom, Atom, PrimitiveAtom } from 'jotai'
+import {
+  Atom,
+  PrimitiveAtom,
+  Provider as ProviderOrig,
+  atom,
+  useAtom,
+} from 'jotai'
 import { render, fireEvent, waitFor } from '@testing-library/react'
+
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 import { splitAtom } from '../../src/utils/splitAtom'
 

--- a/tests/utils/useAtomCallback.test.tsx
+++ b/tests/utils/useAtomCallback.test.tsx
@@ -1,11 +1,10 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { Provider as ProviderOrig, useAtom, atom } from '../../src/index'
+import { useAtom, atom } from '../../src/index'
 import { useAtomCallback } from '../../src/utils'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('useAtomCallback with get', async () => {
   const countAtom = atom(0)

--- a/tests/utils/useAtomCallback.test.tsx
+++ b/tests/utils/useAtomCallback.test.tsx
@@ -1,9 +1,11 @@
-import React, { Fragment, useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Provider as ProviderOrig, useAtom, atom } from '../../src/index'
 import { useAtomCallback } from '../../src/utils'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('useAtomCallback with get', async () => {
   const countAtom = atom(0)
@@ -115,7 +117,7 @@ it('useAtomCallback with set and update and arg', async () => {
   const App = () => {
     const [count] = useAtom(countAtom)
     const setCount = useAtomCallback(
-      useCallback((get, set, arg: number) => {
+      useCallback((_get, set, arg: number) => {
         set(countAtom, arg)
         return arg
       }, [])

--- a/tests/utils/useAtomValue.test.tsx
+++ b/tests/utils/useAtomValue.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Provider as ProviderOrig, atom } from '../../src/index'
+import { atom } from '../../src/index'
 import { useAtomValue, useUpdateAtom } from '../../src/utils'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('useAtomValue basic test', async () => {
   const countAtom = atom(0)

--- a/tests/utils/useAtomValue.test.tsx
+++ b/tests/utils/useAtomValue.test.tsx
@@ -1,9 +1,11 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { Provider as ProviderOrig, atom } from '../../src/index'
 import { useAtomValue, useUpdateAtom } from '../../src/utils'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('useAtomValue basic test', async () => {
   const countAtom = atom(0)

--- a/tests/utils/useReducerAtom.test.tsx
+++ b/tests/utils/useReducerAtom.test.tsx
@@ -1,9 +1,11 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { Provider as ProviderOrig, atom } from '../../src/index'
 import { useReducerAtom } from '../../src/utils'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('useReducerAtom with no action argument', async () => {
   const countAtom = atom(0)

--- a/tests/utils/useReducerAtom.test.tsx
+++ b/tests/utils/useReducerAtom.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Provider as ProviderOrig, atom } from '../../src/index'
+import { atom } from '../../src/index'
 import { useReducerAtom } from '../../src/utils'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('useReducerAtom with no action argument', async () => {
   const countAtom = atom(0)

--- a/tests/utils/useResetAtom.test.tsx
+++ b/tests/utils/useResetAtom.test.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { Provider as ProviderOrig, atom, useAtom } from '../../src/index'
 import {
@@ -8,7 +8,9 @@ import {
   RESET,
 } from '../../src/utils'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('atomWithReset resets to its first value', async () => {
   const countAtom = atomWithReset(0)

--- a/tests/utils/useResetAtom.test.tsx
+++ b/tests/utils/useResetAtom.test.tsx
@@ -1,16 +1,15 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Provider as ProviderOrig, atom, useAtom } from '../../src/index'
+import { atom, useAtom } from '../../src/index'
 import {
   useResetAtom,
   atomWithReducer,
   atomWithReset,
   RESET,
 } from '../../src/utils'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('atomWithReset resets to its first value', async () => {
   const countAtom = atomWithReset(0)

--- a/tests/utils/useUpdateAtom.test.tsx
+++ b/tests/utils/useUpdateAtom.test.tsx
@@ -1,9 +1,11 @@
-import React, { Fragment, StrictMode, useEffect, useRef } from 'react'
+import React, { StrictMode, useEffect, useRef } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Provider as ProviderOrig, atom, useAtom } from '../../src/index'
 import { useUpdateAtom } from '../../src/utils'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 const useRerenderCount = () => {
   const rerenderCountRef = useRef(0)

--- a/tests/utils/useUpdateAtom.test.tsx
+++ b/tests/utils/useUpdateAtom.test.tsx
@@ -1,11 +1,10 @@
 import React, { StrictMode, useEffect, useRef } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { Provider as ProviderOrig, atom, useAtom } from '../../src/index'
+import { atom, useAtom } from '../../src/index'
 import { useUpdateAtom } from '../../src/utils'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 const useRerenderCount = () => {
   const rerenderCountRef = useRef(0)

--- a/tests/utils/waitForAll.test.tsx
+++ b/tests/utils/waitForAll.test.tsx
@@ -1,9 +1,11 @@
-import React, { Fragment, StrictMode, Suspense } from 'react'
+import React, { StrictMode, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { Provider as ProviderOrig, atom, useAtom } from '../../src/index'
 import { waitForAll } from '../../src/utils'
 
-const Provider = process.env.PROVIDER_LESS_MODE ? Fragment : ProviderOrig
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 const consoleWarn = console.warn
 const consoleError = console.error
@@ -298,7 +300,7 @@ it('handles scope', async () => {
 it('warns on different scopes', async () => {
   const scope = Symbol()
   const anotherScope = Symbol()
-  const asyncAtom = atom(async (get) => {
+  const asyncAtom = atom(async (_get) => {
     await new Promise((resolve) => {
       setTimeout(() => {
         resolve(true)

--- a/tests/utils/waitForAll.test.tsx
+++ b/tests/utils/waitForAll.test.tsx
@@ -1,11 +1,10 @@
 import React, { StrictMode, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Provider as ProviderOrig, atom, useAtom } from '../../src/index'
+import { atom, useAtom } from '../../src/index'
 import { waitForAll } from '../../src/utils'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 const consoleWarn = console.warn
 const consoleError = console.error

--- a/tests/valtio/atomWithProxy.test.tsx
+++ b/tests/valtio/atomWithProxy.test.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { proxy, snapshot } from 'valtio/vanilla'
-import { Provider, useAtom } from '../../src/index'
+import { Provider as ProviderOrig, useAtom } from '../../src/index'
 import { atomWithProxy } from '../../src/valtio'
+
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('count state', async () => {
   const proxyState = proxy({ count: 0 })

--- a/tests/valtio/atomWithProxy.test.tsx
+++ b/tests/valtio/atomWithProxy.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { proxy, snapshot } from 'valtio/vanilla'
-import { Provider as ProviderOrig, useAtom } from '../../src/index'
+import { useAtom } from '../../src/index'
 import { atomWithProxy } from '../../src/valtio'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('count state', async () => {
   const proxyState = proxy({ count: 0 })

--- a/tests/xstate/atomWithMachine.test.tsx
+++ b/tests/xstate/atomWithMachine.test.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { createMachine } from 'xstate'
-import { Provider, useAtom } from '../../src/index'
+import { Provider as ProviderOrig, useAtom } from '../../src/index'
 import { atomWithMachine } from '../../src/xstate'
+
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('toggle machine', async () => {
   const toggleMachine = createMachine({

--- a/tests/xstate/atomWithMachine.test.tsx
+++ b/tests/xstate/atomWithMachine.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { createMachine } from 'xstate'
-import { Provider as ProviderOrig, useAtom } from '../../src/index'
+import { useAtom } from '../../src/index'
 import { atomWithMachine } from '../../src/xstate'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('toggle machine', async () => {
   const toggleMachine = createMachine({

--- a/tests/zustand/atomWithStore.test.tsx
+++ b/tests/zustand/atomWithStore.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
 import { fireEvent, render, act } from '@testing-library/react'
 import create from 'zustand/vanilla'
-import { Provider as ProviderOrig, useAtom } from '../../src/index'
+import { useAtom } from '../../src/index'
 import { atomWithStore } from '../../src/zustand'
+import { getTestProvider } from '../testUtils'
 
-const Provider = process.env.PROVIDER_LESS_MODE
-  ? (props: any) => props.children
-  : ProviderOrig
+const Provider = getTestProvider()
 
 it('count state', async () => {
   const store = create(() => ({ count: 0 }))

--- a/tests/zustand/atomWithStore.test.tsx
+++ b/tests/zustand/atomWithStore.test.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
 import { fireEvent, render, act } from '@testing-library/react'
 import create from 'zustand/vanilla'
-import { Provider, useAtom } from '../../src/index'
+import { Provider as ProviderOrig, useAtom } from '../../src/index'
 import { atomWithStore } from '../../src/zustand'
+
+const Provider = process.env.PROVIDER_LESS_MODE
+  ? (props: any) => props.children
+  : ProviderOrig
 
 it('count state', async () => {
   const store = create(() => ({ count: 0 }))


### PR DESCRIPTION
@Thisen does a trick in #425, which seems better than my workaround.
So, this PR fixes it.

However, this PR reveals some other issues. It now shows some warnings on tests. This should actually be addressed in the second iteration of snapshot-based devtools.

Also, fixed warnings in provider-less mode tests. some of tests are missing for provider-less mode. And found an issue with atomWithQuery, which should be addressed separtely (FIXME).