### PR TITLE
test(valtio): infinite loop bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "ts-node": "^10.1.0",
     "tslib": "^2.3.0",
     "typescript": "^4.3.5",
-    "valtio": "^1.1.2",
+    "valtio": "^1.1.3",
     "wonka": "^4.0.15",
     "xstate": "^4.17.1",
     "zustand": "^3.5.7"

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "ts-node": "^10.1.0",
     "tslib": "^2.3.0",
     "typescript": "^4.3.5",
-    "valtio": "^1.0.3",
+    "valtio": "^1.1.2",
     "wonka": "^4.0.15",
     "xstate": "^4.17.1",
     "zustand": "^3.5.7"

--- a/src/valtio/atomWithProxy.ts
+++ b/src/valtio/atomWithProxy.ts
@@ -32,8 +32,6 @@ const applyChanges = <T extends object>(proxyObject: T, prev: T, next: T) => {
   })
 }
 
-// No support for promises in proxy as it's not symmetric
-// Should we type it precisely?
 export function atomWithProxy<Value extends object>(proxyObject: Value) {
   const baseAtom = atom(snapshot(proxyObject))
   baseAtom.onMount = (setValue) => {

--- a/src/valtio/atomWithProxy.ts
+++ b/src/valtio/atomWithProxy.ts
@@ -32,6 +32,13 @@ const applyChanges = <T extends object>(proxyObject: T, prev: T, next: T) => {
   })
 }
 
+// Currently atomWithProxy does not support overwriting Promise() with a primitive
+// due to the requirement of valtio types to always be symmetric.
+// Consequently, this would not work:
+// setStatusState({ ...state, status: 'newStatus' })
+// To overwrite a value that came from a promise you must do it via an immediately
+// resolving promise:
+// setStatusState({ ...state, status: Promise.resolve('newStatus') })
 export function atomWithProxy<Value extends object>(proxyObject: Value) {
   const baseAtom = atom(snapshot(proxyObject))
   baseAtom.onMount = (setValue) => {

--- a/tests/valtio/atomWithProxy.test.tsx
+++ b/tests/valtio/atomWithProxy.test.tsx
@@ -89,7 +89,7 @@ it('nested count state', async () => {
 
 it('state with a promise', async () => {
   const promiseReturningFunction = () =>
-    new Promise((resolve) => {
+    new Promise<string>((resolve) => {
       setTimeout(() => {
         resolve('done')
       }, 15)

--- a/tests/valtio/atomWithProxy.test.tsx
+++ b/tests/valtio/atomWithProxy.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render } from '@testing-library/react'
+import { Suspense } from 'react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import { proxy, snapshot } from 'valtio/vanilla'
 import { useAtom } from '../../src/index'
 import { atomWithProxy } from '../../src/valtio'
@@ -84,4 +85,49 @@ it('nested count state', async () => {
   await findByText('count: 2')
   expect(proxyState.nested.count).toBe(2)
   expect(otherSnap === snapshot(proxyState.other)).toBe(true)
+})
+
+it('state with a promise', async () => {
+  const promiseReturningFunction = () =>
+    new Promise((resolve) => {
+      setTimeout(() => {
+        resolve('done')
+      }, 15)
+    })
+
+  const proxyState = proxy({
+    status: promiseReturningFunction(),
+  })
+  const stateAtom = atomWithProxy(proxyState)
+
+  const Status = () => {
+    const [state, setState] = useAtom(stateAtom)
+    return (
+      <>
+        <span>status: {state.status}</span>
+        <button
+          onClick={() =>
+            setState((prev) => ({
+              ...prev,
+              status: 'modified',
+            }))
+          }>
+          button
+        </button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Suspense fallback="loading...">
+        <Status />
+      </Suspense>
+    </Provider>
+  )
+
+  await findByText('status: done')
+  fireEvent.click(getByText('button'))
+  await findByText('modified')
+  expect(proxyState.status).toBe('modified')
 })

--- a/tests/valtio/atomWithProxy.test.tsx
+++ b/tests/valtio/atomWithProxy.test.tsx
@@ -127,8 +127,6 @@ it('state with a promise', async () => {
   )
 
   await findByText('status: done')
-  expect(proxyState.status).toBe('done')
   fireEvent.click(getByText('button'))
   await findByText('status: modified')
-  expect(proxyState.status).toBe('modified')
 })

--- a/tests/valtio/atomWithProxy.test.tsx
+++ b/tests/valtio/atomWithProxy.test.tsx
@@ -88,15 +88,15 @@ it('nested count state', async () => {
 })
 
 it('state with a promise', async () => {
-  const promiseReturningFunction = () =>
+  const getAsyncStatus = (status: string) =>
     new Promise<string>((resolve) => {
       setTimeout(() => {
-        resolve('done')
+        resolve(status)
       }, 15)
     })
 
   const proxyState = proxy({
-    status: promiseReturningFunction(),
+    status: getAsyncStatus('done'),
   })
   const stateAtom = atomWithProxy(proxyState)
 
@@ -109,7 +109,7 @@ it('state with a promise', async () => {
           onClick={() =>
             setState((prev) => ({
               ...prev,
-              status: 'modified',
+              status: getAsyncStatus('modified'),
             }))
           }>
           button
@@ -127,6 +127,7 @@ it('state with a promise', async () => {
   )
 
   await findByText('status: done')
+  expect(proxyState.status).toBe('done')
   fireEvent.click(getByText('button'))
   await findByText('status: modified')
   expect(proxyState.status).toBe('modified')

--- a/tests/valtio/atomWithProxy.test.tsx
+++ b/tests/valtio/atomWithProxy.test.tsx
@@ -128,6 +128,6 @@ it('state with a promise', async () => {
 
   await findByText('status: done')
   fireEvent.click(getByText('button'))
-  await findByText('modified')
+  await findByText('status: modified')
   expect(proxyState.status).toBe('modified')
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7220,8 +7220,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-"valtio@file:.yalc/valtio":
+valtio@^1.1.2:
   version "1.1.2"
+  resolved "https://registry.yarnpkg.com/valtio/-/valtio-1.1.2.tgz#232095f61efe13755719ed0019b70d7926630be1"
+  integrity sha512-nj2tba3pM/Z3awGZ/A3aRYmBBYjyaeusfUKoWvRdDAO+VL+RgXjKzfarv/ql2HDRQboa3w9FGlpBKiGUODQuQw==
   dependencies:
     proxy-compare "2.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7220,10 +7220,8 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-valtio@^1.0.3:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/valtio/-/valtio-1.0.7.tgz#bbcf1bdf722923d1a3b91452c05936c6ab127b21"
-  integrity sha512-zaaM+QiE6P0pBllFIyDnbjaRILEYsy1YYJf6F1D8dsADKxL2r+Fb3SupM8SHQn2tNx4cbSTu9aarOaoiH+X1dg==
+"valtio@file:.yalc/valtio":
+  version "1.1.2"
   dependencies:
     proxy-compare "2.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7220,10 +7220,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-valtio@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/valtio/-/valtio-1.1.2.tgz#232095f61efe13755719ed0019b70d7926630be1"
-  integrity sha512-nj2tba3pM/Z3awGZ/A3aRYmBBYjyaeusfUKoWvRdDAO+VL+RgXjKzfarv/ql2HDRQboa3w9FGlpBKiGUODQuQw==
+valtio@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/valtio/-/valtio-1.1.3.tgz#e5a922769d64c511b5d9858f2a4156ffa50df7a0"
+  integrity sha512-51WE5jUcqfPcTh6zLB34wt1EtCJJPBGTxX30vP83I7OAyPG7C9fQ6AmDjqS6wBo+A1ulABTMbIImUaCnwf1A8A==
   dependencies:
     proxy-compare "2.0.1"
 


### PR DESCRIPTION
This is a test for the fix of the infinite loop bug (https://github.com/pmndrs/jotai/issues/624) that happens when working with promises and atomWithProxy.

- [x] create a failing test for the issue (passing now with the fix below)
- [x] fix the infinite loop bug (fixed by https://github.com/pmndrs/valtio/pull/202)
- [x] ~sort out the types (needs https://github.com/pmndrs/valtio/pull/203)~ if we accept the fact that we follow the strict typing of the initial state (promise can only be replaced by promise) then the types look OK as it is
- [x] update `valtio` dependency once the type PR is merged