### PR TITLE
chore: avoid using XXX in code comments

### DIFF
--- a/src/core/vanilla.ts
+++ b/src/core/vanilla.ts
@@ -369,7 +369,7 @@ const addAtom = (state: State, addingAtom: AnyAtom): Mounted => {
   return mounted
 }
 
-// XXX doesn't work with mutally dependent atoms
+// FIXME doesn't work with mutally dependent atoms
 const canUnmountAtom = (atom: AnyAtom, mounted: Mounted) =>
   !mounted.l.size &&
   (!mounted.d.size || (mounted.d.size === 1 && mounted.d.has(atom)))

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -5,8 +5,9 @@ import type { Atom } from 'jotai'
 import type { Scope } from '../core/atom'
 import type { AtomState, State } from '../core/vanilla'
 
-// XXX across bundles, this is actually copying code
+// FIXME this does not work at all (requires SECRET_INTERNAL_useMutableSource)
 import { useMutableSource } from '../core/useMutableSource'
+// NOTE this is across bundles and actually copying code
 import { getDebugStateAndAtoms, subscribeDebugStore } from '../core/Provider'
 
 type AtomsSnapshot = Map<Atom<unknown>, unknown>

--- a/src/devtools/useGotoAtomsSnapshot.ts
+++ b/src/devtools/useGotoAtomsSnapshot.ts
@@ -2,6 +2,7 @@ import { useCallback, useContext } from 'react'
 import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
 
 import type { Scope } from '../core/atom'
+// NOTE this is across bundles and actually copying code
 import { isDevStore } from '../core/contexts'
 
 export function useGotoAtomsSnapshot(scope?: Scope) {

--- a/tests/onmount.test.tsx
+++ b/tests/onmount.test.tsx
@@ -144,7 +144,7 @@ it('mount/unmount test', async () => {
   expect(onUnMountFn).toBeCalledTimes(0)
 
   fireEvent.click(getByText('button'))
-  // XXX is there a better way?
+  // FIXME is there a better way?
   await waitFor(() => {})
 
   expect(onMountFn).toBeCalledTimes(1)
@@ -197,7 +197,7 @@ it('one derived atom, one onMount for the derived one, and one for the regular a
   expect(onUnMountFn).toBeCalledTimes(0)
 
   fireEvent.click(getByText('button'))
-  // XXX is there a better way?
+  // FIXME is there a better way?
   await waitFor(() => {})
 
   expect(derivedOnMountFn).toBeCalledTimes(1)
@@ -271,25 +271,25 @@ it('mount/unMount order', async () => {
   expect(committed).toEqual([0, 0])
 
   fireEvent.click(getByText('button'))
-  // XXX is there a better way?
+  // FIXME is there a better way?
   await waitFor(() => {})
 
   expect(committed).toEqual([1, 0])
 
   fireEvent.click(getByText('derived atom'))
-  // XXX is there a better way?
+  // FIXME is there a better way?
   await waitFor(() => {})
 
   expect(committed).toEqual([1, 1])
 
   fireEvent.click(getByText('derived atom'))
-  // XXX is there a better way?
+  // FIXME is there a better way?
   await waitFor(() => {})
 
   expect(committed).toEqual([1, 0])
 
   fireEvent.click(getByText('button'))
-  // XXX is there a better way?
+  // FIXME is there a better way?
   await waitFor(() => {})
 
   expect(committed).toEqual([0, 0])

--- a/tests/utils/splitAtom.test.tsx
+++ b/tests/utils/splitAtom.test.tsx
@@ -213,7 +213,7 @@ it('read-only array atom', async () => {
   const catBox = getByTestId('get cat food-checkbox') as HTMLInputElement
   const dragonBox = getByTestId('get dragon food-checkbox') as HTMLInputElement
 
-  // XXX is there a better way?
+  // FIXME is there a better way?
   await waitFor(() => {})
 
   expect(catBox.checked).toBe(false)
@@ -271,7 +271,7 @@ it('handles scope', async () => {
 
   fireEvent.click(catBox)
 
-  // XXX is there a better way?
+  // FIXME is there a better way?
   await waitFor(() => {})
 
   expect(catBox.checked).toBe(true)


### PR DESCRIPTION
We use the following keywords and avoid `XXX` which is ambiguous.

```ts
// FIXME this means, it's working but should be improved
// TODO this means, it's not implemented and should be done
// HACK this means, it's not very nice but it can't be helped
// NOTE this means, it's something that should be understood
```