### PR TITLE
fix(query): improve initial data method

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -70,16 +70,16 @@
     }
   },
   "query.js": {
-    "bundled": 5106,
-    "minified": 2143,
-    "gzipped": 684,
+    "bundled": 5988,
+    "minified": 2530,
+    "gzipped": 786,
     "treeshaked": {
       "rollup": {
         "code": 80,
         "import_statements": 71
       },
       "webpack": {
-        "code": 1093
+        "code": 1117
       }
     }
   },

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -50,14 +50,23 @@ export function atomWithInfiniteQuery<
       let settlePromise:
         | ((data: InfiniteData<TData> | null, err?: TError) => void)
         | null = null
-      const getInitialData = () =>
-        typeof options.initialData === 'function'
-          ? (
-              options.initialData as InitialDataFunction<
-                InfiniteData<TQueryData>
-              >
-            )()
-          : options.initialData
+
+      const getInitialData = () => {
+        let data: InfiniteData<TQueryData> | InfiniteData<TData> | undefined =
+          queryClient.getQueryData<InfiniteData<TData>>(options.queryKey)
+
+        if (!data && options.initialData)
+          data =
+            typeof options.initialData === 'function'
+              ? (
+                  options.initialData as InitialDataFunction<
+                    InfiniteData<TQueryData>
+                  >
+                )()
+              : options.initialData
+
+        return data
+      }
 
       const initialData = getInitialData()
 
@@ -114,7 +123,7 @@ export function atomWithInfiniteQuery<
 
       const observer = new InfiniteQueryObserver(queryClient, defaultedOptions)
 
-      if (!initialData) {
+      if (initialData === undefined) {
         observer
           .fetchOptimistic(defaultedOptions)
           .then(listener)

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -55,7 +55,7 @@ export function atomWithInfiniteQuery<
         let data: InfiniteData<TQueryData> | InfiniteData<TData> | undefined =
           queryClient.getQueryData<InfiniteData<TData>>(options.queryKey)
 
-        if (!data && options.initialData)
+        if (data === undefined && options.initialData) {
           data =
             typeof options.initialData === 'function'
               ? (
@@ -64,6 +64,7 @@ export function atomWithInfiniteQuery<
                   >
                 )()
               : options.initialData
+        }
 
         return data
       }

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -43,10 +43,19 @@ export function atomWithQuery<
         typeof createQuery === 'function' ? createQuery(get) : createQuery
       let settlePromise: ((data: TData | null, err?: TError) => void) | null =
         null
-      const getInitialData = () =>
-        typeof options.initialData === 'function'
-          ? (options.initialData as InitialDataFunction<TQueryData>)()
-          : options.initialData
+
+      const getInitialData = () => {
+        let data: TQueryData | TData | undefined =
+          queryClient.getQueryData<TData>(options.queryKey)
+
+        if (!data && options.initialData)
+          data =
+            typeof options.initialData === 'function'
+              ? (options.initialData as InitialDataFunction<TQueryData>)()
+              : options.initialData
+
+        return data
+      }
 
       const initialData = getInitialData()
 
@@ -94,7 +103,7 @@ export function atomWithQuery<
         defaultedOptions.staleTime = 1000
       }
       const observer = new QueryObserver(queryClient, defaultedOptions)
-      if (!initialData) {
+      if (initialData === undefined) {
         observer
           .fetchOptimistic(defaultedOptions)
           .then(listener)

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -48,12 +48,12 @@ export function atomWithQuery<
         let data: TQueryData | TData | undefined =
           queryClient.getQueryData<TData>(options.queryKey)
 
-        if (!data && options.initialData)
+        if (data === undefined && options.initialData) {
           data =
             typeof options.initialData === 'function'
               ? (options.initialData as InitialDataFunction<TQueryData>)()
               : options.initialData
-
+        }
         return data
       }
 

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -269,7 +269,6 @@ it('query with enabled (#500)', async () => {
   await findByText('hidden')
 
   fireEvent.click(getByText('toggle'))
-  await findByText('loading')
   await findByText('count: 1')
 })
 
@@ -277,7 +276,7 @@ it('query with initialData test', async () => {
   const mockFetch = jest.fn(fakeFetch)
 
   const countAtom = atomWithQuery(() => ({
-    queryKey: 'count1',
+    queryKey: 'initialData_count1',
     queryFn: async () => {
       return await mockFetch({ count: 10 })
     },


### PR DESCRIPTION
While experimenting with some of the new features in react query, specifically the [`persistQueryClient`](https://react-query.tanstack.com/plugins/persistQueryClient) stuff, I found a bug where if a query has been hydrated via methods exported by react-query (for SSR, or for this new persistence feature), our atom would not handle it correctly.

This fixes that by checking to see if there is data for the queryKey, if there is, treat it the same as if `initialData` was passed.