### PR TITLE
chore(core): flushPending just once on write

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 21126,
-    "minified": 10113,
-    "gzipped": 3334,
+    "bundled": 21254,
+    "minified": 10165,
+    "gzipped": 3360,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -28,9 +28,9 @@
     }
   },
   "devtools.js": {
-    "bundled": 18986,
-    "minified": 9482,
-    "gzipped": 3260,
+    "bundled": 19114,
+    "minified": 9534,
+    "gzipped": 3286,
     "treeshaked": {
       "rollup": {
         "code": 28,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 21254,
-    "minified": 10165,
-    "gzipped": 3360,
+    "bundled": 21249,
+    "minified": 10146,
+    "gzipped": 3357,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -28,9 +28,9 @@
     }
   },
   "devtools.js": {
-    "bundled": 19114,
-    "minified": 9534,
-    "gzipped": 3286,
+    "bundled": 19109,
+    "minified": 9515,
+    "gzipped": 3282,
     "treeshaked": {
       "rollup": {
         "code": 28,

--- a/src/core/vanilla.ts
+++ b/src/core/vanilla.ts
@@ -616,27 +616,25 @@ const commitAtomState = <Value>(
 }
 
 export const flushPending = (state: State): void => {
-  if (!state.p.size) {
-    return
-  }
-  const pending = Array.from(state.p)
-  state.p.clear()
-  pending.forEach(([atom, prevDependencies]) => {
-    const atomState = getAtomState(state, atom)
-    if (atomState) {
-      if (prevDependencies) {
-        mountDependencies(state, atom, atomState, prevDependencies)
+  while (state.p.size) {
+    const pending = Array.from(state.p)
+    state.p.clear()
+    pending.forEach(([atom, prevDependencies]) => {
+      const atomState = getAtomState(state, atom)
+      if (atomState) {
+        if (prevDependencies) {
+          mountDependencies(state, atom, atomState, prevDependencies)
+        }
+      } else if (
+        typeof process === 'object' &&
+        process.env.NODE_ENV !== 'production'
+      ) {
+        console.warn('[Bug] atom state not found in flush', atom)
       }
-    } else if (
-      typeof process === 'object' &&
-      process.env.NODE_ENV !== 'production'
-    ) {
-      console.warn('[Bug] atom state not found in flush', atom)
-    }
-    const mounted = state.m.get(atom)
-    mounted?.l.forEach((listener) => listener())
-  })
-  flushPending(state)
+      const mounted = state.m.get(atom)
+      mounted?.l.forEach((listener) => listener())
+    })
+  }
 }
 
 export const subscribeAtom = (


### PR DESCRIPTION
While working on https://github.com/Thisen/js-framework-benchmark/pull/5,
I found flushPending is invoked multiple times.
Not sure how it would affect performance, but I feel it's better to run flushPending at the end or writeAtom.

The difference in this PR is shown as the comparison between B and C.

<img width="595" alt="image" src="https://user-images.githubusercontent.com/490574/123534745-3f106680-d75a-11eb-951e-4774fddc140c.png">