### PR TITLE
Add an `ExtractAtomValue` type

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -49,3 +49,7 @@ export type PrimitiveAtom<Value> = WritableAtom<Value, SetStateAction<Value>>
 
 export type AnyAtom = Atom<unknown>
 export type AnyWritableAtom = WritableAtom<unknown, unknown>
+
+export type ExtractAtomValue<WithType> = WithType extends Atom<infer Value>
+  ? Value
+  : never


### PR DESCRIPTION
In our codebase, we had an Atom like this:

```ts
const usersAtom = atom((get) => {
  return [{
    id: 1,
    name: 'Alice'
  }, {
    id: 2,
    name: 'Bob'
  }]
}
```

We wanted to pass the value of the Atom from one React component down to another one:

```tsx
function Collection() {
  const users = useAtomValue(usersAtom)

  return <div>
	{/* Some code omitted */}
    <UsersTable users={users} />
  </div>
}
```

We also wanted to add types to `<UsersTable>`, but we didn't want to explicitly define new types for every case like this. So we added an `ExtractAtomValue<AtomWithType>` helper type, and I thought it might be useful to have this in jotai itself.

You can now extract the atoms type like this:

```tsx
function UsersTable(props: {
  users: ExtractAtomValue<typeof usersAtom>
}) {
  // Implementation omitted
}
```

This makes it completely typed and autocompletion works.