### PR TITLE
fix(utils): refactor to avoid variable outside atom

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -14,9 +14,9 @@
     }
   },
   "utils.js": {
-    "bundled": 13604,
-    "minified": 6640,
-    "gzipped": 2497,
+    "bundled": 13479,
+    "minified": 6775,
+    "gzipped": 2544,
     "treeshaked": {
       "rollup": {
         "code": 28,

--- a/src/utils/selectAtom.ts
+++ b/src/utils/selectAtom.ts
@@ -14,15 +14,14 @@ export function selectAtom<Value, Slice>(
   if (cachedAtom) {
     return cachedAtom as Atom<Slice>
   }
-  let initialized = false
-  let prevSlice: Slice
+  const refAtom = atom(() => ({} as { prev?: Slice }))
   const derivedAtom = atom((get) => {
     const slice = selector(get(anAtom))
-    if (initialized && equalityFn(prevSlice, slice)) {
-      return prevSlice
+    const ref = get(refAtom)
+    if ('prev' in ref && equalityFn(ref.prev as Slice, slice)) {
+      return ref.prev as Slice
     }
-    initialized = true
-    prevSlice = slice
+    ref.prev = slice
     return slice
   })
   derivedAtom.scope = anAtom.scope


### PR DESCRIPTION
This is basically some refactor, as the original version I created had an issue with multiple provider scenario.
Basically, we shouldn't use/depend on any variable outside atoms.
`refAtom` is kind of a hack, but I don't know if there's a better way now.