### PR TITLE
refactor: rename store to scope container

### DIFF
--- a/src/core/useAtom.ts
+++ b/src/core/useAtom.ts
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useDebugValue, useEffect } from 'react'
 import type { Atom, Scope, SetAtom, WritableAtom } from './atom'
-import { getStoreContext } from './contexts'
+import { getScopeContext } from './contexts'
 import { useMutableSource } from './useMutableSource'
 import { readAtom, subscribeAtom } from './vanilla'
 import type { State } from './vanilla'
@@ -74,8 +74,8 @@ export function useAtom<Value, Update>(
     scope = atom.scope
   }
 
-  const StoreContext = getStoreContext(scope)
-  const [mutableSource, updateAtom, commitCallback] = useContext(StoreContext)
+  const ScopeContext = getScopeContext(scope)
+  const [mutableSource, updateAtom, commitCallback] = useContext(ScopeContext)
   const value = useMutableSource(mutableSource, getAtomValue, subscribe)
   useEffect(() => {
     commitCallback()

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -1,18 +1,21 @@
 import { useContext } from 'react'
 import {
-  SECRET_INTERNAL_getStoreContext as getStoreContext,
+  SECRET_INTERNAL_getScopeContext as getScopeContext,
   SECRET_INTERNAL_useMutableSource as useMutableSource,
 } from 'jotai'
 import type { Atom, Scope } from '../core/atom'
-import { getDebugStateAndAtoms, subscribeDebugStore } from '../core/Provider'
+import {
+  getDebugStateAndAtoms,
+  subscribeDebugScopeContainer,
+} from '../core/Provider'
 import type { AtomState } from '../core/vanilla'
 // NOTE importing from '../core/Provider' is across bundles and actually copying code
 
 type AtomsSnapshot = Map<Atom<unknown>, unknown>
 
 export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
-  const StoreContext = getStoreContext(scope)
-  const debugMutableSource = useContext(StoreContext)[4]
+  const ScopeContext = getScopeContext(scope)
+  const debugMutableSource = useContext(ScopeContext)[4]
 
   if (debugMutableSource === undefined) {
     throw Error('useAtomsSnapshot can only be used in dev mode.')
@@ -21,7 +24,7 @@ export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
   const [state, atoms] = useMutableSource(
     debugMutableSource,
     getDebugStateAndAtoms,
-    subscribeDebugStore
+    subscribeDebugScopeContainer
   )
 
   const atomToAtomValueTuples = atoms

--- a/src/devtools/useGotoAtomsSnapshot.ts
+++ b/src/devtools/useGotoAtomsSnapshot.ts
@@ -1,17 +1,17 @@
 import { useCallback, useContext } from 'react'
-import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
+import { SECRET_INTERNAL_getScopeContext as getScopeContext } from 'jotai'
 import type { Scope } from '../core/atom'
-import { isDevStore } from '../core/contexts'
+import { isDevScopeContainer } from '../core/contexts'
 // NOTE importing from '../core/contexts' is across bundles and actually copying code
 
 export function useGotoAtomsSnapshot(scope?: Scope) {
-  const StoreContext = getStoreContext(scope)
-  const store = useContext(StoreContext)
+  const ScopeContext = getScopeContext(scope)
+  const scopeContainer = useContext(ScopeContext)
 
-  if (!isDevStore(store)) {
+  if (!isDevScopeContainer(scopeContainer)) {
     throw new Error('useGotoAtomsSnapshot can only be used in dev mode.')
   }
-  const restore = store[3]
+  const restore = scopeContainer[3]
   return useCallback(
     (values: Parameters<typeof restore>[0]) => {
       restore(values)

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export type {
  * This is exported for internal use only.
  * It can change without notice. Do not use it in application code.
  */
-export { getStoreContext as SECRET_INTERNAL_getStoreContext } from './core/contexts'
+export { getScopeContext as SECRET_INTERNAL_getScopeContext } from './core/contexts'
 
 /**
  * This is exported for internal use only.

--- a/src/utils/useHydrateAtoms.ts
+++ b/src/utils/useHydrateAtoms.ts
@@ -1,19 +1,22 @@
 import { useContext } from 'react'
-import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
+import { SECRET_INTERNAL_getScopeContext as getScopeContext } from 'jotai'
 import type { Atom, Scope } from '../core/atom'
-import type { Store } from '../core/contexts'
+import type { ScopeContainer } from '../core/contexts'
 
-const hydratedMap: WeakMap<Store, WeakSet<Atom<unknown>>> = new WeakMap()
+const hydratedMap: WeakMap<
+  ScopeContainer,
+  WeakSet<Atom<unknown>>
+> = new WeakMap()
 
 export function useHydrateAtoms(
   values: Iterable<readonly [Atom<unknown>, unknown]>,
   scope?: Scope
 ) {
-  const StoreContext = getStoreContext(scope)
-  const store = useContext(StoreContext)
-  const restoreAtoms = store[3]
+  const ScopeContext = getScopeContext(scope)
+  const scopeContainer = useContext(ScopeContext)
+  const restoreAtoms = scopeContainer[3]
 
-  const hydratedSet = getHydratedSet(store)
+  const hydratedSet = getHydratedSet(scopeContainer)
   const tuplesToRestore = []
   for (const tuple of values) {
     const atom = tuple[0]
@@ -27,11 +30,11 @@ export function useHydrateAtoms(
   }
 }
 
-function getHydratedSet(store: Store) {
-  let hydratedSet = hydratedMap.get(store)
+function getHydratedSet(scopeContainer: ScopeContainer) {
+  let hydratedSet = hydratedMap.get(scopeContainer)
   if (!hydratedSet) {
     hydratedSet = new WeakSet()
-    hydratedMap.set(store, hydratedSet)
+    hydratedMap.set(scopeContainer, hydratedSet)
   }
   return hydratedSet
 }

--- a/src/utils/useResetAtom.ts
+++ b/src/utils/useResetAtom.ts
@@ -1,5 +1,5 @@
 import { useCallback, useContext } from 'react'
-import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
+import { SECRET_INTERNAL_getScopeContext as getScopeContext } from 'jotai'
 import type { WritableAtom } from 'jotai'
 import type { Scope } from '../core/atom'
 import { RESET } from './constants'
@@ -8,8 +8,8 @@ export function useResetAtom<Value>(
   anAtom: WritableAtom<Value, typeof RESET>,
   scope?: Scope
 ) {
-  const StoreContext = getStoreContext(scope)
-  const [, updateAtom] = useContext(StoreContext)
+  const ScopeContext = getScopeContext(scope)
+  const [, updateAtom] = useContext(ScopeContext)
   const setAtom = useCallback(
     () => updateAtom(anAtom, RESET),
     [updateAtom, anAtom]

--- a/src/utils/useUpdateAtom.ts
+++ b/src/utils/useUpdateAtom.ts
@@ -1,5 +1,5 @@
 import { useCallback, useContext } from 'react'
-import { SECRET_INTERNAL_getStoreContext as getStoreContext } from 'jotai'
+import { SECRET_INTERNAL_getScopeContext as getScopeContext } from 'jotai'
 import type { WritableAtom } from 'jotai'
 import type { Scope, SetAtom } from '../core/atom'
 
@@ -7,8 +7,8 @@ export function useUpdateAtom<Value, Update>(
   anAtom: WritableAtom<Value, Update>,
   scope?: Scope
 ) {
-  const StoreContext = getStoreContext(scope)
-  const [, updateAtom] = useContext(StoreContext)
+  const ScopeContext = getScopeContext(scope)
+  const [, updateAtom] = useContext(ScopeContext)
   const setAtom = useCallback(
     (update: Update) => updateAtom(anAtom, update),
     [updateAtom, anAtom]


### PR DESCRIPTION
This is just a refactoring to rename `Store` to `ScopeContainer` and so on.