### PR TITLE
chore(feat/query): refactor atomWithQuery

### DIFF
--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -7,16 +7,6 @@ import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
 
-// FIXME the tests should also work on DEV
-let savedNodeEnv: string | undefined
-beforeEach(() => {
-  savedNodeEnv = process.env.NODE_ENV
-  process.env.NODE_ENV = 'production'
-})
-afterEach(() => {
-  process.env.NODE_ENV = savedNodeEnv
-})
-
 it('query basic test', async () => {
   const countAtom = atomWithQuery(() => ({
     queryKey: 'count1',


### PR DESCRIPTION
While working on #463, I got a better idea around `initAtom`. This is to follow the pattern.