### PR TITLE
chore(jotai/query): refactor atomWithQuery

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -70,9 +70,9 @@
     }
   },
   "query.js": {
-    "bundled": 2651,
-    "minified": 1311,
-    "gzipped": 616,
+    "bundled": 2114,
+    "minified": 1005,
+    "gzipped": 535,
     "treeshaked": {
       "rollup": {
         "code": 84,

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -40,7 +40,7 @@ export function atomWithQuery<
         })
       )
       let setData: (data: TData) => void = () => {
-        throw new Error('setting data without mount')
+        throw new Error('atomWithQuery: setting data without mount')
       }
       let prevData: TData | null = null
       const listener = (result: QueryObserverResult<TData, TError>) => {

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -8,7 +8,7 @@ import { atom } from 'jotai'
 import type { WritableAtom, Getter } from 'jotai'
 import { queryClientAtom } from './queryClientAtom'
 
-type Action = { type: 'refetch' } | { type: 'cleanup' }
+type Action = { type: 'refetch' }
 
 type AtomQueryOptions<TQueryFnData, TError, TData, TQueryData> =
   QueryObserverOptions<TQueryFnData, TError, TData, TQueryData> & {
@@ -28,76 +28,60 @@ export function atomWithQuery<
       ) => AtomQueryOptions<TQueryFnData, TError, TData, TQueryData>),
   equalityFn: (a: TData, b: TData) => boolean = Object.is
 ): WritableAtom<TData, Action> {
-  const stateAtom = atom(() => {
-    const state = {
-      resolve: null as ((data: TData) => void) | null,
-      setData: null as ((data: TData) => void) | null,
-      prevData: null as TData | null,
-      unsubscribe: null as (() => void) | null,
-      handle(result: QueryObserverResult<TData, TError>) {
+  const queryDataAtom = atom(
+    (get) => {
+      const queryClient = get(queryClientAtom)
+      const options =
+        typeof createQuery === 'function' ? createQuery(get) : createQuery
+      let resolve: ((data: TData) => void) | null = null
+      const dataAtom = atom<TData | Promise<TData>>(
+        new Promise<TData>((r) => {
+          resolve = r
+        })
+      )
+      let setData: (data: TData) => void = () => {
+        throw new Error('setting data without mount')
+      }
+      let prevData: TData | null = null
+      const listener = (result: QueryObserverResult<TData, TError>) => {
         // TODO error handling
         if (
           result.data === undefined ||
-          (this.prevData !== null && equalityFn(this.prevData, result.data))
+          (prevData !== null && equalityFn(prevData, result.data))
         ) {
           return
         }
-        this.prevData = result.data
-        if (this.resolve) {
-          this.resolve(result.data)
-          this.resolve = null
-        } else if (this.setData) {
-          this.setData(result.data)
+        prevData = result.data
+        if (resolve) {
+          resolve(result.data)
+          resolve = null
         } else {
-          throw new Error('setting data without mount')
+          setData(result.data)
         }
-      },
-    }
-    return state
-  })
-  const initAtom = atom(
-    (get) => {
-      const options =
-        typeof createQuery === 'function' ? createQuery(get) : createQuery
-      const state = get(stateAtom)
-      const dataAtom = atom<TData | Promise<TData>>(
-        new Promise<TData>((resolve) => {
-          state.resolve = resolve
+      }
+      const defaultedOptions = queryClient.defaultQueryObserverOptions(options)
+      if (typeof defaultedOptions.staleTime !== 'number') {
+        defaultedOptions.staleTime = 1000
+      }
+      const observer = new QueryObserver(queryClient, defaultedOptions)
+      observer
+        .fetchOptimistic(defaultedOptions)
+        .then(listener)
+        .catch(() => {
+          // TODO error handling
         })
-      )
-      state.prevData = null
-      const queryClient = get(queryClientAtom)
-      const observer = new QueryObserver(queryClient, options)
-      state.unsubscribe?.()
-      state.unsubscribe = observer.subscribe((result) => {
-        state.handle(result)
-      })
+      dataAtom.onMount = (update) => {
+        setData = update
+        const unsubscribe = observer.subscribe(listener)
+        return unsubscribe
+      }
       return { dataAtom, options }
     },
-    (get, set, action: Action | { type: 'mount' }) => {
+    (get, set, action: Action) => {
       switch (action.type) {
-        case 'mount': {
-          const state = get(stateAtom)
-          state.setData = (data) => {
-            const { dataAtom } = get(initAtom)
-            set(dataAtom, data)
-          }
-          return
-        }
-        case 'cleanup': {
-          const { unsubscribe } = get(stateAtom)
-          unsubscribe?.()
-          return
-        }
         case 'refetch': {
-          const state = get(stateAtom)
-          const { dataAtom, options } = get(initAtom)
-          set(
-            dataAtom,
-            new Promise<TData>((resolve) => {
-              state.resolve = resolve
-            })
-          )
+          const { dataAtom, options } = get(queryDataAtom)
+          set(dataAtom, new Promise<TData>(() => {})) // infinite pending
           const queryClient = get(queryClientAtom)
           queryClient.getQueryCache().find(options.queryKey)?.reset()
           const p: Promise<void> = queryClient.refetchQueries(options.queryKey)
@@ -106,16 +90,12 @@ export function atomWithQuery<
       }
     }
   )
-  initAtom.onMount = (dispatch) => {
-    dispatch({ type: 'mount' })
-    return () => dispatch({ type: 'cleanup' })
-  }
   const queryAtom = atom<TData, Action>(
     (get) => {
-      const { dataAtom } = get(initAtom)
+      const { dataAtom } = get(queryDataAtom)
       return get(dataAtom)
     },
-    (_get, set, action) => set(initAtom, action) // delegate action
+    (_get, set, action) => set(queryDataAtom, action) // delegate action
   )
   return queryAtom
 }

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -171,7 +171,7 @@ it('query loading 2', async () => {
   let count = 0
   const mockFetch = jest.fn(fakeFetch)
   const countAtom = atomWithQuery(() => ({
-    queryKey: 'count',
+    queryKey: 'count5',
     queryFn: async () => {
       const response = await mockFetch({ count }, false, 100)
       count++
@@ -217,7 +217,7 @@ it('query with enabled (#500)', async () => {
     const enabled = get(enabledAtom)
     return {
       enabled,
-      queryKey: 'count',
+      queryKey: 'count6',
       queryFn: async () => {
         return await fakeFetch({ count: 1 })
       },


### PR DESCRIPTION
I found `useQuery` in react-query uses `fetchOptimistic` for suspense.
This is undocumented, but it should solve some potential issues in atomWithQuery.
(Previously, there's a risk of memory leak. I'm so glad to get rid of stateAtom which uses mutable state.)
