### PR TITLE
chore(imports): enforce a convention in module import order

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,14 @@
     "plugin:import/errors",
     "plugin:import/warnings"
   ],
-  "plugins": ["@typescript-eslint", "react", "prettier", "react-hooks", "import", "jest"],
+  "plugins": [
+    "@typescript-eslint",
+    "react",
+    "prettier",
+    "react-hooks",
+    "import",
+    "jest"
+  ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2018,
@@ -31,15 +38,22 @@
       "import/namespace": "off",
       "import/default": "off",
       "@typescript-eslint/explicit-module-boundary-types": "off",
-      "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
-      "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+      "no-unused-vars": [
+        "warn",
+        { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
+      ],
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
+      ],
       "@typescript-eslint/no-use-before-define": "off",
       "@typescript-eslint/no-empty-function": "off",
       "@typescript-eslint/no-empty-interface": "off",
       "@typescript-eslint/no-explicit-any": "off",
-      "jest/consistent-test-it": ["error", { "fn": "it", "withinDescribe": "it" }],
-      "react/jsx-uses-react": "off",
-      "react/react-in-jsx-scope": "off"
+      "jest/consistent-test-it": [
+        "error",
+        { "fn": "it", "withinDescribe": "it" }
+      ]
     }
   },
   "settings": {
@@ -66,6 +80,43 @@
       "files": ["src"],
       "parserOptions": {
         "project": "./tsconfig.json"
+      }
+    },
+    {
+      "files": ["./**/*.{js,jsx,ts,tsx}"],
+      "rules": {
+        "import/order": [
+          "error",
+          {
+            "alphabetize": { "order": "asc", "caseInsensitive": true },
+            "groups": [
+              "builtin",
+              "external",
+              "internal",
+              "parent",
+              "sibling",
+              "index",
+              "object"
+            ],
+            "newlines-between": "never",
+            "pathGroups": [
+              {
+                "pattern": "react",
+                "group": "builtin",
+                "position": "before"
+              }
+            ],
+            "pathGroupsExcludedImportTypes": ["builtin"]
+          }
+        ],
+        "react/jsx-uses-react": "off",
+        "react/react-in-jsx-scope": "off",
+        "sort-imports": [
+          "error",
+          {
+            "ignoreDeclarationSort": true
+          }
+        ]
       }
     }
   ]

--- a/benchmarks/simple-read.ts
+++ b/benchmarks/simple-read.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env npx ts-node
 
 import { add, complete, cycle, save, suite } from 'benny'
-
 import { atom } from '../src/core/atom'
 import type { PrimitiveAtom } from '../src/core/atom'
 import { createState, readAtom } from '../src/core/vanilla'

--- a/benchmarks/simple-write.ts
+++ b/benchmarks/simple-write.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env npx ts-node
 
 import { add, complete, cycle, save, suite } from 'benny'
-
 import { atom } from '../src/core/atom'
 import type { PrimitiveAtom } from '../src/core/atom'
 import { createState, writeAtom } from '../src/core/vanilla'

--- a/benchmarks/subscribe-write.ts
+++ b/benchmarks/subscribe-write.ts
@@ -1,14 +1,13 @@
 #!/usr/bin/env npx ts-node
 
 import { add, complete, cycle, save, suite } from 'benny'
-
 import { atom } from '../src/core/atom'
 import type { PrimitiveAtom } from '../src/core/atom'
 import {
   createState,
   readAtom,
-  writeAtom,
   subscribeAtom,
+  writeAtom,
 } from '../src/core/vanilla'
 
 const cleanupFns = new Set<() => void>()

--- a/examples/hacker_news/src/App.tsx
+++ b/examples/hacker_news/src/App.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from 'react'
+import { a, useSpring } from '@react-spring/web'
 import Parser from 'html-react-parser'
 import { Provider, atom, useAtom } from 'jotai'
 import { useUpdateAtom } from 'jotai/utils'
-import { a, useSpring } from '@react-spring/web'
 
 type PostData = {
   by: string

--- a/examples/hello/src/App.tsx
+++ b/examples/hello/src/App.tsx
@@ -1,5 +1,4 @@
 import { atom, useAtom } from 'jotai'
-
 // @ts-ignore
 import PrismCode from 'react-prism'
 import 'prismjs'

--- a/examples/mega-form/src/App.tsx
+++ b/examples/mega-form/src/App.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useCallback } from 'react'
-import { Provider, atom, useAtom, PrimitiveAtom } from 'jotai'
+import { useCallback, useMemo } from 'react'
+import { PrimitiveAtom, Provider, atom, useAtom } from 'jotai'
 import { focusAtom } from 'jotai/optics'
 import { useAtomCallback } from 'jotai/utils'
 import initialValue from './initialValue'

--- a/examples/mega-form/src/useAtomSlice.ts
+++ b/examples/mega-form/src/useAtomSlice.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { useAtom, PrimitiveAtom } from 'jotai'
+import { PrimitiveAtom, useAtom } from 'jotai'
 import { splitAtom } from 'jotai/utils'
 
 const useAtomSlice = <Item>(arrAtom: PrimitiveAtom<Item[]>) => {

--- a/examples/text_length/src/index.tsx
+++ b/examples/text_length/src/index.tsx
@@ -1,6 +1,5 @@
 import { StrictMode } from 'react'
 import ReactDOM from 'react-dom'
-
 import App from './App'
 
 const rootElement = document.getElementById('root')

--- a/examples/todos/src/App.tsx
+++ b/examples/todos/src/App.tsx
@@ -1,9 +1,9 @@
 import { FC, FormEvent } from 'react'
-import { Provider, atom, useAtom, PrimitiveAtom } from 'jotai'
-import { useUpdateAtom } from 'jotai/utils'
-import { Radio } from 'antd'
 import { CloseOutlined } from '@ant-design/icons'
 import { a, useTransition } from '@react-spring/web'
+import { Radio } from 'antd'
+import { PrimitiveAtom, Provider, atom, useAtom } from 'jotai'
+import { useUpdateAtom } from 'jotai/utils'
 
 type Todo = {
   title: string

--- a/examples/todos_with_atomFamily/src/App.tsx
+++ b/examples/todos_with_atomFamily/src/App.tsx
@@ -1,10 +1,10 @@
 import { FC, FormEvent } from 'react'
+import { CloseOutlined } from '@ant-design/icons'
+import { a, useTransition } from '@react-spring/web'
+import { Radio } from 'antd'
 import { Provider, atom, useAtom } from 'jotai'
 import { atomFamily, useUpdateAtom } from 'jotai/utils'
 import { nanoid } from 'nanoid'
-import { Radio } from 'antd'
-import { CloseOutlined } from '@ant-design/icons'
-import { a, useTransition } from '@react-spring/web'
 
 type Param = { id: string; title?: string }
 const todoAtomFamily = atomFamily(

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,9 +1,9 @@
-import { createElement, useRef, useDebugValue, FC } from 'react'
+import { FC, createElement, useDebugValue, useRef } from 'react'
 import type { Atom, Scope } from './atom'
-import type { AtomState, State } from './vanilla'
-import type { StoreForDevelopment } from './contexts'
 import { createStore, getStoreContext, isDevStore } from './contexts'
+import type { StoreForDevelopment } from './contexts'
 import { useMutableSource } from './useMutableSource'
+import type { AtomState, State } from './vanilla'
 
 export const Provider: FC<{
   initialValues?: Iterable<readonly [Atom<unknown>, unknown]>

--- a/src/core/contexts.ts
+++ b/src/core/contexts.ts
@@ -1,10 +1,9 @@
 import { createContext } from 'react'
 import type { Context } from 'react'
-
-import type { Atom, WritableAtom, Scope } from './atom'
-import { createState, writeAtom, restoreAtoms, flushPending } from './vanilla'
-import type { State } from './vanilla'
+import type { Atom, Scope, WritableAtom } from './atom'
 import { createMutableSource } from './useMutableSource'
+import { createState, flushPending, restoreAtoms, writeAtom } from './vanilla'
+import type { State } from './vanilla'
 
 type MutableSource<_Target> = ReturnType<typeof createMutableSource>
 

--- a/src/core/typeUtils.ts
+++ b/src/core/typeUtils.ts
@@ -1,4 +1,4 @@
-import type { Atom, WritableAtom, PrimitiveAtom } from './atom'
+import type { Atom, PrimitiveAtom, WritableAtom } from './atom'
 
 export type Getter = Parameters<Atom<unknown>['read']>[0]
 export type Setter = Parameters<WritableAtom<unknown, unknown>['write']>[1]

--- a/src/core/useAtom.ts
+++ b/src/core/useAtom.ts
@@ -1,10 +1,9 @@
-import { useContext, useEffect, useCallback, useDebugValue } from 'react'
-
+import { useCallback, useContext, useDebugValue, useEffect } from 'react'
+import type { Atom, SetAtom, WritableAtom } from './atom'
 import { getStoreContext } from './contexts'
+import { useMutableSource } from './useMutableSource'
 import { readAtom, subscribeAtom } from './vanilla'
 import type { State } from './vanilla'
-import type { Atom, WritableAtom, SetAtom } from './atom'
-import { useMutableSource } from './useMutableSource'
 
 const isWritable = <Value, Update>(
   atom: Atom<Value> | WritableAtom<Value, Update>

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useAtom, WritableAtom } from 'jotai'
+import { WritableAtom, useAtom } from 'jotai'
 
 type Config = {
   instanceID?: number

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -3,11 +3,10 @@ import {
   SECRET_INTERNAL_getStoreContext as getStoreContext,
   SECRET_INTERNAL_useMutableSource as useMutableSource,
 } from 'jotai'
-
 import type { Atom, Scope } from '../core/atom'
+import { getDebugStateAndAtoms, subscribeDebugStore } from '../core/Provider'
 import type { AtomState, State } from '../core/vanilla'
 // NOTE this is across bundles and actually copying code
-import { getDebugStateAndAtoms, subscribeDebugStore } from '../core/Provider'
 
 type AtomsSnapshot = Map<Atom<unknown>, unknown>
 

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -6,7 +6,7 @@ import {
 import type { Atom, Scope } from '../core/atom'
 import { getDebugStateAndAtoms, subscribeDebugStore } from '../core/Provider'
 import type { AtomState, State } from '../core/vanilla'
-// NOTE this is across bundles and actually copying code
+// NOTE importing from '../core/Provider' is across bundles and actually copying code
 
 type AtomsSnapshot = Map<Atom<unknown>, unknown>
 

--- a/src/devtools/useGotoAtomsSnapshot.ts
+++ b/src/devtools/useGotoAtomsSnapshot.ts
@@ -2,7 +2,7 @@ import { useCallback, useContext } from 'react'
 import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
 import type { Scope } from '../core/atom'
 import { isDevStore } from '../core/contexts'
-// NOTE this is across bundles and actually copying code
+// NOTE importing from '../core/contexts' is across bundles and actually copying code
 
 export function useGotoAtomsSnapshot(scope?: Scope) {
   const StoreContext = getStoreContext(scope)

--- a/src/devtools/useGotoAtomsSnapshot.ts
+++ b/src/devtools/useGotoAtomsSnapshot.ts
@@ -1,9 +1,8 @@
 import { useCallback, useContext } from 'react'
 import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
-
 import type { Scope } from '../core/atom'
-// NOTE this is across bundles and actually copying code
 import { isDevStore } from '../core/contexts'
+// NOTE this is across bundles and actually copying code
 
 export function useGotoAtomsSnapshot(scope?: Scope) {
   const StoreContext = getStoreContext(scope)

--- a/src/immer/atomWithImmer.ts
+++ b/src/immer/atomWithImmer.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/named */
-import { produce, Draft } from 'immer'
-import { atom, WritableAtom } from 'jotai'
+import { Draft, produce } from 'immer'
+import { WritableAtom, atom } from 'jotai'
 
 export function atomWithImmer<Value>(
   initialValue: Value

--- a/src/immer/useImmerAtom.ts
+++ b/src/immer/useImmerAtom.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/named */
 import { useCallback } from 'react'
-import { produce, Draft } from 'immer'
+import { Draft, produce } from 'immer'
 import { WritableAtom, useAtom } from 'jotai'
 
 export function useImmerAtom<Value>(

--- a/src/immer/withImmer.ts
+++ b/src/immer/withImmer.ts
@@ -1,7 +1,6 @@
 /* eslint-disable import/named */
-import { produce, Draft } from 'immer'
+import { Draft, produce } from 'immer'
 import { PrimitiveAtom, WritableAtom, atom } from 'jotai'
-
 import { getWeakCacheItem, setWeakCacheItem } from '../utils/weakCache'
 
 const withImmerCache = new WeakMap()

--- a/src/optics/focusAtom.ts
+++ b/src/optics/focusAtom.ts
@@ -1,10 +1,10 @@
-import { atom } from 'jotai'
-import type { WritableAtom, SetStateAction } from 'jotai'
 import * as O from 'optics-ts'
+import { atom } from 'jotai'
+import type { SetStateAction, WritableAtom } from 'jotai'
 import {
+  WeakCache,
   getWeakCacheItem,
   setWeakCacheItem,
-  WeakCache,
 } from '../utils/weakCache'
 
 const focusAtomCache: WeakCache<WritableAtom<any, any>> = new WeakMap()

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -1,15 +1,15 @@
 import {
-  QueryClient,
-  QueryKey,
+  InfiniteData,
   InfiniteQueryObserver,
   InfiniteQueryObserverOptions,
-  InfiniteData,
   InitialDataFunction,
+  QueryClient,
+  QueryKey,
   QueryObserverResult,
   isCancelledError,
 } from 'react-query'
 import { atom } from 'jotai'
-import type { WritableAtom, Getter } from 'jotai'
+import type { Getter, WritableAtom } from 'jotai'
 import { queryClientAtom } from './queryClientAtom'
 
 export type AtomWithInfiniteQueryAction = {

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -1,13 +1,13 @@
 import {
+  InitialDataFunction,
   QueryClient,
   QueryKey,
   QueryObserver,
   QueryObserverOptions,
   QueryObserverResult,
-  InitialDataFunction,
 } from 'react-query'
 import { atom } from 'jotai'
-import type { WritableAtom, PrimitiveAtom, Getter } from 'jotai'
+import type { Getter, PrimitiveAtom, WritableAtom } from 'jotai'
 import { queryClientAtom } from './queryClientAtom'
 
 export type AtomWithQueryAction = { type: 'refetch' }

--- a/src/query/queryClientAtom.ts
+++ b/src/query/queryClientAtom.ts
@@ -1,4 +1,4 @@
-import { atom } from 'jotai'
 import { QueryClient } from 'react-query'
+import { atom } from 'jotai'
 
 export const queryClientAtom = atom(new QueryClient())

--- a/src/redux/atomWithStore.ts
+++ b/src/redux/atomWithStore.ts
@@ -1,4 +1,4 @@
-import type { Store, Action, AnyAction } from 'redux'
+import type { Action, AnyAction, Store } from 'redux'
 import { atom } from 'jotai'
 
 export function atomWithStore<State, A extends Action = AnyAction>(

--- a/src/urql/atomWithMutation.ts
+++ b/src/urql/atomWithMutation.ts
@@ -1,8 +1,8 @@
 import {
   Client,
-  TypedDocumentNode,
   OperationContext,
   OperationResult,
+  TypedDocumentNode,
 } from '@urql/core'
 import { atom } from 'jotai'
 import type { Getter } from 'jotai'

--- a/src/urql/atomWithQuery.ts
+++ b/src/urql/atomWithQuery.ts
@@ -1,11 +1,11 @@
-import { pipe, subscribe } from 'wonka'
 import {
   Client,
-  TypedDocumentNode,
   OperationContext,
   OperationResult,
   RequestPolicy,
+  TypedDocumentNode,
 } from '@urql/core'
+import { pipe, subscribe } from 'wonka'
 import { atom } from 'jotai'
 import type { Getter } from 'jotai'
 import { clientAtom } from './clientAtom'

--- a/src/urql/atomWithSubscription.ts
+++ b/src/urql/atomWithSubscription.ts
@@ -1,10 +1,10 @@
-import { pipe, subscribe } from 'wonka'
 import {
   Client,
-  TypedDocumentNode,
   OperationContext,
   OperationResult,
+  TypedDocumentNode,
 } from '@urql/core'
+import { pipe, subscribe } from 'wonka'
 import { atom } from 'jotai'
 import type { Getter } from 'jotai'
 import { clientAtom } from './clientAtom'

--- a/src/urql/clientAtom.ts
+++ b/src/urql/clientAtom.ts
@@ -1,5 +1,5 @@
-import { atom } from 'jotai'
 import { createClient } from '@urql/core'
+import { atom } from 'jotai'
 
 const DEFAULT_URL =
   (typeof process === 'object' && process.env.JOTAI_URQL_DEFAULT_URL) ||

--- a/src/utils/atomWithDefault.ts
+++ b/src/utils/atomWithDefault.ts
@@ -1,6 +1,5 @@
 import { atom } from 'jotai'
-import type { Atom, WritableAtom, SetStateAction } from 'jotai'
-
+import type { Atom, SetStateAction, WritableAtom } from 'jotai'
 import { RESET } from './constants'
 
 type Read<Value> = Atom<Value>['read']

--- a/src/utils/atomWithObservable.ts
+++ b/src/utils/atomWithObservable.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai'
-import type { Atom, WritableAtom, Getter } from 'jotai'
+import type { Atom, Getter, WritableAtom } from 'jotai'
 
 type Subscription = {
   unsubscribe: () => void

--- a/src/utils/atomWithReducer.ts
+++ b/src/utils/atomWithReducer.ts
@@ -1,4 +1,4 @@
-import { atom, WritableAtom } from 'jotai'
+import { WritableAtom, atom } from 'jotai'
 
 export function atomWithReducer<Value, Action>(
   initialValue: Value,

--- a/src/utils/atomWithReset.ts
+++ b/src/utils/atomWithReset.ts
@@ -1,6 +1,5 @@
 import { atom } from 'jotai'
-import type { WritableAtom, SetStateAction } from 'jotai'
-
+import type { SetStateAction, WritableAtom } from 'jotai'
 import { RESET } from './constants'
 
 export function atomWithReset<Value>(initialValue: Value) {

--- a/src/utils/freezeAtom.ts
+++ b/src/utils/freezeAtom.ts
@@ -1,6 +1,5 @@
 import { atom } from 'jotai'
 import type { Atom, Getter } from 'jotai'
-
 import { getWeakCacheItem, setWeakCacheItem } from './weakCache'
 
 const freezeAtomCache = new WeakMap()

--- a/src/utils/selectAtom.ts
+++ b/src/utils/selectAtom.ts
@@ -1,5 +1,4 @@
-import { atom, Atom } from 'jotai'
-
+import { Atom, atom } from 'jotai'
 import { getWeakCacheItem, setWeakCacheItem } from './weakCache'
 
 const selectAtomCache = new WeakMap()

--- a/src/utils/splitAtom.ts
+++ b/src/utils/splitAtom.ts
@@ -1,13 +1,12 @@
 import { atom } from 'jotai'
 import type {
   Atom,
-  WritableAtom,
-  PrimitiveAtom,
   Getter,
-  Setter,
+  PrimitiveAtom,
   SetStateAction,
+  Setter,
+  WritableAtom,
 } from 'jotai'
-
 import { getWeakCacheItem, setWeakCacheItem } from './weakCache'
 
 const splitAtomCache = new WeakMap()

--- a/src/utils/useAtomCallback.ts
+++ b/src/utils/useAtomCallback.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import { atom, useAtom } from 'jotai'
-import type { WritableAtom, Setter } from 'jotai'
-
+import type { Setter, WritableAtom } from 'jotai'
 import type { Scope } from '../core/atom'
 
 type WriteGetter = Parameters<WritableAtom<unknown, unknown>['write']>[0]

--- a/src/utils/useReducerAtom.ts
+++ b/src/utils/useReducerAtom.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { useAtom, PrimitiveAtom } from 'jotai'
+import { PrimitiveAtom, useAtom } from 'jotai'
 
 /* this doesn't seem to work as expected in TS4.1
 export function useReducerAtom<Value, Action>(

--- a/src/utils/useResetAtom.ts
+++ b/src/utils/useResetAtom.ts
@@ -1,7 +1,6 @@
 import { useCallback, useContext } from 'react'
 import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
 import type { WritableAtom } from 'jotai'
-
 import { RESET } from './constants'
 
 export function useResetAtom<Value>(anAtom: WritableAtom<Value, typeof RESET>) {

--- a/src/utils/useUpdateAtom.ts
+++ b/src/utils/useUpdateAtom.ts
@@ -1,7 +1,6 @@
 import { useCallback, useContext } from 'react'
 import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
 import type { WritableAtom } from 'jotai'
-
 import type { SetAtom } from '../core/atom'
 
 export function useUpdateAtom<Value, Update>(

--- a/src/valtio/atomWithProxy.ts
+++ b/src/valtio/atomWithProxy.ts
@@ -1,4 +1,4 @@
-import { subscribe, snapshot } from 'valtio/vanilla'
+import { snapshot, subscribe } from 'valtio/vanilla'
 import { atom } from 'jotai'
 import type { SetStateAction } from 'jotai'
 

--- a/src/xstate/atomWithMachine.ts
+++ b/src/xstate/atomWithMachine.ts
@@ -1,12 +1,12 @@
 import {
-  interpret,
   EventObject,
-  StateMachine,
+  Interpreter,
   InterpreterOptions,
   MachineOptions,
-  Typestate,
   State,
-  Interpreter,
+  StateMachine,
+  Typestate,
+  interpret,
 } from 'xstate'
 import { atom } from 'jotai'
 import type { Atom, Getter } from 'jotai'

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -1,6 +1,6 @@
-import { StrictMode, Suspense, useRef, useEffect, FC } from 'react'
+import { FC, StrictMode, Suspense, useEffect, useRef } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { atom, useAtom, Atom } from '../src/index'
+import { Atom, atom, useAtom } from '../src/index'
 import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,14 +1,14 @@
 import {
+  FC,
   StrictMode,
   Suspense,
   useEffect,
+  useMemo,
   useRef,
   useState,
-  useMemo,
-  FC,
 } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { atom, useAtom, WritableAtom } from '../src/index'
+import { WritableAtom, atom, useAtom } from '../src/index'
 import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()

--- a/tests/devtools/useAtomsSnapshot.test.tsx
+++ b/tests/devtools/useAtomsSnapshot.test.tsx
@@ -1,7 +1,7 @@
 import { FC, useState } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Provider, atom, useAtom } from '../../src/index'
 import { useAtomsSnapshot } from '../../src/devtools'
+import { Provider, atom, useAtom } from '../../src/index'
 
 it('should register newly added atoms', async () => {
   const countAtom = atom(1)

--- a/tests/devtools/useGoToAtomsSnapshot.test.tsx
+++ b/tests/devtools/useGoToAtomsSnapshot.test.tsx
@@ -1,8 +1,8 @@
-import { Suspense, useRef, useEffect, FC } from 'react'
+import { FC, Suspense, useEffect, useRef } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
+import { useAtomsSnapshot, useGotoAtomsSnapshot } from '../../src/devtools'
 import { Provider, atom, useAtom } from '../../src/index'
 import type { Atom } from '../../src/index'
-import { useAtomsSnapshot, useGotoAtomsSnapshot } from '../../src/devtools'
 
 it('useGotoAtomsSnapshot should modify atoms snapshot', async () => {
   const petAtom = atom('cat')

--- a/tests/error.test.tsx
+++ b/tests/error.test.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState, useEffect, Component, FC } from 'react'
+import { Component, FC, Suspense, useEffect, useState } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom, useAtom } from '../src/index'
 import { getTestProvider } from './testUtils'

--- a/tests/immer/atomWithImmer.test.tsx
+++ b/tests/immer/atomWithImmer.test.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { useAtom } from '../../src/index'
 import { atomWithImmer } from '../../src/immer'
+import { useAtom } from '../../src/index'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/immer/useImmerAtom.test.tsx
+++ b/tests/immer/useImmerAtom.test.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { atom } from '../../src/index'
 import { atomWithImmer, useImmerAtom, withImmer } from '../../src/immer'
+import { atom } from '../../src/index'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/immer/withImmer.test.tsx
+++ b/tests/immer/withImmer.test.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { atom, useAtom } from '../../src/index'
 import { withImmer } from '../../src/immer'
+import { atom, useAtom } from '../../src/index'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/items.test.tsx
+++ b/tests/items.test.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { atom, useAtom, PrimitiveAtom } from '../src/index'
+import { PrimitiveAtom, atom, useAtom } from '../src/index'
 import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()

--- a/tests/onmount.test.tsx
+++ b/tests/onmount.test.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState, FC } from 'react'
+import { FC, Suspense, useState } from 'react'
 import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from '../src/index'
 import { getTestProvider } from './testUtils'

--- a/tests/optics/focus-lens.test.tsx
+++ b/tests/optics/focus-lens.test.tsx
@@ -1,8 +1,8 @@
 import { FC, Suspense } from 'react'
+import * as rtl from '@testing-library/react'
+import * as O from 'optics-ts'
 import { atom, useAtom } from 'jotai'
 import type { SetStateAction } from 'jotai'
-import * as O from 'optics-ts'
-import * as rtl from '@testing-library/react'
 import { focusAtom } from '../../src/optics/focusAtom'
 import { getTestProvider } from '../testUtils'
 

--- a/tests/optics/focus-prism.test.tsx
+++ b/tests/optics/focus-prism.test.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
-import { atom, useAtom } from 'jotai'
-import * as O from 'optics-ts'
 import * as rtl from '@testing-library/react'
+import * as O from 'optics-ts'
+import { atom, useAtom } from 'jotai'
 import { focusAtom } from '../../src/optics'
 import { getTestProvider } from '../testUtils'
 

--- a/tests/optics/focus-traversal.test.tsx
+++ b/tests/optics/focus-traversal.test.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
-import { atom, useAtom } from 'jotai'
-import * as O from 'optics-ts'
 import * as rtl from '@testing-library/react'
+import * as O from 'optics-ts'
+import { atom, useAtom } from 'jotai'
 import { focusAtom } from '../../src/optics/focusAtom'
 import { getTestProvider } from '../testUtils'
 

--- a/tests/query/atomWithInfiniteQuery.test.tsx
+++ b/tests/query/atomWithInfiniteQuery.test.tsx
@@ -1,9 +1,9 @@
 import { FC, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { useAtom } from '../../src/'
-import fakeFetch from './fakeFetch'
-import { getTestProvider } from '../testUtils'
 import { atomWithInfiniteQuery } from '../../src/query/atomWithInfiniteQuery'
+import { getTestProvider } from '../testUtils'
+import fakeFetch from './fakeFetch'
 
 const Provider = getTestProvider()
 

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -1,9 +1,9 @@
 import { FC, Suspense, useState } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom, useAtom } from '../../src/'
-import fakeFetch from './fakeFetch'
 import { atomWithQuery } from '../../src/query'
 import { getTestProvider } from '../testUtils'
+import fakeFetch from './fakeFetch'
 
 const Provider = getTestProvider()
 

--- a/tests/redux/atomWithStore.test.tsx
+++ b/tests/redux/atomWithStore.test.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { fireEvent, render, act } from '@testing-library/react'
+import { act, fireEvent, render } from '@testing-library/react'
 import { createStore } from 'redux'
 import { useAtom } from '../../src/index'
 import { atomWithStore } from '../../src/redux'

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -1,6 +1,6 @@
 import { expectType } from 'ts-expect'
-import { atom, Atom, PrimitiveAtom, useAtom, WritableAtom } from '../src/index'
 import { SetAtom } from '../src/core/atom'
+import { Atom, PrimitiveAtom, WritableAtom, atom, useAtom } from '../src/index'
 
 it('atom() should return the correct types', () => {
   function Component() {

--- a/tests/urql/atomWithMutation.test.tsx
+++ b/tests/urql/atomWithMutation.test.tsx
@@ -1,7 +1,7 @@
 import { FC, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { delay, fromValue, pipe, take, toPromise } from 'wonka'
 import { Client } from '@urql/core'
+import { delay, fromValue, pipe, take, toPromise } from 'wonka'
 import { atom, useAtom } from '../../src/'
 import { atomWithMutation } from '../../src/urql'
 import { getTestProvider } from '../testUtils'

--- a/tests/urql/atomWithQuery.test.tsx
+++ b/tests/urql/atomWithQuery.test.tsx
@@ -1,7 +1,7 @@
 import { FC, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { map, interval, pipe, take, toPromise } from 'wonka'
 import { Client } from '@urql/core'
+import { interval, map, pipe, take, toPromise } from 'wonka'
 import { atom, useAtom } from '../../src/'
 import { atomWithQuery } from '../../src/urql'
 import { getTestProvider } from '../testUtils'

--- a/tests/urql/atomWithSubscription.test.tsx
+++ b/tests/urql/atomWithSubscription.test.tsx
@@ -1,7 +1,7 @@
 import { FC, Suspense } from 'react'
 import { render } from '@testing-library/react'
-import { map, interval, pipe, take, toPromise } from 'wonka'
 import { Client, TypedDocumentNode } from '@urql/core'
+import { interval, map, pipe, take, toPromise } from 'wonka'
 import { useAtom } from '../../src/'
 import { atomWithSubscription } from '../../src/urql'
 import { getTestProvider } from '../testUtils'

--- a/tests/utils/atomFamily.test.tsx
+++ b/tests/utils/atomFamily.test.tsx
@@ -1,7 +1,7 @@
-import { useState, useRef, useEffect, StrictMode, Suspense, FC } from 'react'
+import { FC, StrictMode, Suspense, useEffect, useRef, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from '../../src/index'
-import type { WritableAtom, SetStateAction } from '../../src/index'
+import type { SetStateAction, WritableAtom } from '../../src/index'
 import { atomFamily, useUpdateAtom } from '../../src/utils'
 import { getTestProvider } from '../testUtils'
 

--- a/tests/utils/atomWithDefault.test.tsx
+++ b/tests/utils/atomWithDefault.test.tsx
@@ -1,7 +1,7 @@
 import { FC, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom, useAtom } from '../../src/index'
-import { atomWithDefault, RESET } from '../../src/utils'
+import { RESET, atomWithDefault } from '../../src/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -1,9 +1,9 @@
-import { FC, Suspense, Component } from 'react'
+import { Component, FC, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { getTestProvider } from '../testUtils'
+import { Observable, Subject } from 'rxjs'
 import { useAtom } from '../../src/index'
 import { atomWithObservable } from '../../src/utils'
-import { Observable, Subject } from 'rxjs'
+import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
 

--- a/tests/utils/atomWithStorage.test.tsx
+++ b/tests/utils/atomWithStorage.test.tsx
@@ -1,7 +1,7 @@
 import { FC, Suspense } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { useAtom } from '../../src/index'
-import { atomWithStorage, atomWithHash } from '../../src/utils'
+import { atomWithHash, atomWithStorage } from '../../src/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/splitAtom.test.tsx
+++ b/tests/utils/splitAtom.test.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useRef, FC, ChangeEvent } from 'react'
+import { ChangeEvent, FC, useEffect, useRef } from 'react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
 import type { Atom, PrimitiveAtom } from 'jotai'
-import { render, fireEvent, waitFor } from '@testing-library/react'
-import { getTestProvider } from '../testUtils'
 import { splitAtom } from '../../src/utils'
+import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
 

--- a/tests/utils/useAtomCallback.test.tsx
+++ b/tests/utils/useAtomCallback.test.tsx
@@ -1,6 +1,6 @@
 import { FC, useCallback, useEffect, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { useAtom, atom } from '../../src/index'
+import { atom, useAtom } from '../../src/index'
 import { useAtomCallback } from '../../src/utils'
 import { getTestProvider } from '../testUtils'
 

--- a/tests/utils/useResetAtom.test.tsx
+++ b/tests/utils/useResetAtom.test.tsx
@@ -2,10 +2,10 @@ import { FC } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom, useAtom } from '../../src/index'
 import {
-  useResetAtom,
+  RESET,
   atomWithReducer,
   atomWithReset,
-  RESET,
+  useResetAtom,
 } from '../../src/utils'
 import { getTestProvider } from '../testUtils'
 

--- a/tests/utils/waitForAll.test.tsx
+++ b/tests/utils/waitForAll.test.tsx
@@ -1,7 +1,7 @@
-import { StrictMode, Suspense, Component, FC } from 'react'
+import { Component, FC, StrictMode, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom, useAtom } from '../../src/index'
-import { waitForAll, useUpdateAtom } from '../../src/utils'
+import { useUpdateAtom, waitForAll } from '../../src/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/zustand/atomWithStore.test.tsx
+++ b/tests/zustand/atomWithStore.test.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { fireEvent, render, act } from '@testing-library/react'
+import { act, fireEvent, render } from '@testing-library/react'
 import create from 'zustand/vanilla'
 import { useAtom } from '../../src/index'
 import { atomWithStore } from '../../src/zustand'


### PR DESCRIPTION
Specific changes and motives:
1. Add rules for `js,jsx,ts,tsx` files in `overrides`
    1.1 `alphabetize`: Sort the order within each group in alphabetical manner based on **import path**.(autofixable)
    1.2 `groups`: [Details](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md#groups-array)(autofixable)
    1.3 `newlines-between`: Enforces or forbids new lines between import groups.(autofixable)
    1.4 `pathGroups`: Force sort order of certain packages within group.(autofixable)
    1.5 `pathGroupsExcludedImportTypes `: Configure the `pathGroups` option to use the.(autofixable)
    1.6 `sort-imports`: Order members of import with multiple members.(autofixable)
2. Move `"react/jsx-uses-react": "off",` and `"react/react-in-jsx-scope": "off",` into the `overrides`