### PR TITLE
fix(query): queryClientAtom for initialValues

### DIFF
--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -6,7 +6,7 @@ import {
 } from 'react-query'
 import { atom } from 'jotai'
 import type { WritableAtom, Getter } from 'jotai'
-import { queryClientAtom } from './queryClientAtom'
+import { getQueryClientAtom } from './queryClientAtom'
 
 type Action = { type: 'refetch' }
 
@@ -30,7 +30,7 @@ export function atomWithQuery<
 ): WritableAtom<TData, Action> {
   const queryDataAtom = atom(
     (get) => {
-      const queryClient = get(queryClientAtom)
+      const queryClient = get(getQueryClientAtom)
       const options =
         typeof createQuery === 'function' ? createQuery(get) : createQuery
       let resolve: ((data: TData) => void) | null = null
@@ -82,7 +82,7 @@ export function atomWithQuery<
         case 'refetch': {
           const { dataAtom, options } = get(queryDataAtom)
           set(dataAtom, new Promise<TData>(() => {})) // infinite pending
-          const queryClient = get(queryClientAtom)
+          const queryClient = get(getQueryClientAtom)
           queryClient.getQueryCache().find(options.queryKey)?.reset()
           const p: Promise<void> = queryClient.refetchQueries(options.queryKey)
           return p

--- a/src/query/queryClientAtom.ts
+++ b/src/query/queryClientAtom.ts
@@ -1,4 +1,8 @@
 import { atom } from 'jotai'
 import { QueryClient } from 'react-query'
 
-export const queryClientAtom = atom(() => new QueryClient())
+export const queryClientAtom = atom<QueryClient | null>(null)
+
+export const getQueryClientAtom = atom(
+  (get) => get(queryClientAtom) || new QueryClient()
+)


### PR DESCRIPTION
With #516, setting initialValue in Provider for derived atoms is not recommended.
This PR provides a primitive atom for queryClient. This allows to set the atom in useEffect too.