### PR TITLE
fix(atomWithQuery): Error: Uncaught [TypeError: Cannot set property 'listeners' of undefined]

### DIFF
--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -38,14 +38,7 @@ export function atomWithQuery<
         typeof createQuery === 'function' ? createQuery(get) : createQuery
       const initAtom = atom(
         null,
-        (
-          get,
-          set,
-          cleanup: (
-            callback: () => void,
-            bindObserver: QueryObserver<any, any, any, any>
-          ) => void
-        ) => {
+        (get, set, cleanup: (callback: () => void) => void) => {
           set(
             dataAtom,
             new Promise<TData>(() => {}) // new fetch
@@ -62,19 +55,16 @@ export function atomWithQuery<
               }
             }
           })
-          cleanup(observer.destroy, observer)
+          cleanup(() => observer.destroy())
         }
       )
       initAtom.onMount = (init) => {
         let destroy: (() => void) | undefined | false
-        const cleanup = (
-          callback: () => void,
-          bindObserver: QueryObserver<any, any, any, any>
-        ) => {
+        const cleanup = (callback: () => void) => {
           if (destroy === false) {
-            callback.call(bindObserver)
+            callback()
           } else {
-            destroy = callback.bind(bindObserver)
+            destroy = callback
           }
         }
         init(cleanup)

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -5,14 +5,10 @@ import { getQueryClient } from './queryClientAtom'
 
 type ResultActions = { type: 'refetch' }
 
-type AtomQueryOptions<
-  TQueryFnData,
-  TError,
-  TData,
-  TQueryData
-> = QueryObserverOptions<TQueryFnData, TError, TData, TQueryData> & {
-  queryKey: QueryKey
-}
+type AtomQueryOptions<TQueryFnData, TError, TData, TQueryData> =
+  QueryObserverOptions<TQueryFnData, TError, TData, TQueryData> & {
+    queryKey: QueryKey
+  }
 
 export function atomWithQuery<
   TQueryFnData,


### PR DESCRIPTION
The destroy function loses the observer, So we save the observer and bind it later.