### PR TITLE
breaking: useAtom scope instead of atom scope

### DIFF
--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -46,6 +46,9 @@ type OnMount<Update> = <S extends SetAtom<Update>>(
 export type Atom<Value> = {
   toString: () => string
   debugLabel?: string
+  /**
+   * @deprecated
+   */
   scope?: Scope
   read: Read<Value>
 }

--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -47,7 +47,7 @@ export type Atom<Value> = {
   toString: () => string
   debugLabel?: string
   /**
-   * @deprecated
+   * @deprecated Instead use `useAtom(atom, scope)`
    */
   scope?: Scope
   read: Read<Value>

--- a/src/core/useAtom.ts
+++ b/src/core/useAtom.ts
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useDebugValue, useEffect } from 'react'
-import type { Atom, SetAtom, WritableAtom } from './atom'
+import type { Atom, Scope, SetAtom, WritableAtom } from './atom'
 import { getStoreContext } from './contexts'
 import { useMutableSource } from './useMutableSource'
 import { readAtom, subscribeAtom } from './vanilla'
@@ -11,27 +11,35 @@ const isWritable = <Value, Update>(
   !!(atom as WritableAtom<Value, Update>).write
 
 export function useAtom<Value, Update>(
-  atom: WritableAtom<Value | Promise<Value>, Update>
+  atom: WritableAtom<Value | Promise<Value>, Update>,
+  scope?: Scope
 ): [Value, SetAtom<Update>]
 
 export function useAtom<Value, Update>(
-  atom: WritableAtom<Promise<Value>, Update>
+  atom: WritableAtom<Promise<Value>, Update>,
+  scope?: Scope
 ): [Value, SetAtom<Update>]
 
 export function useAtom<Value, Update>(
-  atom: WritableAtom<Value, Update>
+  atom: WritableAtom<Value, Update>,
+  scope?: Scope
 ): [Value, SetAtom<Update>]
 
 export function useAtom<Value>(
-  atom: Atom<Value | Promise<Value>>
+  atom: Atom<Value | Promise<Value>>,
+  scope?: Scope
 ): [Value, never]
 
-export function useAtom<Value>(atom: Atom<Promise<Value>>): [Value, never]
+export function useAtom<Value>(
+  atom: Atom<Promise<Value>>,
+  scope?: Scope
+): [Value, never]
 
-export function useAtom<Value>(atom: Atom<Value>): [Value, never]
+export function useAtom<Value>(atom: Atom<Value>, scope?: Scope): [Value, never]
 
 export function useAtom<Value, Update>(
-  atom: Atom<Value> | WritableAtom<Value, Update>
+  atom: Atom<Value> | WritableAtom<Value, Update>,
+  scope?: Scope
 ) {
   const getAtomValue = useCallback(
     (state: State) => {
@@ -59,7 +67,14 @@ export function useAtom<Value, Update>(
     [atom]
   )
 
-  const StoreContext = getStoreContext(atom.scope)
+  if ('scope' in atom) {
+    console.warn(
+      'atom.scope is deprecated. Please do useAtom(atom, scope) instead.'
+    )
+    scope = atom.scope
+  }
+
+  const StoreContext = getStoreContext(scope)
   const [mutableSource, updateAtom, commitCallback] = useContext(StoreContext)
   const value: Value = useMutableSource(mutableSource, getAtomValue, subscribe)
   useEffect(() => {

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useAtom } from 'jotai'
 import type { WritableAtom } from 'jotai'
+import type { Scope } from '../core/atom'
 
 type Config = {
   instanceID?: number
@@ -32,7 +33,8 @@ type Extension = {
 
 export function useAtomDevtools<Value>(
   anAtom: WritableAtom<Value, Value>,
-  name?: string
+  name?: string,
+  scope?: Scope
 ) {
   let extension: Extension | undefined
   try {
@@ -48,7 +50,7 @@ export function useAtomDevtools<Value>(
     }
   }
 
-  const [value, setValue] = useAtom(anAtom)
+  const [value, setValue] = useAtom(anAtom, scope)
   const lastValue = useRef(value)
   const isTimeTraveling = useRef(false)
   const devtools = useRef<ConnectionResult & { shouldInit?: boolean }>()

--- a/src/devtools/useGotoAtomsSnapshot.ts
+++ b/src/devtools/useGotoAtomsSnapshot.ts
@@ -14,13 +14,8 @@ export function useGotoAtomsSnapshot(scope?: Scope) {
   const restore = store[4]
   return useCallback(
     (values: Parameters<typeof restore>[0]) => {
-      for (const [atom] of values) {
-        if (atom.scope !== scope) {
-          throw new Error('atom scope mismatch to restore')
-        }
-      }
       restore(values)
     },
-    [restore, scope]
+    [restore]
   )
 }

--- a/src/immer/useImmerAtom.ts
+++ b/src/immer/useImmerAtom.ts
@@ -4,19 +4,23 @@ import { produce } from 'immer'
 import type { Draft } from 'immer'
 import { useAtom } from 'jotai'
 import type { WritableAtom } from 'jotai'
+import type { Scope } from '../core/atom'
 
 export function useImmerAtom<Value>(
-  anAtom: WritableAtom<Value, (draft: Draft<Value>) => void>
+  anAtom: WritableAtom<Value, (draft: Draft<Value>) => void>,
+  scope?: Scope
 ): [Value, (fn: (draft: Draft<Value>) => void) => void]
 
 export function useImmerAtom<Value>(
-  anAtom: WritableAtom<Value, (value: Value) => Value>
+  anAtom: WritableAtom<Value, (value: Value) => Value>,
+  scope?: Scope
 ): [Value, (fn: (draft: Draft<Value>) => void) => void]
 
 export function useImmerAtom<Value>(
-  anAtom: WritableAtom<Value, (value: Value) => Value>
+  anAtom: WritableAtom<Value, (value: Value) => Value>,
+  scope?: Scope
 ) {
-  const [state, setState] = useAtom(anAtom)
+  const [state, setState] = useAtom(anAtom, scope)
   const setStateWithImmer = useCallback(
     (fn) => {
       setState(produce((draft) => fn(draft)) as (value: Value) => Value)

--- a/src/immer/withImmer.ts
+++ b/src/immer/withImmer.ts
@@ -34,7 +34,6 @@ export function withImmer<Value>(anAtom: WritableAtom<Value, Value>) {
         )
       )
   )
-  derivedAtom.scope = anAtom.scope
   setWeakCacheItem(withImmerCache, deps, derivedAtom)
   return derivedAtom
 }

--- a/src/optics/focusAtom.ts
+++ b/src/optics/focusAtom.ts
@@ -53,7 +53,6 @@ export function focusAtom<S, A>(
       set(baseAtom, newValueProducer(get(baseAtom)) as NonFunction<S>)
     }
   )
-  derivedAtom.scope = baseAtom.scope
   setWeakCacheItem(focusAtomCache, deps, derivedAtom)
   return derivedAtom
 }

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -76,7 +76,6 @@ export function atomWithInfiniteQuery<
             }
           })
       )
-      dataAtom.scope = queryAtom.scope
       let setData: (
         data: InfiniteData<TData> | Promise<InfiniteData<TData>>
       ) => void = () => {
@@ -130,7 +129,6 @@ export function atomWithInfiniteQuery<
       return { dataAtom, observer, options }
     },
     (get, _set, action: AtomWithInfiniteQueryAction) => {
-      queryDataAtom.scope = queryAtom.scope
       const { observer } = get(queryDataAtom)
       switch (action.type) {
         case 'refetch': {
@@ -154,12 +152,10 @@ export function atomWithInfiniteQuery<
     AtomWithInfiniteQueryAction
   >(
     (get) => {
-      queryDataAtom.scope = queryAtom.scope
       const { dataAtom } = get(queryDataAtom)
       return get(dataAtom)
     },
     (_get, set, action) => {
-      queryDataAtom.scope = queryAtom.scope
       set(queryDataAtom, action) // delegate action
     }
   )

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -62,7 +62,6 @@ export function atomWithQuery<
             }
           })
       )
-      dataAtom.scope = queryAtom.scope
       let setData: (data: TData | Promise<TData>) => void = () => {
         throw new Error('atomWithQuery: setting data without mount')
       }
@@ -111,7 +110,6 @@ export function atomWithQuery<
     (get, set, action: AtomWithQueryAction) => {
       switch (action.type) {
         case 'refetch': {
-          queryDataAtom.scope = queryAtom.scope
           const { dataAtom, observer } = get(queryDataAtom)
           set(dataAtom, new Promise<TData>(() => {})) // infinite pending
           const p = observer.refetch({ cancelRefetch: true }).then(() => {})
@@ -122,12 +120,10 @@ export function atomWithQuery<
   )
   const queryAtom = atom<TData | TQueryData, AtomWithQueryAction>(
     (get) => {
-      queryDataAtom.scope = queryAtom.scope
       const { dataAtom } = get(queryDataAtom)
       return get(dataAtom)
     },
     (_get, set, action) => {
-      queryDataAtom.scope = queryAtom.scope
       set(queryDataAtom, action) // delegate action
     }
   )

--- a/src/redux/atomWithStore.ts
+++ b/src/redux/atomWithStore.ts
@@ -14,10 +14,7 @@ export function atomWithStore<State, A extends Action = AnyAction>(
     return unsub
   }
   const derivedAtom = atom(
-    (get) => {
-      baseAtom.scope = derivedAtom.scope
-      return get(baseAtom)
-    },
+    (get) => get(baseAtom),
     (_get, _set, action: A) => {
       store.dispatch(action)
     }

--- a/src/urql/atomWithMutation.ts
+++ b/src/urql/atomWithMutation.ts
@@ -24,12 +24,8 @@ export function atomWithMutation<Data, Variables extends object>(
     new Promise<OperationResult<Data, Variables>>(() => {}) // infinite pending
   )
   const queryResultAtom = atom(
-    (get) => {
-      operationResultAtom.scope = queryResultAtom.scope
-      return get(operationResultAtom)
-    },
+    (get) => get(operationResultAtom),
     (get, set, action: MutationAction<Data, Variables>) => {
-      operationResultAtom.scope = queryResultAtom.scope
       set(
         operationResultAtom,
         new Promise<OperationResult<Data, Variables>>(() => {}) // new fetch

--- a/src/urql/atomWithQuery.ts
+++ b/src/urql/atomWithQuery.ts
@@ -34,7 +34,6 @@ export function atomWithQuery<Data, Variables extends object>(
         resolve = r
       })
     )
-    resultAtom.scope = queryAtom.scope
     let setResult: (result: OperationResult<Data, Variables>) => void = () => {
       throw new Error('setting result without mount')
     }
@@ -70,7 +69,6 @@ export function atomWithQuery<Data, Variables extends object>(
     return { resultAtom, args }
   })
   const queryAtom = atom((get) => {
-    queryResultAtom.scope = queryAtom.scope
     const { resultAtom } = get(queryResultAtom)
     return get(resultAtom)
   })

--- a/src/urql/atomWithSubscription.ts
+++ b/src/urql/atomWithSubscription.ts
@@ -32,7 +32,6 @@ export function atomWithSubscription<Data, Variables extends object>(
         resolve = r
       })
     )
-    resultAtom.scope = queryAtom.scope
     let setResult: (result: OperationResult<Data, Variables>) => void = () => {
       throw new Error('setting result without mount')
     }
@@ -69,7 +68,6 @@ export function atomWithSubscription<Data, Variables extends object>(
     return { resultAtom, args }
   })
   const queryAtom = atom((get) => {
-    queryResultAtom.scope = queryAtom.scope
     const { resultAtom } = get(queryResultAtom)
     return get(resultAtom)
   })

--- a/src/utils/atomWithDefault.ts
+++ b/src/utils/atomWithDefault.ts
@@ -10,7 +10,6 @@ export function atomWithDefault<Value>(getDefault: Read<Value>) {
   const overwrittenAtom = atom<Value | typeof EMPTY>(EMPTY)
   const anAtom: WritableAtom<Value, Update> = atom(
     (get) => {
-      overwrittenAtom.scope = anAtom.scope
       const overwritten = get(overwrittenAtom)
       if (overwritten !== EMPTY) {
         return overwritten
@@ -18,7 +17,6 @@ export function atomWithDefault<Value>(getDefault: Read<Value>) {
       return getDefault(get)
     },
     (get, set, update) => {
-      overwrittenAtom.scope = anAtom.scope
       if (update === RESET) {
         set(overwrittenAtom, EMPTY)
       } else {

--- a/src/utils/atomWithObservable.ts
+++ b/src/utils/atomWithObservable.ts
@@ -59,7 +59,6 @@ export function atomWithObservable<TData>(
         }
       })
     )
-    dataAtom.scope = observableAtom.scope
     let setData: (data: TData | Promise<TData>) => void = () => {
       throw new Error('setting data without mount')
     }
@@ -104,12 +103,10 @@ export function atomWithObservable<TData>(
   })
   const observableAtom = atom(
     (get) => {
-      observableResultAtom.scope = observableAtom.scope
       const { dataAtom } = get(observableResultAtom)
       return get(dataAtom)
     },
     (get, _set, data: TData) => {
-      observableResultAtom.scope = observableAtom.scope
       const { observable } = get(observableResultAtom)
       if ('next' in observable) {
         observable.next(data)

--- a/src/utils/atomWithStorage.ts
+++ b/src/utils/atomWithStorage.ts
@@ -68,12 +68,8 @@ export function atomWithStorage<Value>(
   }
 
   const anAtom = atom(
-    (get) => {
-      baseAtom.scope = anAtom.scope
-      return get(baseAtom)
-    },
+    (get) => get(baseAtom),
     (get, set, update: SetStateAction<Value>) => {
-      baseAtom.scope = anAtom.scope
       const newValue =
         typeof update === 'function'
           ? (update as (prev: Value) => Value)(get(baseAtom))

--- a/src/utils/freezeAtom.ts
+++ b/src/utils/freezeAtom.ts
@@ -27,7 +27,6 @@ export function freezeAtom<AtomType extends Atom<any>>(
     (get) => deepFreeze(get(anAtom)),
     (_get, set, arg) => set(anAtom as any, arg)
   )
-  frozenAtom.scope = anAtom.scope
   setWeakCacheItem(freezeAtomCache, deps, frozenAtom)
   return frozenAtom
 }

--- a/src/utils/selectAtom.ts
+++ b/src/utils/selectAtom.ts
@@ -15,7 +15,6 @@ export function selectAtom<Value, Slice>(
     return cachedAtom as Atom<Slice>
   }
   const refAtom = atom(() => ({} as { prev?: Slice }))
-  refAtom.scope = anAtom.scope
   const derivedAtom = atom((get) => {
     const slice = selector(get(anAtom))
     const ref = get(refAtom)
@@ -25,7 +24,6 @@ export function selectAtom<Value, Slice>(
     ref.prev = slice
     return slice
   })
-  derivedAtom.scope = anAtom.scope
   setWeakCacheItem(selectAtomCache, deps, derivedAtom)
   return derivedAtom
 }

--- a/src/utils/splitAtom.ts
+++ b/src/utils/splitAtom.ts
@@ -45,7 +45,6 @@ export function splitAtom<Item, Key>(
         keyList?: Key[]
       })
   )
-  refAtom.scope = arrAtom.scope
   const read = (get: Getter) => {
     const ref = get(refAtom)
     let nextAtomList: Atom<Item>[] = []
@@ -90,7 +89,6 @@ export function splitAtom<Item, Key>(
         ])
       }
       const itemAtom = isWritable(arrAtom) ? atom(read, write) : atom(read)
-      itemAtom.scope = arrAtom.scope
       nextAtomList[index] = itemAtom
     })
     ref.keyList = nextKeyList
@@ -114,7 +112,6 @@ export function splitAtom<Item, Key>(
     }
   }
   const splittedAtom = isWritable(arrAtom) ? atom(read, write) : atom(read)
-  splittedAtom.scope = arrAtom.scope
   setWeakCacheItem(splitAtomCache, deps, splittedAtom)
   return splittedAtom
 }

--- a/src/utils/useAtomCallback.ts
+++ b/src/utils/useAtomCallback.ts
@@ -45,8 +45,7 @@ export function useAtomCallback<Result, Arg>(
       ),
     [callback]
   )
-  anAtom.scope = scope
-  const [, invoke] = useAtom(anAtom)
+  const [, invoke] = useAtom(anAtom, scope)
   return useCallback(
     (arg: Arg) =>
       new Promise<Result>((resolve, reject) => {

--- a/src/utils/useAtomValue.ts
+++ b/src/utils/useAtomValue.ts
@@ -1,6 +1,7 @@
 import { useAtom } from 'jotai'
 import type { Atom } from 'jotai'
+import type { Scope } from '../core/atom'
 
-export function useAtomValue<Value>(anAtom: Atom<Value>) {
-  return useAtom(anAtom)[0]
+export function useAtomValue<Value>(anAtom: Atom<Value>, scope?: Scope) {
+  return useAtom(anAtom, scope)[0]
 }

--- a/src/utils/useReducerAtom.ts
+++ b/src/utils/useReducerAtom.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import { useAtom } from 'jotai'
 import type { PrimitiveAtom } from 'jotai'
+import type { Scope } from '../core/atom'
 
 /* this doesn't seem to work as expected in TS4.1
 export function useReducerAtom<Value, Action>(
@@ -11,19 +12,22 @@ export function useReducerAtom<Value, Action>(
 
 export function useReducerAtom<Value, Action>(
   anAtom: PrimitiveAtom<Value>,
-  reducer: (v: Value, a?: Action) => Value
+  reducer: (v: Value, a?: Action) => Value,
+  scope?: Scope
 ): [Value, (action?: Action) => void]
 
 export function useReducerAtom<Value, Action>(
   anAtom: PrimitiveAtom<Value>,
-  reducer: (v: Value, a: Action) => Value
+  reducer: (v: Value, a: Action) => Value,
+  scope?: Scope
 ): [Value, (action: Action) => void]
 
 export function useReducerAtom<Value, Action>(
   anAtom: PrimitiveAtom<Value>,
-  reducer: (v: Value, a: Action) => Value
+  reducer: (v: Value, a: Action) => Value,
+  scope?: Scope
 ) {
-  const [state, setState] = useAtom(anAtom)
+  const [state, setState] = useAtom(anAtom, scope)
   const dispatch = useCallback(
     (action: Action) => {
       setState((prev) => reducer(prev, action))

--- a/src/utils/useResetAtom.ts
+++ b/src/utils/useResetAtom.ts
@@ -1,10 +1,14 @@
 import { useCallback, useContext } from 'react'
 import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
 import type { WritableAtom } from 'jotai'
+import type { Scope } from '../core/atom'
 import { RESET } from './constants'
 
-export function useResetAtom<Value>(anAtom: WritableAtom<Value, typeof RESET>) {
-  const StoreContext = getStoreContext(anAtom.scope)
+export function useResetAtom<Value>(
+  anAtom: WritableAtom<Value, typeof RESET>,
+  scope?: Scope
+) {
+  const StoreContext = getStoreContext(scope)
   const [, updateAtom] = useContext(StoreContext)
   const setAtom = useCallback(
     () => updateAtom(anAtom, RESET),

--- a/src/utils/useUpdateAtom.ts
+++ b/src/utils/useUpdateAtom.ts
@@ -1,12 +1,13 @@
 import { useCallback, useContext } from 'react'
 import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
 import type { WritableAtom } from 'jotai'
-import type { SetAtom } from '../core/atom'
+import type { Scope, SetAtom } from '../core/atom'
 
 export function useUpdateAtom<Value, Update>(
-  anAtom: WritableAtom<Value, Update>
+  anAtom: WritableAtom<Value, Update>,
+  scope?: Scope
 ) {
-  const StoreContext = getStoreContext(anAtom.scope)
+  const StoreContext = getStoreContext(scope)
   const [, updateAtom] = useContext(StoreContext)
   const setAtom = useCallback(
     (update: Update) => updateAtom(anAtom, update),

--- a/src/utils/waitForAll.ts
+++ b/src/utils/waitForAll.ts
@@ -1,6 +1,5 @@
 import { atom } from 'jotai'
 import type { Atom } from 'jotai'
-import type { Scope } from '../core/atom'
 import { getWeakCacheItem, setWeakCacheItem } from './weakCache'
 
 const waitForAllCache = new WeakMap()
@@ -41,11 +40,6 @@ export function waitForAll<
     return wrapResults(atoms, values)
   })
 
-  const waitForAllScope = unwrappedAtoms[0].scope
-  derivedAtom.scope = waitForAllScope
-
-  validateAtomScopes(waitForAllScope, unwrappedAtoms)
-
   if (Array.isArray(atoms)) {
     setWeakCacheItem(waitForAllCache, atoms, derivedAtom)
   }
@@ -71,11 +65,3 @@ const wrapResults = <Values extends Record<string, unknown> | unknown[]>(
         (out, key, idx) => ({ ...out, [key]: results[idx] }),
         {}
       )
-
-function validateAtomScopes(scope: Scope | undefined, atoms: Atom<unknown>[]) {
-  if (scope && !atoms.every((a) => a.scope === scope)) {
-    console.warn(
-      'Different scopes were found for atoms supplied to waitForAll. This is unsupported and will result in unexpected behavior.'
-    )
-  }
-}

--- a/src/valtio/atomWithProxy.ts
+++ b/src/valtio/atomWithProxy.ts
@@ -50,12 +50,8 @@ export function atomWithProxy<Value extends object>(proxyObject: Value) {
     return unsub
   }
   const derivedAtom = atom(
-    (get) => {
-      baseAtom.scope = derivedAtom.scope
-      return get(baseAtom) as Value
-    },
+    (get) => get(baseAtom) as Value,
     (get, _set, update: SetStateAction<Value>) => {
-      baseAtom.scope = derivedAtom.scope
       const newValue =
         typeof update === 'function'
           ? (update as (prev: Value) => Value)(get(baseAtom) as Value)

--- a/src/xstate/atomWithMachine.ts
+++ b/src/xstate/atomWithMachine.ts
@@ -34,7 +34,6 @@ export function atomWithMachine<
   )
   const machineAtom = atom(
     (get) => {
-      cachedMachineAtom.scope = machineStateWithServiceAtom.scope
       const cachedMachine = get(cachedMachineAtom)
       if (cachedMachine) {
         return cachedMachine
@@ -74,8 +73,6 @@ export function atomWithMachine<
       return { machine: machineWithConfig, service }
     },
     (get, set, _arg) => {
-      cachedMachineAtom.scope = machineStateWithServiceAtom.scope
-      machineAtom.scope = machineStateWithServiceAtom.scope
       set(cachedMachineAtom, get(machineAtom))
     }
   )
@@ -84,16 +81,9 @@ export function atomWithMachine<
   }
   const cachedMachineStateAtom = atom<MachineState | null>(null)
   const machineStateAtom = atom(
-    (get) => {
-      cachedMachineStateAtom.scope = machineStateWithServiceAtom.scope
-      machineAtom.scope = machineStateWithServiceAtom.scope
-      return (
-        get(cachedMachineStateAtom) ?? get(machineAtom).machine.initialState
-      )
-    },
+    (get) =>
+      get(cachedMachineStateAtom) ?? get(machineAtom).machine.initialState,
     (get, set, registerCleanup: (cleanup: () => void) => void) => {
-      cachedMachineStateAtom.scope = machineStateWithServiceAtom.scope
-      machineAtom.scope = machineStateWithServiceAtom.scope
       const { service } = get(machineAtom)
       service.onTransition((nextState) => {
         set(cachedMachineStateAtom, nextState)
@@ -121,12 +111,8 @@ export function atomWithMachine<
     }
   }
   const machineStateWithServiceAtom = atom(
-    (get) => {
-      machineStateAtom.scope = machineStateWithServiceAtom.scope
-      return get(machineStateAtom)
-    },
+    (get) => get(machineStateAtom),
     (get, _set, event: Parameters<Service['send']>[0]) => {
-      machineAtom.scope = machineStateWithServiceAtom.scope
       const { service } = get(machineAtom)
       service.send(event)
     }

--- a/src/zustand/atomWithStore.ts
+++ b/src/zustand/atomWithStore.ts
@@ -13,12 +13,8 @@ export function atomWithStore<T extends State>(store: StoreApi<T>) {
     return unsub
   }
   const derivedAtom = atom(
-    (get) => {
-      baseAtom.scope = derivedAtom.scope
-      return get(baseAtom)
-    },
+    (get) => get(baseAtom),
     (get, _set, update: SetStateAction<T>) => {
-      baseAtom.scope = derivedAtom.scope
       const newState =
         typeof update === 'function'
           ? (update as (prev: T) => T)(get(baseAtom))

--- a/tests/devtools/useGoToAtomsSnapshot.test.tsx
+++ b/tests/devtools/useGoToAtomsSnapshot.test.tsx
@@ -219,10 +219,9 @@ it('useGotoAtomsSnapshot should work with original snapshot', async () => {
 it('useGotoAtomsSnapshot should respect atom scope', async () => {
   const scope = Symbol()
   const petAtom = atom('cat')
-  petAtom.scope = scope
 
   const DisplayAtoms = () => {
-    const [pet] = useAtom(petAtom)
+    const [pet] = useAtom(petAtom, scope)
     return <p>{pet}</p>
   }
 
@@ -251,55 +250,4 @@ it('useGotoAtomsSnapshot should respect atom scope', async () => {
   await findByText('cat')
   fireEvent.click(getByText('click'))
   await findByText('dog')
-})
-
-it('useGotoAtomsSnapshot should error on scope mismatch', async () => {
-  const petScope = Symbol()
-  const colorScope = Symbol()
-  const petAtom = atom('cat')
-  petAtom.scope = petScope
-  const colorAtom = atom('blue')
-  colorAtom.scope = colorScope
-
-  const DisplayAtoms = () => {
-    const [pet] = useAtom(petAtom)
-    const [color] = useAtom(colorAtom)
-    return (
-      <>
-        <p>{pet}</p>
-        <p>{color}</p>
-      </>
-    )
-  }
-
-  const UpdateSnapshot = () => {
-    const snapshot = useAtomsSnapshot()
-    const goToSnapshot = useGotoAtomsSnapshot()
-    return (
-      <button
-        onClick={() => {
-          const newSnapshot = new Map(snapshot)
-          newSnapshot.set(petAtom, 'dog')
-          newSnapshot.set(colorAtom, 'green')
-          try {
-            goToSnapshot(newSnapshot)
-          } catch (e) {
-            expect(e.message).toBe('atom scope mismatch to restore')
-          }
-        }}>
-        click
-      </button>
-    )
-  }
-
-  const { findByText, getByText } = render(
-    <Provider scope={colorScope}>
-      <DisplayAtoms />
-      <UpdateSnapshot />
-    </Provider>
-  )
-
-  await findByText('cat')
-  await findByText('blue')
-  fireEvent.click(getByText('click'))
 })

--- a/tests/immer/withImmer.test.tsx
+++ b/tests/immer/withImmer.test.tsx
@@ -41,11 +41,10 @@ it('withImmer derived atom with useAtom', async () => {
 it('withImmer derived atom with useAtom + scope', async () => {
   const scope = Symbol()
   const regularCountAtom = atom(0)
-  regularCountAtom.scope = scope
 
   const Parent = () => {
-    const [regularCount] = useAtom(regularCountAtom)
-    const [count, setCount] = useAtom(withImmer(regularCountAtom))
+    const [regularCount] = useAtom(regularCountAtom, scope)
+    const [count, setCount] = useAtom(withImmer(regularCountAtom), scope)
     return (
       <>
         <div>

--- a/tests/optics/focus-lens.test.tsx
+++ b/tests/optics/focus-lens.test.tsx
@@ -192,12 +192,11 @@ it('focus on async atom works', async () => {
 it('basic derivation using focus with scope works', async () => {
   const scope = Symbol()
   const bigAtom = atom({ a: 0 })
-  bigAtom.scope = scope
   const focusFunction = (optic: O.OpticFor<{ a: number }>) => optic.prop('a')
 
   const Counter = () => {
-    const [count, setCount] = useAtom(focusAtom(bigAtom, focusFunction))
-    const [bigAtomValue] = useAtom(bigAtom)
+    const [count, setCount] = useAtom(focusAtom(bigAtom, focusFunction), scope)
+    const [bigAtomValue] = useAtom(bigAtom, scope)
     return (
       <>
         <div>bigAtom: {JSON.stringify(bigAtomValue)}</div>

--- a/tests/scope.test.tsx
+++ b/tests/scope.test.tsx
@@ -16,10 +16,9 @@ afterEach(() => {
 it('simple scoped provider with scoped atom', async () => {
   const scope = Symbol()
   const countAtom = atom(0)
-  countAtom.scope = scope
 
   const Display = () => {
-    const [count, setCount] = useAtom(countAtom)
+    const [count, setCount] = useAtom(countAtom, scope)
 
     return (
       <>
@@ -43,11 +42,10 @@ it('default provider and atom with scoped provider and scoped atom', async () =>
   const scope = Symbol()
 
   const scopedCountAtom = atom(0)
-  scopedCountAtom.scope = scope
   const countAtom = atom(0)
 
   const Display = () => {
-    const [scopedCount, setScopedCount] = useAtom(scopedCountAtom)
+    const [scopedCount, setScopedCount] = useAtom(scopedCountAtom, scope)
     const [count, setCount] = useAtom(countAtom)
 
     return (
@@ -87,10 +85,9 @@ it('keeps scoped atom value when default provider is removed', async () => {
   const scope = Symbol()
 
   const scopedCountAtom = atom(0)
-  scopedCountAtom.scope = scope
 
   const Display = () => {
-    const [scopedCount, setScopedCount] = useAtom(scopedCountAtom)
+    const [scopedCount, setScopedCount] = useAtom(scopedCountAtom, scope)
 
     return (
       <>
@@ -139,13 +136,11 @@ it('two different scoped providers and scoped atoms', async () => {
   const scopedCountAtom = atom(0)
   const secondScopedCountAtom = atom(10)
 
-  scopedCountAtom.scope = scope
-  secondScopedCountAtom.scope = secondScope
-
   const Display = () => {
-    const [scopedCount, setScopedCount] = useAtom(scopedCountAtom)
+    const [scopedCount, setScopedCount] = useAtom(scopedCountAtom, scope)
     const [secondScopedCount, setSecondScopedCount] = useAtom(
-      secondScopedCountAtom
+      secondScopedCountAtom,
+      secondScope
     )
 
     return (

--- a/tests/utils/selectAtom.test.tsx
+++ b/tests/utils/selectAtom.test.tsx
@@ -132,10 +132,9 @@ it('do not update unless equality function says value has changed', async () => 
 it('useSelector with scope', async () => {
   const scope = Symbol()
   const bigAtom = atom({ a: 0, b: 'othervalue' })
-  bigAtom.scope = scope
 
   const Parent = () => {
-    const setValue = useUpdateAtom(bigAtom)
+    const setValue = useUpdateAtom(bigAtom, scope)
     return (
       <>
         <button
@@ -150,7 +149,7 @@ it('useSelector with scope', async () => {
 
   const selectA = (value: { a: number }) => value.a
   const Selector = () => {
-    const a = useAtomValue(selectAtom(bigAtom, selectA))
+    const a = useAtomValue(selectAtom(bigAtom, selectA), scope)
     return (
       <>
         <div>a: {a}</div>

--- a/tests/utils/splitAtom.test.tsx
+++ b/tests/utils/splitAtom.test.tsx
@@ -241,10 +241,9 @@ it('handles scope', async () => {
     { task: 'get cat food', checked: false },
     { task: 'get dragon food', checked: false },
   ])
-  todosAtom.scope = scope
 
   const TaskList = ({ listAtom }: { listAtom: typeof todosAtom }) => {
-    const [atoms] = useAtom(splitAtom(listAtom))
+    const [atoms] = useAtom(splitAtom(listAtom), scope)
     return (
       <>
         {atoms.map((anAtom, index) => (
@@ -255,7 +254,7 @@ it('handles scope', async () => {
   }
 
   const TaskItem = ({ itemAtom }: { itemAtom: PrimitiveAtom<TodoItem> }) => {
-    const [value, onChange] = useAtom(itemAtom)
+    const [value, onChange] = useAtom(itemAtom, scope)
     const toggle = () =>
       onChange((value) => ({ ...value, checked: !value.checked }))
     return (

--- a/tests/utils/useResetAtom.test.tsx
+++ b/tests/utils/useResetAtom.test.tsx
@@ -137,11 +137,10 @@ it('useResetAtom with custom atom', async () => {
 it('useResetAtom with scope', async () => {
   const scope = Symbol()
   const countAtom = atomWithReset(0)
-  countAtom.scope = scope
 
   const Parent = () => {
-    const [count, setValue] = useAtom(countAtom)
-    const resetAtom = useResetAtom(countAtom)
+    const [count, setValue] = useAtom(countAtom, scope)
+    const resetAtom = useResetAtom(countAtom, scope)
     return (
       <>
         <div>count: {count}</div>

--- a/tests/utils/useUpdateAtom.test.tsx
+++ b/tests/utils/useUpdateAtom.test.tsx
@@ -82,15 +82,14 @@ it('useUpdateAtom does not trigger rerender in component', async () => {
 it('useUpdateAtom with scope', async () => {
   const scope = Symbol()
   const countAtom = atom(0)
-  countAtom.scope = scope
 
   const Displayer = () => {
-    const [count] = useAtom(countAtom)
+    const [count] = useAtom(countAtom, scope)
     return <div>count: {count}</div>
   }
 
   const Updater = () => {
-    const setCount = useUpdateAtom(countAtom)
+    const setCount = useUpdateAtom(countAtom, scope)
     return (
       <button onClick={() => setCount((value) => value + 1)}>increment</button>
     )


### PR DESCRIPTION
close #639 

This changes how to use atom scope. It's not a new feature, but fixing the existing feature. (The previous atom scope abstraction was problematic.)

This makes `atom.scope` type deprecated.
`useAtom` falls back to the previous behavior, so there's no breaking changes in core.

For non-core functions, changes are technically breaking. We expect this is not too confusing as atom scope is mainly for library use. If it's too confusing, let's consider creating a preliminary patch release to only warn the upcoming change.