### PR TITLE
fix: disable useDebugState in test env

### DIFF
--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -19,6 +19,7 @@ export const Provider: React.FC<{
   if (
     typeof process === 'object' &&
     process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
     isDevStore(storeRef.current)
   ) {
     // eslint-disable-next-line react-hooks/rules-of-hooks


### PR DESCRIPTION
While starting to test our state, I noticed a warning from jest/hooks-testing-library about needing to wrap a function in Provider with `act`. This is the change @dai-shi recommended and I've tested it locally.