### PR TITLE
fix(query): subscribe instead of fetch if initialData

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -70,9 +70,9 @@
     }
   },
   "query.js": {
-    "bundled": 5223,
-    "minified": 2285,
-    "gzipped": 714,
+    "bundled": 5321,
+    "minified": 2315,
+    "gzipped": 721,
     "treeshaked": {
       "rollup": {
         "code": 105,

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -120,7 +120,7 @@ export function atomWithInfiniteQuery<
 
       const observer = new InfiniteQueryObserver(queryClient, defaultedOptions)
 
-      if (!defaultedOptions.initialData) {
+      if (!getInitialData()) {
         observer
           .fetchOptimistic(defaultedOptions)
           .then(listener)

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -61,11 +61,14 @@ export function atomWithInfiniteQuery<
               >
             )()
           : options.initialData
+
+      const initialData = getInitialData()
+
       const dataAtom = atom<
         | InfiniteData<TData | TQueryData>
         | Promise<InfiniteData<TData | TQueryData>>
       >(
-        getInitialData() ||
+        initialData ||
           new Promise<InfiniteData<TData>>((resolve, reject) => {
             settlePromise = (data, err) => {
               if (err) {
@@ -120,7 +123,7 @@ export function atomWithInfiniteQuery<
 
       const observer = new InfiniteQueryObserver(queryClient, defaultedOptions)
 
-      if (!getInitialData()) {
+      if (!initialData) {
         observer
           .fetchOptimistic(defaultedOptions)
           .then(listener)

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -120,10 +120,12 @@ export function atomWithInfiniteQuery<
 
       const observer = new InfiniteQueryObserver(queryClient, defaultedOptions)
 
-      observer
-        .fetchOptimistic(defaultedOptions)
-        .then(listener)
-        .catch((error) => listener({ error }))
+      if (!defaultedOptions.initialData) {
+        observer
+          .fetchOptimistic(defaultedOptions)
+          .then(listener)
+          .catch((error) => listener({ error }))
+      }
 
       dataAtom.onMount = (update) => {
         setData = update

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -95,10 +95,12 @@ export function atomWithQuery<
         defaultedOptions.staleTime = 1000
       }
       const observer = new QueryObserver(queryClient, defaultedOptions)
-      observer
-        .fetchOptimistic(defaultedOptions)
-        .then(listener)
-        .catch((error) => listener({ error }))
+      if (!defaultedOptions.initialData) {
+        observer
+          .fetchOptimistic(defaultedOptions)
+          .then(listener)
+          .catch((error) => listener({ error }))
+      }
       dataAtom.onMount = (update) => {
         setData = update
         const unsubscribe = observer.subscribe(listener)

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -95,7 +95,7 @@ export function atomWithQuery<
         defaultedOptions.staleTime = 1000
       }
       const observer = new QueryObserver(queryClient, defaultedOptions)
-      if (!defaultedOptions.initialData) {
+      if (!getInitialData()) {
         observer
           .fetchOptimistic(defaultedOptions)
           .then(listener)

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -46,8 +46,11 @@ export function atomWithQuery<
         typeof options.initialData === 'function'
           ? (options.initialData as InitialDataFunction<TQueryData>)()
           : options.initialData
+
+      const initialData = getInitialData()
+
       const dataAtom = atom<TData | TQueryData | Promise<TData | TQueryData>>(
-        getInitialData() ||
+        initialData ||
           new Promise<TData>((resolve, reject) => {
             settlePromise = (data, err) => {
               if (err) {
@@ -95,7 +98,7 @@ export function atomWithQuery<
         defaultedOptions.staleTime = 1000
       }
       const observer = new QueryObserver(queryClient, defaultedOptions)
-      if (!getInitialData()) {
+      if (!initialData) {
         observer
           .fetchOptimistic(defaultedOptions)
           .then(listener)

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -271,14 +271,15 @@ it('query with enabled (#500)', async () => {
 })
 
 it('query with initialData test', async () => {
+  const mockFetch = jest.fn(fakeFetch)
+
   const countAtom = atomWithQuery(() => ({
     queryKey: 'count1',
     queryFn: async () => {
-      return await fakeFetch({ count: 10 }) // will run after "initialData"
+      return await mockFetch({ count: 10 })
     },
     initialData: { response: { count: 0 } },
-    keepPreviousData: true, // to prevent suspense on refresh
-    refetchInterval: 0, // to immediately refresh (after mount) to count: 10
+    refetchInterval: 100,
   }))
   const Counter: React.FC = () => {
     const [
@@ -301,5 +302,7 @@ it('query with initialData test', async () => {
 
   // NOTE: the atom never suspends
   await findByText('count: 0')
+  expect(mockFetch).toHaveBeenCalledTimes(0)
   await findByText('count: 10')
+  expect(mockFetch).toHaveBeenCalledTimes(1)
 })


### PR DESCRIPTION
While doing some more testing, I noticed that on mount a query would automatically refetch even though I had provided `initialData` to it. I could not stop this behavior -- based off of reading https://react-query.tanstack.com/guides/initial-query-data#_top, it is the case that initialData will be treated as fresh until the staleTime has been met, or based on other user options passed (meaning a fetch should not happen until it become stale, and there have been some refetch options passed)

Because we were automatically running the fetchOptimistic method regardless of if initialData was passed, we were causing an unneeded fetch to happen. React query will pick up and take over and do all the fetching if needed when there is initialData. We are already subscribing on mount, so there is no need to fetch during the initial get.