### PR TITLE
feat: drop returning promise by writeAtom/setAtom

### DIFF
--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -25,8 +25,8 @@ export type Scope = symbol | string | number
 
 // Are there better typings?
 export type SetAtom<Update> = undefined extends Update
-  ? (update?: Update) => void | Promise<void>
-  : (update: Update) => void | Promise<void>
+  ? (update?: Update) => void
+  : (update: Update) => void
 
 type OnUnmount = () => void
 type OnMount<Update> = <S extends SetAtom<Update>>(

--- a/src/core/contexts.ts
+++ b/src/core/contexts.ts
@@ -11,7 +11,7 @@ type MutableSource<_Target> = ReturnType<typeof createMutableSource>
 type UpdateAtom = <Value, Update>(
   atom: WritableAtom<Value, Update>,
   update: Update
-) => void | Promise<void>
+) => void
 
 type StoreForProduction = [
   stateMutableSource: MutableSource<State>,

--- a/src/core/useAtom.ts
+++ b/src/core/useAtom.ts
@@ -67,7 +67,7 @@ export function useAtom<Value, Update>(
   const setAtom = useCallback(
     (update: Update) => {
       if (isWritable(atom)) {
-        return updateAtom(atom, update)
+        updateAtom(atom, update)
       } else {
         throw new Error('not writable atom')
       }

--- a/src/core/vanilla.ts
+++ b/src/core/vanilla.ts
@@ -396,129 +396,80 @@ const invalidateDependents = <Value>(state: State, atom: Atom<Value>): void => {
 const writeAtomState = <Value, Update>(
   state: State,
   atom: WritableAtom<Value, Update>,
-  update: Update,
-  pendingPromises: Promise<void>[]
+  update: Update
 ): void => {
-  const isPendingPromisesExpired = !pendingPromises.length
   const writePromise = getAtomState(state, atom)?.w
   if (writePromise) {
-    const promise = writePromise.then(() => {
-      writeAtomState(state, atom, update, pendingPromises)
-      if (isPendingPromisesExpired) {
-        flushPending(state)
-      }
+    writePromise.then(() => {
+      writeAtomState(state, atom, update)
+      flushPending(state)
     })
-    if (!isPendingPromisesExpired) {
-      pendingPromises.push(promise)
-    }
     return
   }
-  try {
-    const promiseOrVoid = atom.write(
-      ((a: AnyAtom) => {
-        const aState = readAtomState(state, a)
-        if (aState.e) {
-          throw aState.e // read error
-        }
-        if (aState.p) {
-          if (
-            typeof process === 'object' &&
-            process.env.NODE_ENV !== 'production'
-          ) {
-            console.warn(
-              'Reading pending atom state in write operation. We throw a promise for now.',
-              a
-            )
-          }
-          throw aState.p // read promise
-        }
-        if ('v' in aState) {
-          return aState.v // value
-        }
+  const promiseOrVoid = atom.write(
+    ((a: AnyAtom) => {
+      const aState = readAtomState(state, a)
+      if (aState.e) {
+        throw aState.e // read error
+      }
+      if (aState.p) {
         if (
           typeof process === 'object' &&
           process.env.NODE_ENV !== 'production'
         ) {
           console.warn(
-            '[Bug] no value found while reading atom in write operation. This probably a bug.',
+            'Reading pending atom state in write operation. We throw a promise for now.',
             a
           )
         }
-        throw new Error('no value found')
-      }) as Getter,
-      ((a: AnyWritableAtom, v: unknown) => {
-        const isPendingPromisesExpired = !pendingPromises.length
-        if (a === atom) {
-          if (!hasInitialValue(a)) {
-            // NOTE technically possible but restricted as it may cause bugs
-            throw new Error('no atom init')
-          }
-          setAtomValue(state, a, v)
-          invalidateDependents(state, a)
-        } else {
-          writeAtomState(state, a, v, pendingPromises)
-        }
-        if (isPendingPromisesExpired) {
-          flushPending(state)
-        }
-      }) as Setter,
-      update
-    )
-    if (promiseOrVoid instanceof Promise) {
-      const promise = promiseOrVoid.finally(() => {
-        setAtomWritePromise(state, atom)
-        if (isPendingPromisesExpired) {
-          flushPending(state)
-        }
-      })
-      if (!isPendingPromisesExpired) {
-        pendingPromises.push(promise)
+        throw aState.p // read promise
       }
-      setAtomWritePromise(state, atom, promise)
-    }
-  } catch (e) {
-    if (pendingPromises.length === 1) {
-      // still in sync, throw it right away
-      throw e
-    } else if (!isPendingPromisesExpired) {
-      pendingPromises.push(Promise.reject(e))
-    } else {
-      console.error('Uncaught exception: Use promise to catch error', e)
-    }
+      if ('v' in aState) {
+        return aState.v // value
+      }
+      if (
+        typeof process === 'object' &&
+        process.env.NODE_ENV !== 'production'
+      ) {
+        console.warn(
+          '[Bug] no value found while reading atom in write operation. This probably a bug.',
+          a
+        )
+      }
+      throw new Error('no value found')
+    }) as Getter,
+    ((a: AnyWritableAtom, v: unknown) => {
+      if (a === atom) {
+        if (!hasInitialValue(a)) {
+          // NOTE technically possible but restricted as it may cause bugs
+          throw new Error('no atom init')
+        }
+        setAtomValue(state, a, v)
+        invalidateDependents(state, a)
+      } else {
+        writeAtomState(state, a, v)
+      }
+      flushPending(state)
+    }) as Setter,
+    update
+  )
+  if (promiseOrVoid instanceof Promise) {
+    const promise = promiseOrVoid.finally(() => {
+      setAtomWritePromise(state, atom)
+      flushPending(state)
+    })
+    setAtomWritePromise(state, atom, promise)
   }
+  // TODO write error is not handled
 }
 
 export const writeAtom = <Value, Update>(
   state: State,
   writingAtom: WritableAtom<Value, Update>,
   update: Update
-): void | Promise<void> => {
-  const pendingPromises: Promise<void>[] = [Promise.resolve()]
-
-  writeAtomState(state, writingAtom, update, pendingPromises)
+): void => {
+  writeAtomState(state, writingAtom, update)
   flushPending(state)
-
-  if (pendingPromises.length <= 1) {
-    pendingPromises.splice(0)
-  } else {
-    return new Promise<void>((resolve, reject) => {
-      const loop = () => {
-        if (pendingPromises.length <= 1) {
-          pendingPromises.splice(0)
-          resolve()
-        } else {
-          Promise.all(pendingPromises)
-            .then(() => {
-              pendingPromises.splice(1)
-              flushPending(state)
-              loop()
-            })
-            .catch(reject)
-        }
-      }
-      loop()
-    })
-  }
 }
 
 const isActuallyWritableAtom = (atom: AnyAtom): atom is AnyWritableAtom =>

--- a/src/core/vanilla.ts
+++ b/src/core/vanilla.ts
@@ -432,7 +432,7 @@ const writeAtomState = <Value, Update>(
         process.env.NODE_ENV !== 'production'
       ) {
         console.warn(
-          '[Bug] no value found while reading atom in write operation. This probably a bug.',
+          '[Bug] no value found while reading atom in write operation. This is probably a bug.',
           a
         )
       }

--- a/tests/error.test.tsx
+++ b/tests/error.test.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useState, useEffect } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import { atom, useAtom } from '../src/index'
 import { getTestProvider } from './testUtils'
 
@@ -256,49 +256,6 @@ it('can throw an error in write function', async () => {
 
   fireEvent.click(getByText('button'))
   expect(console.error).toHaveBeenCalledTimes(1)
-})
-
-it('can throw an error in async write function', async () => {
-  const countAtom = atom(0)
-  const errorAtom = atom(
-    (get) => get(countAtom),
-    async () => {
-      throw new Error()
-    }
-  )
-
-  const Counter: React.FC = () => {
-    const [count, dispatch] = useAtom(errorAtom)
-    const onClick = async () => {
-      try {
-        await dispatch()
-      } catch (e) {
-        console.error(e)
-      }
-    }
-    return (
-      <>
-        <div>count: {count}</div>
-        <div>no error</div>
-        <button onClick={onClick}>button</button>
-      </>
-    )
-  }
-
-  const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback={null}>
-        <Counter />
-      </Suspense>
-    </Provider>
-  )
-
-  await findByText('no error')
-
-  fireEvent.click(getByText('button'))
-  await waitFor(() => {
-    expect(console.error).toHaveBeenCalledTimes(1)
-  })
 })
 
 it('can throw a chained error in write function', async () => {


### PR DESCRIPTION
The API is confusing especially in TypeScript and the implementation is too tricky.
We remain error handling as `TODO`.