### PR TITLE
Devtools: Atoms in store in dev mode

### DIFF
--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,10 +1,4 @@
-import React, {
-  createElement,
-  useCallback,
-  useRef,
-  useDebugValue,
-  useState,
-} from 'react'
+import React, { createElement, useCallback, useRef, useDebugValue } from 'react'
 
 import type { AnyAtom, Scope } from './types'
 import { subscribeAtom } from './vanilla'
@@ -61,12 +55,19 @@ const stateToPrintable = ([state, atoms]: [State, AnyAtom[]]) =>
   )
 
 const getState = (state: State) => ({ ...state }) // shallow copy
-const getAtoms = (atoms: AnyAtom[]) => atoms
+const getAtoms = ({ atoms }: { atoms: AnyAtom[] }) => atoms
+const subscribeAtoms = (
+  { listeners }: { listeners: Set<() => void> },
+  callback: () => void
+) => {
+  listeners.add(callback)
+  return () => listeners.delete(callback)
+}
 
 // We keep a reference to the atoms in Provider's registeredAtoms in dev mode,
 // so atoms aren't garbage collected by the WeakMap of mounted atoms
 const useDebugState = (store: StoreForDevelopment) => {
-  const [stateMutableSource, , atomsMutableSource, subscribeAtoms] = store
+  const [stateMutableSource, , atomsMutableSource] = store
   const atoms: AnyAtom[] = useMutableSource(
     atomsMutableSource,
     getAtoms,

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -54,9 +54,9 @@ const stateToPrintable = ([state, atoms]: [State, AnyAtom[]]) =>
     })
   )
 
-const getState = (state: State) => ({ ...state }) // shallow copy
-const getAtoms = ({ atoms }: { atoms: AnyAtom[] }) => atoms
-const subscribeAtoms = (
+export const getState = (state: State) => ({ ...state }) // shallow copy
+export const getAtoms = ({ atoms }: { atoms: AnyAtom[] }) => atoms
+export const subscribeAtoms = (
   { listeners }: { listeners: Set<() => void> },
   callback: () => void
 ) => {

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -61,6 +61,7 @@ const stateToPrintable = ([state, atoms]: [State, AnyAtom[]]) =>
   )
 
 const getState = (state: State) => ({ ...state }) // shallow copy
+const getAtoms = (atoms: AnyAtom[]) => atoms
 
 // We keep a reference to the atoms in Provider's registeredAtoms in dev mode,
 // so atoms aren't garbage collected by the WeakMap of mounted atoms
@@ -68,7 +69,7 @@ const useDebugState = (store: StoreForDevelopment) => {
   const [stateMutableSource, , atomsMutableSource, subscribeAtoms] = store
   const atoms: AnyAtom[] = useMutableSource(
     atomsMutableSource,
-    (atoms: AnyAtom[]) => atoms,
+    getAtoms,
     subscribeAtoms
   )
   const subscribe = useCallback(

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -21,19 +21,12 @@ export const Provider: React.FC<{
   initialValues?: Iterable<readonly [AnyAtom, unknown]>
   scope?: Scope
 }> = ({ initialValues, scope, children: baseChildren }) => {
-  const storeRef = useRef<ReturnType<typeof createStore> | null>(null)
+  const storeRef = useRef(createStore(initialValues))
   let children = baseChildren
 
   if (typeof process === 'object' && process.env.NODE_ENV !== 'production') {
     /* eslint-disable react-hooks/rules-of-hooks */
     const [registeredAtoms, setRegisteredAtoms] = useState<AnyAtom[]>([])
-    if (storeRef.current === null) {
-      // lazy initialization
-      storeRef.current = createStore(initialValues, (newAtom) => {
-        // FIXME find a proper way to handle registered atoms
-        setTimeout(() => setRegisteredAtoms((atoms) => [...atoms, newAtom]), 0)
-      })
-    }
     useDebugState(
       storeRef.current as ReturnType<typeof createStore>,
       registeredAtoms
@@ -44,11 +37,6 @@ export const Provider: React.FC<{
       baseChildren
     )
     /* eslint-enable react-hooks/rules-of-hooks */
-  } else {
-    if (storeRef.current === null) {
-      // lazy initialization
-      storeRef.current = createStore(initialValues)
-    }
   }
 
   const StoreContext = getStoreContext(scope)

--- a/src/core/contexts.ts
+++ b/src/core/contexts.ts
@@ -17,7 +17,7 @@ type StoreForProduction = [
   updateAtom: UpdateAtom
 ]
 
-type StoreForDevelopment = [
+export type StoreForDevelopment = [
   stateMutableSource: MutableSource<State>,
   updateAtom: UpdateAtom,
   atomsMutableSource: MutableSource<AnyAtom[]>,
@@ -81,6 +81,3 @@ export const getStoreContext = (scope?: Scope) => {
   }
   return StoreContextMap.get(scope) as StoreContext
 }
-
-// only for DEV purpose
-export const RegisteredAtomsContext = createContext<AnyAtom[]>([])

--- a/src/core/vanilla.ts
+++ b/src/core/vanilla.ts
@@ -71,7 +71,7 @@ type Mounted = {
 
 type MountedMap = WeakMap<AnyAtom, Mounted>
 
-export type NewAtomReceiver = (newAtom: AnyAtom) => void
+type NewAtomReceiver = (newAtom: AnyAtom) => void
 
 type StateVersion = number
 

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -3,7 +3,7 @@ import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
 import type { AnyAtom } from '../core/types'
 import type { AtomState, State } from '../core/vanilla'
 
-// FIXME across bundles, may or may not work
+// XXX across bundles, this is actually copying code
 import { subscribeAtom } from '../core/vanilla'
 import { useMutableSource } from '../core/useMutableSource'
 import { getDevState, getDevAtoms, subscribeDevAtoms } from '../core/Provider'

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -1,9 +1,12 @@
 import { useCallback, useContext, useMemo } from 'react'
 import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
-import { AtomState, State, subscribeAtom } from '../core/vanilla'
+import type { AnyAtom } from '../core/types'
+import type { AtomState, State } from '../core/vanilla'
+
+// FIXME across bundles, may or may not work
+import { subscribeAtom } from '../core/vanilla'
 import { useMutableSource } from '../core/useMutableSource'
-import { AnyAtom } from '../core/types'
-import { getState, getAtoms, subscribeAtoms } from '../core/Provider'
+import { getDevState, getDevAtoms, subscribeDevAtoms } from '../core/Provider'
 
 type AtomsSnapshot = Map<AnyAtom, unknown>
 
@@ -17,8 +20,8 @@ export function useAtomsSnapshot(): AtomsSnapshot {
 
   const atoms: AnyAtom[] = useMutableSource(
     atomsMutableSource,
-    getAtoms,
-    subscribeAtoms
+    getDevAtoms,
+    subscribeDevAtoms
   )
 
   const subscribe = useCallback(
@@ -31,7 +34,7 @@ export function useAtomsSnapshot(): AtomsSnapshot {
     },
     [atoms]
   )
-  const state: State = useMutableSource(mutableSource, getState, subscribe)
+  const state: State = useMutableSource(mutableSource, getDevState, subscribe)
 
   return useMemo(() => {
     const atomToAtomValueTuples = atoms

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -3,6 +3,7 @@ import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
 import { AtomState, State, subscribeAtom } from '../core/vanilla'
 import { useMutableSource } from '../core/useMutableSource'
 import { AnyAtom } from '../core/types'
+import { getState, getAtoms, subscribeAtoms } from '../core/Provider'
 
 type AtomsSnapshot = Map<AnyAtom, unknown>
 
@@ -41,14 +42,4 @@ export function useAtomsSnapshot(): AtomsSnapshot {
       })
     return new Map(atomToAtomValueTuples)
   }, [atoms, state])
-}
-
-const getState = (state: State) => ({ ...state }) // shallow copy
-const getAtoms = ({ atoms }: { atoms: AnyAtom[] }) => atoms
-const subscribeAtoms = (
-  { listeners }: { listeners: Set<() => void> },
-  callback: () => void
-) => {
-  listeners.add(callback)
-  return () => listeners.delete(callback)
 }

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -8,7 +8,19 @@ type AtomsSnapshot = Map<AnyAtom, unknown>
 
 export function useAtomsSnapshot(): AtomsSnapshot {
   const StoreContext = getStoreContext()
-  const [mutableSource] = useContext(StoreContext)
+  const [mutableSource, , atomsMutableSource, subscribeAtoms] = useContext(
+    StoreContext
+  )
+
+  if (atomsMutableSource === undefined && subscribeAtoms === undefined) {
+    throw Error('useAtomsSnapshot can only be used in dev mode.')
+  }
+
+  const atoms: AnyAtom[] = useMutableSource(
+    atomsMutableSource,
+    (atoms: AnyAtom[]) => atoms,
+    subscribeAtoms
+  )
 
   const subscribe = useCallback(
     (state: State, callback: () => void) => {

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -1,7 +1,6 @@
 import { useCallback, useContext, useMemo } from 'react'
 import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
 import { AtomState, State, subscribeAtom } from '../core/vanilla'
-import { RegisteredAtomsContext } from '../core/contexts'
 import { useMutableSource } from '../core/useMutableSource'
 import { AnyAtom } from '../core/types'
 
@@ -10,7 +9,6 @@ type AtomsSnapshot = Map<AnyAtom, unknown>
 export function useAtomsSnapshot(): AtomsSnapshot {
   const StoreContext = getStoreContext()
   const [mutableSource] = useContext(StoreContext)
-  const atoms = useContext(RegisteredAtomsContext)
 
   const subscribe = useCallback(
     (state: State, callback: () => void) => {

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -12,13 +12,13 @@ export function useAtomsSnapshot(): AtomsSnapshot {
     StoreContext
   )
 
-  if (atomsMutableSource === undefined && subscribeAtoms === undefined) {
+  if (atomsMutableSource === undefined || subscribeAtoms === undefined) {
     throw Error('useAtomsSnapshot can only be used in dev mode.')
   }
 
   const atoms: AnyAtom[] = useMutableSource(
     atomsMutableSource,
-    (atoms: AnyAtom[]) => atoms,
+    getAtoms,
     subscribeAtoms
   )
 
@@ -46,3 +46,4 @@ export function useAtomsSnapshot(): AtomsSnapshot {
 }
 
 const getState = (state: State) => ({ ...state }) // shallow copy
+const getAtoms = (atoms: AnyAtom[]) => atoms

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -8,11 +8,9 @@ type AtomsSnapshot = Map<AnyAtom, unknown>
 
 export function useAtomsSnapshot(): AtomsSnapshot {
   const StoreContext = getStoreContext()
-  const [mutableSource, , atomsMutableSource, subscribeAtoms] = useContext(
-    StoreContext
-  )
+  const [mutableSource, , atomsMutableSource] = useContext(StoreContext)
 
-  if (atomsMutableSource === undefined || subscribeAtoms === undefined) {
+  if (atomsMutableSource === undefined) {
     throw Error('useAtomsSnapshot can only be used in dev mode.')
   }
 
@@ -46,4 +44,11 @@ export function useAtomsSnapshot(): AtomsSnapshot {
 }
 
 const getState = (state: State) => ({ ...state }) // shallow copy
-const getAtoms = (atoms: AnyAtom[]) => atoms
+const getAtoms = ({ atoms }: { atoms: AnyAtom[] }) => atoms
+const subscribeAtoms = (
+  { listeners }: { listeners: Set<() => void> },
+  callback: () => void
+) => {
+  listeners.add(callback)
+  return () => listeners.delete(callback)
+}


### PR DESCRIPTION
This PR splits the store for production and development mode.
This brings us back to a single context, without breaking changes.