### PR TITLE
breaking(rxjs): move atomWithObservable in utils

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -14,9 +14,9 @@
     }
   },
   "utils.js": {
-    "bundled": 13716,
-    "minified": 6895,
-    "gzipped": 2574,
+    "bundled": 15731,
+    "minified": 7669,
+    "gzipped": 2831,
     "treeshaked": {
       "rollup": {
         "code": 28,
@@ -150,20 +150,6 @@
       },
       "webpack": {
         "code": 1355
-      }
-    }
-  },
-  "rxjs.js": {
-    "bundled": 2116,
-    "minified": 912,
-    "gzipped": 447,
-    "treeshaked": {
-      "rollup": {
-        "code": 103,
-        "import_statements": 14
-      },
-      "webpack": {
-        "code": 1087
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -83,12 +83,6 @@
       "module": "./esm/urql.js",
       "import": "./esm/urql.js",
       "default": "./urql.js"
-    },
-    "./rxjs": {
-      "types": "./rxjs.d.ts",
-      "module": "./esm/rxjs.js",
-      "import": "./esm/rxjs.js",
-      "default": "./rxjs.js"
     }
   },
   "files": [
@@ -109,7 +103,6 @@
     "build:zustand": "rollup -c --config-zustand",
     "build:redux": "rollup -c --config-redux",
     "build:urql": "rollup -c --config-urql",
-    "build:rxjs": "rollup -c --config-rxjs",
     "postbuild": "yarn copy",
     "eslint": "eslint --fix '{src,tests,benchmarks}/**/*.{js,ts,jsx,tsx}'",
     "eslint:ci": "eslint '{src,tests,benchmarks}/**/*.{js,ts,jsx,tsx}'",
@@ -252,9 +245,6 @@
       "optional": true
     },
     "react-query": {
-      "optional": true
-    },
-    "rxjs": {
       "optional": true
     },
     "valtio": {

--- a/src/rxjs.ts
+++ b/src/rxjs.ts
@@ -1,1 +1,0 @@
-export { atomWithObservable } from './rxjs/atomWithObservable'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,3 +17,4 @@ export {
   atomWithHash,
   createJSONStorage,
 } from './utils/atomWithStorage'
+export { atomWithObservable } from './utils/atomWithObservable'

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -2,7 +2,7 @@ import React, { Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { getTestProvider } from '../testUtils'
 import { useAtom } from '../../src/index'
-import { atomWithObservable } from '../../src/rxjs'
+import { atomWithObservable } from '../../src/utils'
 import { Observable, Subject } from 'rxjs'
 
 const Provider = getTestProvider()


### PR DESCRIPTION
Thanks to #593, atomWithObservable doesn't depend on rxjs, so moving to utils. Modified a bit to fit with coding styles.