### PR TITLE
refactor(core): useMutableSource emulation without symbol and any

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,15 +1,15 @@
 {
   "index.js": {
-    "bundled": 21268,
-    "minified": 10175,
-    "gzipped": 3361,
+    "bundled": 21267,
+    "minified": 10148,
+    "gzipped": 3367,
     "treeshaked": {
       "rollup": {
         "code": 14,
         "import_statements": 14
       },
       "webpack": {
-        "code": 1220
+        "code": 1202
       }
     }
   },
@@ -29,15 +29,15 @@
   },
   "devtools.js": {
     "bundled": 19122,
-    "minified": 9544,
-    "gzipped": 3281,
+    "minified": 9537,
+    "gzipped": 3288,
     "treeshaked": {
       "rollup": {
         "code": 28,
         "import_statements": 28
       },
       "webpack": {
-        "code": 1259
+        "code": 1241
       }
     }
   },

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -68,7 +68,8 @@ export const getDebugStateAndAtoms = ({
 }: {
   atoms: Atom<unknown>[]
   state: State
-}) => [state, atoms]
+}) => [state, atoms] as const
+
 export const subscribeDebugStore = (
   { listeners }: { listeners: Set<() => void> },
   callback: () => void
@@ -81,7 +82,7 @@ export const subscribeDebugStore = (
 // so atoms aren't garbage collected by the WeakMap of mounted atoms
 const useDebugState = (store: StoreForDevelopment) => {
   const debugMutableSource = store[3]
-  const [state, atoms]: [State, Atom<unknown>[]] = useMutableSource(
+  const [state, atoms] = useMutableSource(
     debugMutableSource,
     getDebugStateAndAtoms,
     subscribeDebugStore

--- a/src/core/contexts.ts
+++ b/src/core/contexts.ts
@@ -3,41 +3,10 @@ import type { Context } from 'react'
 import type { Atom, Scope, WritableAtom } from './atom'
 import { createMutableSource } from './useMutableSource'
 import { createState, flushPending, restoreAtoms, writeAtom } from './vanilla'
-import type { State } from './vanilla'
-
-type MutableSource<_Target> = ReturnType<typeof createMutableSource>
-
-type UpdateAtom = <Value, Update>(
-  atom: WritableAtom<Value, Update>,
-  update: Update
-) => void
-
-type CommitCallback = () => void
-
-type StoreForProduction = [
-  stateMutableSource: MutableSource<State>,
-  updateAtom: UpdateAtom,
-  commitCallback: CommitCallback
-]
-
-export type StoreForDevelopment = [
-  stateMutableSource: MutableSource<State>,
-  updateAtom: UpdateAtom,
-  commitCallback: CommitCallback,
-  debugMutableSource: MutableSource<{
-    version: number
-    atoms: Atom<unknown>[]
-    state: State
-    listeners: Set<() => void>
-  }>,
-  restore: (values: Iterable<readonly [Atom<unknown>, unknown]>) => void
-]
-
-export type Store = StoreForProduction | StoreForDevelopment
 
 const createStoreForProduction = (
   initialValues?: Iterable<readonly [Atom<unknown>, unknown]>
-): StoreForProduction => {
+) => {
   const state = createState(initialValues)
   const stateMutableSource = createMutableSource(state, () => state.v)
   const commitCallback = () => flushPending(state)
@@ -45,12 +14,12 @@ const createStoreForProduction = (
     atom: WritableAtom<Value, Update>,
     update: Update
   ) => writeAtom(state, atom, update)
-  return [stateMutableSource, updateAtom, commitCallback]
+  return [stateMutableSource, updateAtom, commitCallback] as const
 }
 
 const createStoreForDevelopment = (
   initialValues?: Iterable<readonly [Atom<unknown>, unknown]>
-): StoreForDevelopment => {
+) => {
   const stateListener = (updatedAtom: Atom<unknown>, isNewAtom: boolean) => {
     ++debugStore.version
     if (isNewAtom) {
@@ -87,8 +56,12 @@ const createStoreForDevelopment = (
     commitCallback,
     debugMutableSource,
     restore,
-  ]
+  ] as const
 }
+
+type StoreForProduction = ReturnType<typeof createStoreForProduction>
+export type StoreForDevelopment = ReturnType<typeof createStoreForDevelopment>
+export type Store = StoreForProduction | StoreForDevelopment
 
 type CreateStore = (
   initialValues?: Iterable<readonly [Atom<unknown>, unknown]>

--- a/src/core/useAtom.ts
+++ b/src/core/useAtom.ts
@@ -46,7 +46,7 @@ export function useAtom<Value, Update>(
         throw atomState.w // write promise
       }
       if ('v' in atomState) {
-        return atomState.v
+        return atomState.v as Value
       }
       throw new Error('no atom value')
     },
@@ -61,7 +61,7 @@ export function useAtom<Value, Update>(
 
   const StoreContext = getStoreContext(atom.scope)
   const [mutableSource, updateAtom, commitCallback] = useContext(StoreContext)
-  const value: Value = useMutableSource(mutableSource, getAtomValue, subscribe)
+  const value = useMutableSource(mutableSource, getAtomValue, subscribe)
   useEffect(() => {
     commitCallback()
   })

--- a/src/core/useMutableSource.ts
+++ b/src/core/useMutableSource.ts
@@ -9,20 +9,28 @@ export {
 
 import { useEffect, useRef, useState } from 'react'
 
-const TARGET = Symbol()
-const GET_VERSION = Symbol()
+const TARGET = '_uMS_T'
+const GET_VERSION = '_uMS_V'
 
-export const createMutableSource = (target: any, getVersion: any): any => ({
+type MutableSource<T, V> = {
+  [TARGET]: T
+  [GET_VERSION]: (target: T) => V
+}
+
+export const createMutableSource = <T, V>(
+  target: T,
+  getVersion: (target: T) => V
+): MutableSource<T, V> => ({
   [TARGET]: target,
   [GET_VERSION]: getVersion,
 })
 
-export const useMutableSource = (
-  source: any,
-  getSnapshot: any,
-  subscribe: any
+export const useMutableSource = <T, V, S>(
+  source: MutableSource<T, V>,
+  getSnapshot: (target: T) => S,
+  subscribe: (target: T, callback: () => void) => () => void
 ) => {
-  const lastVersion = useRef(0)
+  const lastVersion = useRef<V>()
   const currentVersion = source[GET_VERSION](source[TARGET])
   const [state, setState] = useState(
     () =>

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -5,7 +5,7 @@ import {
 } from 'jotai'
 import type { Atom, Scope } from '../core/atom'
 import { getDebugStateAndAtoms, subscribeDebugStore } from '../core/Provider'
-import type { AtomState, State } from '../core/vanilla'
+import type { AtomState } from '../core/vanilla'
 // NOTE importing from '../core/Provider' is across bundles and actually copying code
 
 type AtomsSnapshot = Map<Atom<unknown>, unknown>
@@ -18,7 +18,7 @@ export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
     throw Error('useAtomsSnapshot can only be used in dev mode.')
   }
 
-  const [state, atoms]: [State, Atom<unknown>[]] = useMutableSource(
+  const [state, atoms] = useMutableSource(
     debugMutableSource,
     getDebugStateAndAtoms,
     subscribeDebugStore


### PR DESCRIPTION
This is to follow https://github.com/pmndrs/valtio/pull/208 (we use the same code.)

@Thisen once suggested to have precise typing in useMutableSource.ts. This covers it.