### PR TITLE
breaking(query): remove optional equalityFn from atomWith(Infinite)Query

### DIFF
--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -39,11 +39,7 @@ export function atomWithInfiniteQuery<
         TError,
         TData,
         TQueryData
-      >),
-  equalityFn: (
-    a: InfiniteData<TData>,
-    b: InfiniteData<TData>
-  ) => boolean = Object.is
+      >)
 ): WritableAtom<InfiniteData<TData | TQueryData>, AtomWithInfiniteQueryAction> {
   const queryDataAtom = atom(
     (get) => {
@@ -84,8 +80,6 @@ export function atomWithInfiniteQuery<
       ) => void = () => {
         throw new Error('atomWithInfiniteQuery: setting data without mount')
       }
-      let prevData: InfiniteData<TData> | null = null
-
       const listener = (
         result:
           | QueryObserverResult<InfiniteData<TData>, TError>
@@ -100,13 +94,9 @@ export function atomWithInfiniteQuery<
           }
           return
         }
-        if (
-          result.data === undefined ||
-          (prevData !== null && equalityFn(prevData, result.data))
-        ) {
+        if (result.data === undefined) {
           return
         }
-        prevData = result.data
         if (settlePromise) {
           settlePromise(result.data)
           settlePromise = null
@@ -137,7 +127,7 @@ export function atomWithInfiniteQuery<
       }
       return { dataAtom, observer, options }
     },
-    (get, set, action: AtomWithInfiniteQueryAction) => {
+    (get, _set, action: AtomWithInfiniteQueryAction) => {
       const { observer } = get(queryDataAtom)
       switch (action.type) {
         case 'refetch': {

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -26,8 +26,7 @@ export function atomWithQuery<
     | AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>
     | ((
         get: Getter
-      ) => AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>),
-  equalityFn: (a: TData, b: TData) => boolean = Object.is
+      ) => AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>)
 ): WritableAtom<TData | TQueryData, AtomWithQueryAction> {
   const queryDataAtom: WritableAtom<
     {
@@ -64,7 +63,6 @@ export function atomWithQuery<
       let setData: (data: TData | Promise<TData>) => void = () => {
         throw new Error('atomWithQuery: setting data without mount')
       }
-      let prevData: TData | null = null
       const listener = (
         result:
           | QueryObserverResult<TData, TError>
@@ -79,13 +77,9 @@ export function atomWithQuery<
           }
           return
         }
-        if (
-          result.data === undefined ||
-          (prevData !== null && equalityFn(prevData, result.data))
-        ) {
+        if (result.data === undefined) {
           return
         }
-        prevData = result.data
         if (settlePromise) {
           settlePromise(result.data)
           settlePromise = null


### PR DESCRIPTION
This is basically a commit reverting #386.

https://github.com/pmndrs/jotai/pull/589#discussion_r668949661 shows an alternative method, so I think this is not necessary.