### PR TITLE
fix(query): use observer for refetch

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -70,9 +70,9 @@
     }
   },
   "query.js": {
-    "bundled": 5246,
-    "minified": 2261,
-    "gzipped": 694,
+    "bundled": 5170,
+    "minified": 2240,
+    "gzipped": 686,
     "treeshaked": {
       "rollup": {
         "code": 105,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -70,9 +70,9 @@
     }
   },
   "query.js": {
-    "bundled": 5309,
-    "minified": 2316,
-    "gzipped": 720,
+    "bundled": 5246,
+    "minified": 2261,
+    "gzipped": 694,
     "treeshaked": {
       "rollup": {
         "code": 105,

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -98,16 +98,19 @@ export function atomWithQuery<
         const unsubscribe = observer.subscribe(listener)
         return unsubscribe
       }
-      return { dataAtom, options }
+      return {
+        dataAtom,
+        observer,
+      }
     },
     (get, set, action: AtomWithQueryAction) => {
       switch (action.type) {
         case 'refetch': {
-          const { dataAtom, options } = get(queryDataAtom)
+          const { dataAtom, observer } = get(queryDataAtom)
           set(dataAtom, new Promise<TData>(() => {})) // infinite pending
-          const queryClient = get(getQueryClientAtom)
-          queryClient.getQueryCache().find(options.queryKey)?.reset()
-          const p: Promise<void> = queryClient.refetchQueries(options.queryKey)
+          const p: Promise<void> = observer
+            .refetch({ cancelRefetch: true })
+            .then(() => {})
           return p
         }
       }


### PR DESCRIPTION
This takes the pattern of using the `observer` from the `atomWithInfiniteQuery` implementation to refetch vs the queryClient method that was used previously. Suspense behavior has not been impacted.