### PR TITLE
allow edge case of client being null on urql atoms

### DIFF
--- a/src/urql/atomWithQuery.ts
+++ b/src/urql/atomWithQuery.ts
@@ -19,10 +19,13 @@ type QueryArgs<Data, Variables extends object> = {
 
 export function atomWithQuery<Data, Variables extends object>(
   createQueryArgs: (get: Getter) => QueryArgs<Data, Variables>,
-  getClient: (get: Getter) => Client = (get) => get(clientAtom)
+  getClient: (get: Getter) => Client | null = (get) => get(clientAtom)
 ) {
   const queryResultAtom = atom((get) => {
     const client = getClient(get)
+    if (client === null) {
+      throw new Promise(() => {})
+    }
     const args = createQueryArgs(get)
     let resolve: ((result: OperationResult<Data, Variables>) => void) | null =
       null

--- a/src/urql/atomWithSubscription.ts
+++ b/src/urql/atomWithSubscription.ts
@@ -17,10 +17,13 @@ type SubscriptionArgs<Data, Variables extends object> = {
 
 export function atomWithSubscription<Data, Variables extends object>(
   createSubscriptionArgs: (get: Getter) => SubscriptionArgs<Data, Variables>,
-  getClient: (get: Getter) => Client = (get) => get(clientAtom)
+  getClient: (get: Getter) => Client | null = (get) => get(clientAtom)
 ) {
   const queryResultAtom = atom((get) => {
     const client = getClient(get)
+    if (client === null) {
+      throw new Promise(() => {})
+    }
     const args = createSubscriptionArgs(get)
     let resolve: ((result: OperationResult<Data, Variables>) => void) | null =
       null

--- a/tests/urql/atomWithSubscription.test.tsx
+++ b/tests/urql/atomWithSubscription.test.tsx
@@ -126,7 +126,7 @@ it('null client suspense', async () => {
     (get) => get(clientAtom)
   )
   // Derived Atom to safe guard when client is null
-  const guardedIdAtom = atom(
+  const guardedCountAtom = atom(
     (get): { data?: { id: string; count: number } } => {
       const client = get(clientAtom)
       if (client === null) return {}
@@ -135,7 +135,7 @@ it('null client suspense', async () => {
   )
 
   const Counter = () => {
-    const [{ data }] = useAtom(guardedIdAtom)
+    const [{ data }] = useAtom(guardedCountAtom)
     return (
       <>
         <div>

--- a/tests/urql/atomWithSubscription.test.tsx
+++ b/tests/urql/atomWithSubscription.test.tsx
@@ -113,3 +113,73 @@ it('subscription change client at runtime', async () => {
   await findByText('first count: 1')
   await findByText('first count: 2')
 })
+
+it('null client suspense', async () => {
+  const clientAtom = atom<Client | null>(null)
+  const countAtom = atomWithSubscription(
+    () => ({
+      query: 'subscription Test { id, count }' as unknown as TypedDocumentNode<{
+        id: string
+        count: number
+      }>,
+    }),
+    (get) => get(clientAtom)
+  )
+  // Derived Atom to safe guard when client is null
+  const guardedIdAtom = atom(
+    (get): { data?: { id: string; count: number } } => {
+      const client = get(clientAtom)
+      if (client === null) return {}
+      return get(countAtom)
+    }
+  )
+
+  const Counter = () => {
+    const [{ data }] = useAtom(guardedIdAtom)
+    return (
+      <>
+        <div>
+          {data ? (
+            <>
+              {data?.id} count: {data?.count}
+            </>
+          ) : (
+            'no data'
+          )}
+        </div>
+      </>
+    )
+  }
+
+  const Controls = () => {
+    const [, setClient] = useAtom(clientAtom)
+    return (
+      <>
+        <button onClick={() => setClient(generateClient())}>set</button>
+        <button onClick={() => setClient(null)}>unset</button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+      <Controls />
+    </Provider>
+  )
+
+  await findByText('no data')
+  fireEvent.click(getByText('set'))
+  await findByText('loading')
+  await findByText('default count: 0')
+  await findByText('default count: 1')
+  await findByText('default count: 2')
+  fireEvent.click(getByText('unset'))
+  await findByText('no data')
+  fireEvent.click(getByText('set'))
+  await findByText('default count: 0')
+  await findByText('default count: 1')
+  await findByText('default count: 2')
+})

--- a/tests/urql/atomWithSubscription.test.tsx
+++ b/tests/urql/atomWithSubscription.test.tsx
@@ -1,24 +1,21 @@
 import { Suspense } from 'react'
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import type { Client, TypedDocumentNode } from '@urql/core'
 import { interval, map, pipe, take, toPromise } from 'wonka'
-import { useAtom } from '../../src/'
+import { atom, useAtom } from '../../src/'
 import { atomWithSubscription } from '../../src/urql'
 import { getTestProvider } from '../testUtils'
 
-const withPromise = (source$: any) => {
-  source$.toPromise = () => pipe(source$, take(1), toPromise)
-  return source$
-}
-const clientMock = {
-  subscription: () =>
-    withPromise(
+const generateClient = (id = 'default') =>
+  ({
+    subscription: () =>
       pipe(
         interval(10),
-        map((i: number) => ({ data: { count: i } }))
-      )
-    ),
-} as unknown as Client
+        map((i: number) => ({ data: { id, count: i } }))
+      ),
+  } as unknown as Client)
+
+const clientMock = generateClient()
 
 const Provider = getTestProvider()
 
@@ -53,4 +50,66 @@ it('subscription basic test', async () => {
   await findByText('count: 0')
   await findByText('count: 1')
   await findByText('count: 2')
+})
+
+it('subscription change client at runtime', async () => {
+  const clientAtom = atom(generateClient('first'))
+  const countAtom = atomWithSubscription(
+    () => ({
+      query: 'subscription Test { id, count }' as unknown as TypedDocumentNode<{
+        id: string
+        count: number
+      }>,
+    }),
+    (get) => get(clientAtom)
+  )
+
+  const Counter = () => {
+    const [{ data }] = useAtom(countAtom)
+    return (
+      <>
+        <div>
+          {data?.id} count: {data?.count}
+        </div>
+      </>
+    )
+  }
+
+  const Controls = () => {
+    const [, setClient] = useAtom(clientAtom)
+    return (
+      <>
+        <button onClick={() => setClient(generateClient('first'))}>
+          first
+        </button>
+        <button onClick={() => setClient(generateClient('second'))}>
+          second
+        </button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+      <Controls />
+    </Provider>
+  )
+
+  await findByText('loading')
+  await findByText('first count: 0')
+  await findByText('first count: 1')
+  await findByText('first count: 2')
+  fireEvent.click(getByText('second'))
+  await findByText('loading')
+  await findByText('second count: 0')
+  await findByText('second count: 1')
+  await findByText('second count: 2')
+  fireEvent.click(getByText('first'))
+  await findByText('loading')
+  await findByText('first count: 0')
+  await findByText('first count: 1')
+  await findByText('first count: 2')
 })


### PR DESCRIPTION
This solves https://github.com/pmndrs/jotai/issues/622 and adds a test for this edge case.

- [x] test for `atomWithQuery` to work properly when `client` is switched 
- [x] test for `atomWithSubscription` to work properly when `client` is switched 
- [x] throw a promise in `atomWithQuery` if `client === null`
- [x] throw a promise in `atomWithSubscription` if `client === null`
- [x] test for `atomWithQuery` to work properly when `client` is toggled to null
- [x] test for `atomWithSubscription` to work properly when `client` is toggled to null 

This PR expands on https://github.com/pmndrs/jotai/pull/634, and if this one is merged then 634 can be closed as this one has all of those tests as well.