### PR TITLE
chore(imports): update the imports declarations of type annotations and declarations to `import type`

### DIFF
--- a/examples/mega-form/src/App.tsx
+++ b/examples/mega-form/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react'
-import { PrimitiveAtom, Provider, atom, useAtom } from 'jotai'
+import { Provider, atom, useAtom } from 'jotai'
+import type { PrimitiveAtom } from 'jotai'
 import { focusAtom } from 'jotai/optics'
 import { useAtomCallback } from 'jotai/utils'
 import initialValue from './initialValue'

--- a/examples/mega-form/src/useAtomSlice.ts
+++ b/examples/mega-form/src/useAtomSlice.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
-import { PrimitiveAtom, useAtom } from 'jotai'
+import { useAtom } from 'jotai'
+import type { PrimitiveAtom } from 'jotai'
 import { splitAtom } from 'jotai/utils'
 
 const useAtomSlice = <Item>(arrAtom: PrimitiveAtom<Item[]>) => {

--- a/examples/todos/src/App.tsx
+++ b/examples/todos/src/App.tsx
@@ -1,8 +1,9 @@
-import { FormEvent } from 'react'
+import type { FormEvent } from 'react'
 import { CloseOutlined } from '@ant-design/icons'
 import { a, useTransition } from '@react-spring/web'
 import { Radio } from 'antd'
-import { PrimitiveAtom, Provider, atom, useAtom } from 'jotai'
+import { Provider, atom, useAtom } from 'jotai'
+import type { PrimitiveAtom } from 'jotai'
 import { useUpdateAtom } from 'jotai/utils'
 
 type Todo = {

--- a/examples/todos_with_atomFamily/src/App.tsx
+++ b/examples/todos_with_atomFamily/src/App.tsx
@@ -1,4 +1,4 @@
-import { FormEvent } from 'react'
+import type { FormEvent } from 'react'
 import { CloseOutlined } from '@ant-design/icons'
 import { a, useTransition } from '@react-spring/web'
 import { Radio } from 'antd'

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,4 +1,5 @@
-import { PropsWithChildren, createElement, useDebugValue, useRef } from 'react'
+import { createElement, useDebugValue, useRef } from 'react'
+import type { PropsWithChildren } from 'react'
 import type { Atom, Scope } from './atom'
 import { createStore, getStoreContext, isDevStore } from './contexts'
 import type { StoreForDevelopment } from './contexts'

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
-import { WritableAtom, useAtom } from 'jotai'
+import { useAtom } from 'jotai'
+import type { WritableAtom } from 'jotai'
 
 type Config = {
   instanceID?: number

--- a/src/immer/atomWithImmer.ts
+++ b/src/immer/atomWithImmer.ts
@@ -1,6 +1,8 @@
 /* eslint-disable import/named */
-import { Draft, produce } from 'immer'
-import { WritableAtom, atom } from 'jotai'
+import { produce } from 'immer'
+import type { Draft } from 'immer'
+import { atom } from 'jotai'
+import type { WritableAtom } from 'jotai'
 
 export function atomWithImmer<Value>(
   initialValue: Value

--- a/src/immer/useImmerAtom.ts
+++ b/src/immer/useImmerAtom.ts
@@ -1,7 +1,9 @@
 /* eslint-disable import/named */
 import { useCallback } from 'react'
-import { Draft, produce } from 'immer'
-import { WritableAtom, useAtom } from 'jotai'
+import { produce } from 'immer'
+import type { Draft } from 'immer'
+import { useAtom } from 'jotai'
+import type { WritableAtom } from 'jotai'
 
 export function useImmerAtom<Value>(
   anAtom: WritableAtom<Value, (draft: Draft<Value>) => void>

--- a/src/immer/withImmer.ts
+++ b/src/immer/withImmer.ts
@@ -1,6 +1,8 @@
 /* eslint-disable import/named */
-import { Draft, produce } from 'immer'
-import { PrimitiveAtom, WritableAtom, atom } from 'jotai'
+import { produce } from 'immer'
+import type { Draft } from 'immer'
+import { atom } from 'jotai'
+import type { PrimitiveAtom, WritableAtom } from 'jotai'
 import { getWeakCacheItem, setWeakCacheItem } from '../utils/weakCache'
 
 const withImmerCache = new WeakMap()

--- a/src/optics/focusAtom.ts
+++ b/src/optics/focusAtom.ts
@@ -1,11 +1,8 @@
 import * as O from 'optics-ts'
 import { atom } from 'jotai'
 import type { SetStateAction, WritableAtom } from 'jotai'
-import {
-  WeakCache,
-  getWeakCacheItem,
-  setWeakCacheItem,
-} from '../utils/weakCache'
+import { getWeakCacheItem, setWeakCacheItem } from '../utils/weakCache'
+import type { WeakCache } from '../utils/weakCache'
 
 const focusAtomCache: WeakCache<WritableAtom<any, any>> = new WeakMap()
 

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -1,12 +1,11 @@
-import {
+import { InfiniteQueryObserver, isCancelledError } from 'react-query'
+import type {
   InfiniteData,
-  InfiniteQueryObserver,
   InfiniteQueryObserverOptions,
   InitialDataFunction,
   QueryClient,
   QueryKey,
   QueryObserverResult,
-  isCancelledError,
 } from 'react-query'
 import { atom } from 'jotai'
 import type { Getter, WritableAtom } from 'jotai'

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -1,8 +1,8 @@
-import {
+import { QueryObserver } from 'react-query'
+import type {
   InitialDataFunction,
   QueryClient,
   QueryKey,
-  QueryObserver,
   QueryObserverOptions,
   QueryObserverResult,
 } from 'react-query'

--- a/src/urql/atomWithMutation.ts
+++ b/src/urql/atomWithMutation.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Client,
   OperationContext,
   OperationResult,

--- a/src/urql/atomWithQuery.ts
+++ b/src/urql/atomWithQuery.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Client,
   OperationContext,
   OperationResult,

--- a/src/urql/atomWithSubscription.ts
+++ b/src/urql/atomWithSubscription.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Client,
   OperationContext,
   OperationResult,

--- a/src/utils/atomFamily.ts
+++ b/src/utils/atomFamily.ts
@@ -1,4 +1,4 @@
-import { Atom, WritableAtom } from 'jotai'
+import type { Atom, WritableAtom } from 'jotai'
 
 type ShouldRemove<Param> = (createdAt: number, param: Param) => boolean
 

--- a/src/utils/atomWithReducer.ts
+++ b/src/utils/atomWithReducer.ts
@@ -1,4 +1,5 @@
-import { WritableAtom, atom } from 'jotai'
+import { atom } from 'jotai'
+import type { WritableAtom } from 'jotai'
 
 export function atomWithReducer<Value, Action>(
   initialValue: Value,

--- a/src/utils/selectAtom.ts
+++ b/src/utils/selectAtom.ts
@@ -1,4 +1,5 @@
-import { Atom, atom } from 'jotai'
+import { atom } from 'jotai'
+import type { Atom } from 'jotai'
 import { getWeakCacheItem, setWeakCacheItem } from './weakCache'
 
 const selectAtomCache = new WeakMap()

--- a/src/utils/useAtomValue.ts
+++ b/src/utils/useAtomValue.ts
@@ -1,4 +1,5 @@
-import { Atom, useAtom } from 'jotai'
+import { useAtom } from 'jotai'
+import type { Atom } from 'jotai'
 
 export function useAtomValue<Value>(anAtom: Atom<Value>) {
   return useAtom(anAtom)[0]

--- a/src/utils/useReducerAtom.ts
+++ b/src/utils/useReducerAtom.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
-import { PrimitiveAtom, useAtom } from 'jotai'
+import { useAtom } from 'jotai'
+import type { PrimitiveAtom } from 'jotai'
 
 /* this doesn't seem to work as expected in TS4.1
 export function useReducerAtom<Value, Action>(

--- a/src/xstate/atomWithMachine.ts
+++ b/src/xstate/atomWithMachine.ts
@@ -1,4 +1,5 @@
-import {
+import { interpret } from 'xstate'
+import type {
   EventObject,
   Interpreter,
   InterpreterOptions,
@@ -6,7 +7,6 @@ import {
   State,
   StateMachine,
   Typestate,
-  interpret,
 } from 'xstate'
 import { atom } from 'jotai'
 import type { Atom, Getter } from 'jotai'

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -1,6 +1,7 @@
 import { StrictMode, Suspense, useEffect, useRef } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { Atom, atom, useAtom } from '../src/index'
+import { atom, useAtom } from 'jotai'
+import type { Atom } from 'jotai'
 import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -7,7 +7,8 @@ import {
   useState,
 } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { WritableAtom, atom, useAtom } from '../src/index'
+import type { WritableAtom } from 'jotai'
+import { atom, useAtom } from '../src/index'
 import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()

--- a/tests/items.test.tsx
+++ b/tests/items.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { PrimitiveAtom, atom, useAtom } from '../src/index'
+import type { PrimitiveAtom } from 'jotai'
+import { atom, useAtom } from '../src/index'
 import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -1,6 +1,7 @@
 import { expectType } from 'ts-expect'
-import { SetAtom } from '../src/core/atom'
-import { Atom, PrimitiveAtom, WritableAtom, atom, useAtom } from '../src/index'
+import { atom, useAtom } from 'jotai'
+import type { Atom, PrimitiveAtom, WritableAtom } from 'jotai'
+import type { SetAtom } from '../src/core/atom'
 
 it('atom() should return the correct types', () => {
   function Component() {

--- a/tests/urql/atomWithMutation.test.tsx
+++ b/tests/urql/atomWithMutation.test.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Client } from '@urql/core'
+import type { Client } from '@urql/core'
 import { delay, fromValue, pipe, take, toPromise } from 'wonka'
 import { atom, useAtom } from '../../src/'
 import { atomWithMutation } from '../../src/urql'

--- a/tests/urql/atomWithQuery.test.tsx
+++ b/tests/urql/atomWithQuery.test.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { Client } from '@urql/core'
+import type { Client } from '@urql/core'
 import { interval, map, pipe, take, toPromise } from 'wonka'
 import { atom, useAtom } from '../../src/'
 import { atomWithQuery } from '../../src/urql'

--- a/tests/urql/atomWithSubscription.test.tsx
+++ b/tests/urql/atomWithSubscription.test.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 import { render } from '@testing-library/react'
-import { Client, TypedDocumentNode } from '@urql/core'
+import type { Client, TypedDocumentNode } from '@urql/core'
 import { interval, map, pipe, take, toPromise } from 'wonka'
 import { useAtom } from '../../src/'
 import { atomWithSubscription } from '../../src/urql'

--- a/tests/utils/splitAtom.test.tsx
+++ b/tests/utils/splitAtom.test.tsx
@@ -1,4 +1,5 @@
-import { ChangeEvent, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
+import type { ChangeEvent } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
 import type { Atom, PrimitiveAtom } from 'jotai'

--- a/tests/utils/useUpdateAtom.test.tsx
+++ b/tests/utils/useUpdateAtom.test.tsx
@@ -1,4 +1,5 @@
-import { PropsWithChildren, StrictMode, useEffect, useRef } from 'react'
+import { StrictMode, useEffect, useRef } from 'react'
+import type { PropsWithChildren } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from '../../src/index'
 import { useUpdateAtom } from '../../src/utils'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2019",
     "strict": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "moduleResolution": "node",


### PR DESCRIPTION
To be honest, when I was doing this PR, I saw a lot of related issues and pull.
e.g.:
- [Type-only imports and exports](https://github.com/microsoft/TypeScript/pull/35200)
- [Add option to disable TS using inline import types in quick fixes](https://github.com/microsoft/TypeScript/issues/35078)
- [Feedback on 'import type' UX for editors](https://github.com/microsoft/TypeScript/issues/36038)
- [Update type-only import semantics to allow type queries](https://github.com/microsoft/TypeScript/pull/36092)
- [Type-only auto imports](https://github.com/microsoft/TypeScript/pull/36412)
- [Auto import adds types to existing value imports under --importsNotUsedAsValues=error](https://github.com/microsoft/TypeScript/issues/39432)

Now I am beginning to think, is this really necessary?