### PR TITLE
feat(rxjs): Convert atomWithObservable to Observable spec

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -154,16 +154,16 @@
     }
   },
   "rxjs.js": {
-    "bundled": 1714,
-    "minified": 748,
-    "gzipped": 399,
+    "bundled": 2116,
+    "minified": 912,
+    "gzipped": 447,
     "treeshaked": {
       "rollup": {
-        "code": 37,
-        "import_statements": 37
+        "code": 103,
+        "import_statements": 14
       },
       "webpack": {
-        "code": 1054
+        "code": 1087
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -237,7 +237,6 @@
     "optics-ts": "*",
     "react": ">=16.8",
     "react-query": "*",
-    "rxjs": "*",
     "valtio": "*",
     "wonka": "*",
     "xstate": "*"


### PR DESCRIPTION
**This is a draft / WIP.**

Ref: #234

This converts `jotai/rxjs` over to a generic `atomWithObservable` that potentially supports all `Observable` libraries that adhere to the [Observable proposal.](https://github.com/tc39/proposal-observable)

To replace `first` the initial subscription unsubscribes at the earliest possible time, which takes synchronous (non-deferred) results into account. The `resultAtom.onMount` function will also now reuse the subscription if possible and otherwise start a new subscription, to match the previous implementation closely in its double-subscription behaviour.