### PR TITLE
test(urql): add tests for client switching

### DIFF
--- a/tests/urql/atomWithSubscription.test.tsx
+++ b/tests/urql/atomWithSubscription.test.tsx
@@ -1,24 +1,21 @@
 import { Suspense } from 'react'
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import type { Client, TypedDocumentNode } from '@urql/core'
 import { interval, map, pipe, take, toPromise } from 'wonka'
-import { useAtom } from '../../src/'
+import { atom, useAtom } from '../../src/'
 import { atomWithSubscription } from '../../src/urql'
 import { getTestProvider } from '../testUtils'
 
-const withPromise = (source$: any) => {
-  source$.toPromise = () => pipe(source$, take(1), toPromise)
-  return source$
-}
-const clientMock = {
-  subscription: () =>
-    withPromise(
+const generateClient = (id = 'default') =>
+  ({
+    subscription: () =>
       pipe(
         interval(10),
-        map((i: number) => ({ data: { count: i } }))
-      )
-    ),
-} as unknown as Client
+        map((i: number) => ({ data: { id, count: i } }))
+      ),
+  } as unknown as Client)
+
+const clientMock = generateClient()
 
 const Provider = getTestProvider()
 
@@ -53,4 +50,66 @@ it('subscription basic test', async () => {
   await findByText('count: 0')
   await findByText('count: 1')
   await findByText('count: 2')
+})
+
+it('subscription change client at runtime', async () => {
+  const clientAtom = atom(generateClient('first'))
+  const countAtom = atomWithSubscription(
+    () => ({
+      query: 'subscription Test { id, count }' as unknown as TypedDocumentNode<{
+        id: string
+        count: number
+      }>,
+    }),
+    (get) => get(clientAtom)
+  )
+
+  const Counter = () => {
+    const [{ data }] = useAtom(countAtom)
+    return (
+      <>
+        <div>
+          {data?.id} count: {data?.count}
+        </div>
+      </>
+    )
+  }
+
+  const Controls = () => {
+    const [, setClient] = useAtom(clientAtom)
+    return (
+      <>
+        <button onClick={() => setClient(generateClient('first'))}>
+          first
+        </button>
+        <button onClick={() => setClient(generateClient('second'))}>
+          second
+        </button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+      <Controls />
+    </Provider>
+  )
+
+  await findByText('loading')
+  await findByText('first count: 0')
+  await findByText('first count: 1')
+  await findByText('first count: 2')
+  fireEvent.click(getByText('second'))
+  await findByText('loading')
+  await findByText('second count: 0')
+  await findByText('second count: 1')
+  await findByText('second count: 2')
+  fireEvent.click(getByText('first'))
+  await findByText('loading')
+  await findByText('first count: 0')
+  await findByText('first count: 1')
+  await findByText('first count: 2')
 })


### PR DESCRIPTION
Introduce passing tests for the use case of switching clients for both subscriptions and queries. The tests are passing and are meant for better coverage of this as it is a rather widespread use-case (authentication involves switching clients) that we don't want breaking.

**This PR is a partial of https://github.com/pmndrs/jotai/pull/635 (in case 635 needs further discussion). Only merge it if 635 will become delayed. If 635 is OK, merge that instead**

- [x] test for `atomWithQuery` to work properly when `client` is switched 
- [x] test for `atomWithSubscription` to work properly when `client` is switched 
- [ ] throw a promise in `atomWithQuery` if `client === null`
- [ ] throw a promise in `atomWithSubscription` if `client === null`
- [ ] test for `atomWithQuery` to work properly when `client` is toggled to null
- [ ] test for `atomWithSubscription` to work properly when `client` is toggled to null 