### PR TITLE
chore: warn initial value for derived atom

### DIFF
--- a/src/core/vanilla.ts
+++ b/src/core/vanilla.ts
@@ -99,6 +99,12 @@ export const createState = (
         process.env.NODE_ENV !== 'production'
       ) {
         Object.freeze(atomState)
+        if (!hasInitialValue(atom)) {
+          console.warn(
+            'Found initial value for derived atom which can cause unexpected behavior',
+            atom
+          )
+        }
       }
       state.a.set(atom, atomState)
     }


### PR DESCRIPTION
because it may not work as expected without dependencies. we would revisit this as we collect more use cases.