### PR TITLE
fix(query): gracefully handle CancelledError

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -70,9 +70,9 @@
     }
   },
   "query.js": {
-    "bundled": 5170,
-    "minified": 2240,
-    "gzipped": 686,
+    "bundled": 5330,
+    "minified": 2351,
+    "gzipped": 746,
     "treeshaked": {
       "rollup": {
         "code": 105,

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -5,6 +5,7 @@ import {
   InfiniteData,
   InitialDataFunction,
   QueryObserverResult,
+  isCancelledError,
 } from 'react-query'
 import { atom } from 'jotai'
 import type { WritableAtom, Getter } from 'jotai'
@@ -87,7 +88,7 @@ export function atomWithInfiniteQuery<
           | QueryObserverResult<InfiniteData<TData>, TError>
           | { data?: undefined; error: TError }
       ) => {
-        if (result.error) {
+        if (result.error && !isCancelledError(result.error)) {
           if (settlePromise) {
             settlePromise(null, result.error)
             settlePromise = null


### PR DESCRIPTION
So this was a strange bug that I came upon. It would happen where I had an `atomWithInfiniteQuery` already loaded, and then navigated to a page that had that same query. It seems there is some [default cancellation behavior](https://github.com/tannerlinsley/react-query/blob/16b7d290c70639b627d9ada32951d211eac3adc3/src/core/infiniteQueryBehavior.ts#L118) in the way infiniteQueries work in react query.

I think this solution makes sense, and it fixes my bug (without this, the application breaks).