### PR TITLE
fix(examples, tests): use `useUpdateAtom` and write-only atoms to avoid re-render

### DIFF
--- a/examples/hacker_news/src/App.tsx
+++ b/examples/hacker_news/src/App.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import Parser from 'html-react-parser'
 import { Provider, atom, useAtom } from 'jotai'
+import { useUpdateAtom } from 'jotai/utils'
 import { a, useSpring } from '@react-spring/web'
 
 type PostData = {
@@ -13,7 +14,7 @@ type PostData = {
   text?: string
   time: number
   title?: string
-  type: "comment" | "story"
+  type: 'comment' | 'story'
   url?: string
 }
 
@@ -33,9 +34,11 @@ function Id() {
 }
 
 function Next() {
-  const [, set] = useAtom(postId)
+  // Use `useUpdateAtom` to avoid re-render
+  // const [, set] = useAtom(postId)
+  const setPostId = useUpdateAtom(postId)
   return (
-    <button onClick={() => set((x) => x + 1)}>
+    <button onClick={() => setPostId((id) => id + 1)}>
       <div>→</div>
     </button>
   )

--- a/examples/todos/src/App.tsx
+++ b/examples/todos/src/App.tsx
@@ -1,5 +1,6 @@
 import { FC, FormEvent } from 'react'
 import { Provider, atom, useAtom, PrimitiveAtom } from 'jotai'
+import { useUpdateAtom } from 'jotai/utils'
 import { Radio } from 'antd'
 import { CloseOutlined } from '@ant-design/icons'
 import { a, useTransition } from '@react-spring/web'
@@ -74,7 +75,9 @@ const Filtered: FC<FilteredType> = (props) => {
 }
 
 const TodoList = () => {
-  const [, setTodos] = useAtom(todosAtom)
+  // Use `useUpdateAtom` to avoid re-render
+  // const [, setTodos] = useAtom(todosAtom)
+  const setTodos = useUpdateAtom(todosAtom)
   const remove: RemoveFn = (todo) =>
     setTodos((prev) => prev.filter((item) => item !== todo))
   const add = (e: FormEvent<HTMLFormElement>) => {

--- a/examples/todos_with_atomFamily/src/App.tsx
+++ b/examples/todos_with_atomFamily/src/App.tsx
@@ -1,6 +1,6 @@
 import { FC, FormEvent } from 'react'
 import { Provider, atom, useAtom } from 'jotai'
-import { atomFamily } from 'jotai/utils'
+import { atomFamily, useUpdateAtom } from 'jotai/utils'
 import { nanoid } from 'nanoid'
 import { Radio } from 'antd'
 import { CloseOutlined } from '@ant-design/icons'
@@ -74,7 +74,9 @@ const Filtered: FC<{
 }
 
 const TodoList = () => {
-  const [, setTodos] = useAtom(todosAtom)
+  // Use `useUpdateAtom` to avoid re-render
+  // const [, setTodos] = useAtom(todosAtom)
+  const setTodos = useUpdateAtom(todosAtom)
   const remove = (id: string) => {
     setTodos((prev) => prev.filter((item) => item !== id))
     todoAtomFamily.remove({ id })

--- a/tests/items.test.tsx
+++ b/tests/items.test.tsx
@@ -94,13 +94,18 @@ it('add an item with filtered list', async () => {
     text: string
     checked: boolean
   }
+  type ItemAtoms = PrimitiveAtom<Item>[]
+  type Update = (prev: ItemAtoms) => ItemAtoms
 
   let itemIndex = 0
-  const itemsAtom = atom<PrimitiveAtom<Item>[]>([])
+  const itemAtomsAtom = atom<ItemAtoms>([])
+  const setItemsAtom = atom<null, Update>(null, (_get, set, update) =>
+    set(itemAtomsAtom, update)
+  )
   const filterAtom = atom<'all' | 'checked' | 'not-checked'>('all')
   const filteredAtom = atom((get) => {
     const filter = get(filterAtom)
-    const items = get(itemsAtom)
+    const items = get(itemAtomsAtom)
     if (filter === 'all') return items
     else if (filter === 'checked')
       return items.filter((atom) => get(atom).checked)
@@ -155,7 +160,7 @@ it('add an item with filtered list', async () => {
   }
 
   const List: React.FC = () => {
-    const [, setItems] = useAtom(itemsAtom)
+    const [, setItems] = useAtom(setItemsAtom)
     const addItem = () => {
       setItems((prev) => [
         ...prev,

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -213,7 +213,11 @@ it('query loading 2', async () => {
 })
 
 it('query with enabled (#500)', async () => {
+  type Update = (prev: boolean) => boolean
   const enabledAtom = atom(true)
+  const setEnabledAtom = atom<null, Update>(null, (_get, set, update) =>
+    set(enabledAtom, update)
+  )
   const countAtom = atomWithQuery((get) => {
     const enabled = get(enabledAtom)
     return {
@@ -236,7 +240,7 @@ it('query with enabled (#500)', async () => {
 
   const Parent: React.FC = () => {
     const [showChildren, setShowChildren] = useState(true)
-    const [, setEnabled] = useAtom(enabledAtom)
+    const [, setEnabled] = useAtom(setEnabledAtom)
     return (
       <div>
         <button

--- a/tests/urql/atomWithQuery.test.tsx
+++ b/tests/urql/atomWithQuery.test.tsx
@@ -52,7 +52,11 @@ it('query basic test', async () => {
 })
 
 it('query dependency test', async () => {
+  type Update = (prev: number) => number
   const dummyAtom = atom(10)
+  const setDummyAtom = atom<null, Update>(null, (_get, set, update) =>
+    set(dummyAtom, update)
+  )
   const countAtom = atomWithQuery<{ count: number }, { dummy: number }>(
     (get) => ({
       query: '{ count }',
@@ -73,7 +77,7 @@ it('query dependency test', async () => {
   }
 
   const Controls: React.FC = () => {
-    const [, setDummy] = useAtom(dummyAtom)
+    const [, setDummy] = useAtom(setDummyAtom)
     return <button onClick={() => setDummy((c) => c + 1)}>dummy</button>
   }
 

--- a/tests/utils/atomFamily.test.tsx
+++ b/tests/utils/atomFamily.test.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect, StrictMode, Suspense } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from '../../src/index'
 import type { WritableAtom, SetStateAction } from '../../src/index'
-import { atomFamily } from '../../src/utils'
+import { atomFamily, useUpdateAtom } from '../../src/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
@@ -229,7 +229,7 @@ it('a derived atom from an async atomFamily (#351)', async () => {
   const derivedAtom = atom((get) => get(getAsyncAtom(get(countAtom))))
 
   const Counter: React.FC = () => {
-    const [, setCount] = useAtom(countAtom)
+    const setCount = useUpdateAtom(countAtom)
     const [derived] = useAtom(derivedAtom)
     return (
       <>

--- a/tests/utils/waitForAll.test.tsx
+++ b/tests/utils/waitForAll.test.tsx
@@ -1,7 +1,7 @@
 import React, { StrictMode, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom, useAtom } from '../../src/index'
-import { waitForAll } from '../../src/utils'
+import { waitForAll, useUpdateAtom } from '../../src/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
@@ -258,7 +258,7 @@ it('handles scope', async () => {
 
   const Counter: React.FC = () => {
     const [[num1, num2]] = useAtom(waitForAll([asyncAtom, anotherAsyncAtom]))
-    const [, setValue] = useAtom(valueAtom)
+    const setValue = useUpdateAtom(valueAtom)
     return (
       <>
         <div>


### PR DESCRIPTION
Response to the call for this [issue](https://github.com/pmndrs/jotai/issues/26#issuecomment-691588119)
> The utility hooks can get big. I need someone to volunteer to help it, especially for documentation & examples.