### PR TITLE
fix: throw error for prohibited write operations

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 21553,
-    "minified": 10086,
-    "gzipped": 3303,
+    "bundled": 21641,
+    "minified": 10148,
+    "gzipped": 3315,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -28,9 +28,9 @@
     }
   },
   "devtools.js": {
-    "bundled": 19663,
-    "minified": 9575,
-    "gzipped": 3288,
+    "bundled": 19751,
+    "minified": 9637,
+    "gzipped": 3297,
     "treeshaked": {
       "rollup": {
         "code": 28,

--- a/src/core/vanilla.ts
+++ b/src/core/vanilla.ts
@@ -449,13 +449,12 @@ const writeAtomState = <Value, Update>(
       ((a: AnyWritableAtom, v: unknown) => {
         const isPendingPromisesExpired = !pendingPromises.length
         if (a === atom) {
-          if (hasInitialValue(a)) {
-            setAtomValue(state, a, v)
-            invalidateDependents(state, a)
-          } else {
+          if (!hasInitialValue(a)) {
             // NOTE technically possible but restricted as it may cause bugs
             throw new Error('no atom init')
           }
+          setAtomValue(state, a, v)
+          invalidateDependents(state, a)
         } else {
           writeAtomState(state, a, v, pendingPromises)
         }

--- a/src/core/vanilla.ts
+++ b/src/core/vanilla.ts
@@ -449,8 +449,13 @@ const writeAtomState = <Value, Update>(
       ((a: AnyWritableAtom, v: unknown) => {
         const isPendingPromisesExpired = !pendingPromises.length
         if (a === atom) {
-          setAtomValue(state, a, v)
-          invalidateDependents(state, a)
+          if (hasInitialValue(a)) {
+            setAtomValue(state, a, v)
+            invalidateDependents(state, a)
+          } else {
+            // NOTE technically possible but restricted as it may cause bugs
+            throw new Error('no atom init')
+          }
         } else {
           writeAtomState(state, a, v, pendingPromises)
         }


### PR DESCRIPTION
ref: https://github.com/pmndrs/jotai/issues/231#issuecomment-851075102

I just found it was possible to set values to an atom that has `read` function.
This is not a supported pattern, and should be error to avoid misusing.