### PR TITLE
fix: support atom scope outside core

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -1,4 +1,4 @@
-export { queryClientAtom, getQueryClientAtom } from './query/queryClientAtom'
+export { queryClientAtom } from './query/queryClientAtom'
 export { atomWithQuery } from './query/atomWithQuery'
 export { atomWithInfiniteQuery } from './query/atomWithInfiniteQuery'
 export type {

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -1,4 +1,5 @@
 import {
+  QueryClient,
   QueryKey,
   QueryObserver,
   QueryObserverOptions,
@@ -7,7 +8,7 @@ import {
 } from 'react-query'
 import { atom } from 'jotai'
 import type { WritableAtom, PrimitiveAtom, Getter } from 'jotai'
-import { getQueryClientAtom } from './queryClientAtom'
+import { queryClientAtom } from './queryClientAtom'
 
 export type AtomWithQueryAction = { type: 'refetch' }
 
@@ -27,7 +28,8 @@ export function atomWithQuery<
     | ((
         get: Getter
       ) => AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>),
-  equalityFn: (a: TData, b: TData) => boolean = Object.is
+  equalityFn: (a: TData, b: TData) => boolean = Object.is,
+  getQueryClient: (get: Getter) => QueryClient = (get) => get(queryClientAtom)
 ): WritableAtom<TData | TQueryData, AtomWithQueryAction> {
   const queryDataAtom: WritableAtom<
     {
@@ -37,7 +39,7 @@ export function atomWithQuery<
     AtomWithQueryAction
   > = atom(
     (get) => {
-      const queryClient = get(getQueryClientAtom)
+      const queryClient = getQueryClient(get)
       const options =
         typeof createQuery === 'function' ? createQuery(get) : createQuery
       let settlePromise: ((data: TData | null, err?: TError) => void) | null =
@@ -58,6 +60,7 @@ export function atomWithQuery<
             }
           })
       )
+      dataAtom.scope = queryAtom.scope
       let setData: (data: TData | Promise<TData>) => void = () => {
         throw new Error('atomWithQuery: setting data without mount')
       }
@@ -109,6 +112,7 @@ export function atomWithQuery<
     (get, set, action: AtomWithQueryAction) => {
       switch (action.type) {
         case 'refetch': {
+          queryDataAtom.scope = queryAtom.scope
           const { dataAtom, observer } = get(queryDataAtom)
           set(dataAtom, new Promise<TData>(() => {})) // infinite pending
           const p = observer.refetch({ cancelRefetch: true }).then(() => {})
@@ -119,10 +123,14 @@ export function atomWithQuery<
   )
   const queryAtom = atom<TData | TQueryData, AtomWithQueryAction>(
     (get) => {
+      queryDataAtom.scope = queryAtom.scope
       const { dataAtom } = get(queryDataAtom)
       return get(dataAtom)
     },
-    (_get, set, action) => set(queryDataAtom, action) // delegate action
+    (_get, set, action) => {
+      queryDataAtom.scope = queryAtom.scope
+      set(queryDataAtom, action) // delegate action
+    }
   )
   return queryAtom
 }

--- a/src/query/queryClientAtom.ts
+++ b/src/query/queryClientAtom.ts
@@ -1,8 +1,4 @@
 import { atom } from 'jotai'
 import { QueryClient } from 'react-query'
 
-export const queryClientAtom = atom<QueryClient | null>(null)
-
-export const getQueryClientAtom = atom(
-  (get) => get(queryClientAtom) || new QueryClient()
-)
+export const queryClientAtom = atom(new QueryClient())

--- a/src/redux/atomWithStore.ts
+++ b/src/redux/atomWithStore.ts
@@ -14,7 +14,10 @@ export function atomWithStore<State, A extends Action = AnyAction>(
     return unsub
   }
   const derivedAtom = atom(
-    (get) => get(baseAtom),
+    (get) => {
+      baseAtom.scope = derivedAtom.scope
+      return get(baseAtom)
+    },
     (_get, _set, action: A) => {
       store.dispatch(action)
     }

--- a/src/urql/atomWithQuery.ts
+++ b/src/urql/atomWithQuery.ts
@@ -8,7 +8,7 @@ import {
 } from '@urql/core'
 import { atom } from 'jotai'
 import type { Getter } from 'jotai'
-import { getClientAtom } from './clientAtom'
+import { clientAtom } from './clientAtom'
 
 type QueryArgs<Data, Variables extends object> = {
   query: TypedDocumentNode<Data, Variables> | string
@@ -19,7 +19,7 @@ type QueryArgs<Data, Variables extends object> = {
 
 export function atomWithQuery<Data, Variables extends object>(
   createQueryArgs: (get: Getter) => QueryArgs<Data, Variables>,
-  getClient: (get: Getter) => Client = (get) => get(getClientAtom)
+  getClient: (get: Getter) => Client = (get) => get(clientAtom)
 ) {
   const queryResultAtom = atom((get) => {
     const client = getClient(get)
@@ -34,6 +34,7 @@ export function atomWithQuery<Data, Variables extends object>(
         resolve = r
       })
     )
+    resultAtom.scope = queryAtom.scope
     let setResult: (result: OperationResult<Data, Variables>) => void = () => {
       throw new Error('setting result without mount')
     }
@@ -69,6 +70,7 @@ export function atomWithQuery<Data, Variables extends object>(
     return { resultAtom, args }
   })
   const queryAtom = atom((get) => {
+    queryResultAtom.scope = queryAtom.scope
     const { resultAtom } = get(queryResultAtom)
     return get(resultAtom)
   })

--- a/src/urql/atomWithSubscription.ts
+++ b/src/urql/atomWithSubscription.ts
@@ -7,7 +7,7 @@ import {
 } from '@urql/core'
 import { atom } from 'jotai'
 import type { Getter } from 'jotai'
-import { getClientAtom } from './clientAtom'
+import { clientAtom } from './clientAtom'
 
 type SubscriptionArgs<Data, Variables extends object> = {
   query: TypedDocumentNode<Data, Variables> | string
@@ -17,7 +17,7 @@ type SubscriptionArgs<Data, Variables extends object> = {
 
 export function atomWithSubscription<Data, Variables extends object>(
   createSubscriptionArgs: (get: Getter) => SubscriptionArgs<Data, Variables>,
-  getClient: (get: Getter) => Client = (get) => get(getClientAtom)
+  getClient: (get: Getter) => Client = (get) => get(clientAtom)
 ) {
   const queryResultAtom = atom((get) => {
     const client = getClient(get)
@@ -32,6 +32,7 @@ export function atomWithSubscription<Data, Variables extends object>(
         resolve = r
       })
     )
+    resultAtom.scope = queryAtom.scope
     let setResult: (result: OperationResult<Data, Variables>) => void = () => {
       throw new Error('setting result without mount')
     }
@@ -68,6 +69,7 @@ export function atomWithSubscription<Data, Variables extends object>(
     return { resultAtom, args }
   })
   const queryAtom = atom((get) => {
+    queryResultAtom.scope = queryAtom.scope
     const { resultAtom } = get(queryResultAtom)
     return get(resultAtom)
   })

--- a/src/urql/clientAtom.ts
+++ b/src/urql/clientAtom.ts
@@ -1,12 +1,8 @@
 import { atom } from 'jotai'
-import { Client, createClient } from '@urql/core'
+import { createClient } from '@urql/core'
 
 const DEFAULT_URL =
   (typeof process === 'object' && process.env.JOTAI_URQL_DEFAULT_URL) ||
   '/graphql'
 
-export const clientAtom = atom<Client | null>(null)
-
-export const getClientAtom = atom(
-  (get) => get(clientAtom) || createClient({ url: DEFAULT_URL })
-)
+export const clientAtom = atom(createClient({ url: DEFAULT_URL }))

--- a/src/utils/atomWithDefault.ts
+++ b/src/utils/atomWithDefault.ts
@@ -11,6 +11,7 @@ export function atomWithDefault<Value>(getDefault: Read<Value>) {
   const overwrittenAtom = atom<Value | typeof EMPTY>(EMPTY)
   const anAtom: WritableAtom<Value, Update> = atom(
     (get) => {
+      overwrittenAtom.scope = anAtom.scope
       const overwritten = get(overwrittenAtom)
       if (overwritten !== EMPTY) {
         return overwritten
@@ -18,6 +19,7 @@ export function atomWithDefault<Value>(getDefault: Read<Value>) {
       return getDefault(get)
     },
     (get, set, update) => {
+      overwrittenAtom.scope = anAtom.scope
       if (update === RESET) {
         set(overwrittenAtom, EMPTY)
       } else {

--- a/src/utils/atomWithStorage.ts
+++ b/src/utils/atomWithStorage.ts
@@ -68,8 +68,12 @@ export function atomWithStorage<Value>(
   }
 
   const anAtom = atom(
-    (get) => get(baseAtom),
+    (get) => {
+      baseAtom.scope = anAtom.scope
+      return get(baseAtom)
+    },
     (get, set, update: SetStateAction<Value>) => {
+      baseAtom.scope = anAtom.scope
       const newValue =
         typeof update === 'function'
           ? (update as (prev: Value) => Value)(get(baseAtom))

--- a/src/utils/selectAtom.ts
+++ b/src/utils/selectAtom.ts
@@ -15,6 +15,7 @@ export function selectAtom<Value, Slice>(
     return cachedAtom as Atom<Slice>
   }
   const refAtom = atom(() => ({} as { prev?: Slice }))
+  refAtom.scope = anAtom.scope
   const derivedAtom = atom((get) => {
     const slice = selector(get(anAtom))
     const ref = get(refAtom)

--- a/src/utils/splitAtom.ts
+++ b/src/utils/splitAtom.ts
@@ -46,6 +46,7 @@ export function splitAtom<Item, Key>(
         keyList?: Key[]
       })
   )
+  refAtom.scope = arrAtom.scope
   const read = (get: Getter) => {
     const ref = get(refAtom)
     let nextAtomList: Atom<Item>[] = []

--- a/src/valtio/atomWithProxy.ts
+++ b/src/valtio/atomWithProxy.ts
@@ -45,8 +45,12 @@ export function atomWithProxy<Value extends object>(proxyObject: Value) {
     return unsub
   }
   const derivedAtom = atom(
-    (get) => get(baseAtom) as Value,
+    (get) => {
+      baseAtom.scope = derivedAtom.scope
+      return get(baseAtom) as Value
+    },
     (get, _set, update: SetStateAction<Value>) => {
+      baseAtom.scope = derivedAtom.scope
       const newValue =
         typeof update === 'function'
           ? (update as (prev: Value) => Value)(get(baseAtom) as Value)

--- a/src/zustand/atomWithStore.ts
+++ b/src/zustand/atomWithStore.ts
@@ -13,8 +13,12 @@ export function atomWithStore<T extends State>(store: StoreApi<T>) {
     return unsub
   }
   const derivedAtom = atom(
-    (get) => get(baseAtom),
+    (get) => {
+      baseAtom.scope = derivedAtom.scope
+      return get(baseAtom)
+    },
     (get, _set, update: SetStateAction<T>) => {
+      baseAtom.scope = derivedAtom.scope
       const newState =
         typeof update === 'function'
           ? (update as (prev: T) => T)(get(baseAtom))


### PR DESCRIPTION
An internal discussion with @aulneau revealed that many of utils/integrations don't support atom scope properly, especially when we create internal atoms in a function.
This PR addresses the issue. Note this affects only the case using `scope`, which is mainly for library usage.