### PR TITLE
feat(query): enabled functionality

### DIFF
--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -1,18 +1,16 @@
 import { QueryObserver } from 'react-query'
 import type {
   InitialDataFunction,
-  QueryClient,
   QueryKey,
   QueryObserverOptions,
   QueryObserverResult,
 } from 'react-query'
 import { atom } from 'jotai'
-import type { Getter, PrimitiveAtom, WritableAtom } from 'jotai'
+import type { PrimitiveAtom, WritableAtom } from 'jotai'
 import { queryClientAtom } from './queryClientAtom'
+import type { CreateQueryOptions, GetQueryClient } from './types'
 
 export type AtomWithQueryAction = { type: 'refetch' }
-export type CreateQueryOptions<Options> = Options | ((get: Getter) => Options)
-export type GetQueryClient = (get: Getter) => QueryClient
 export type AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData> =
   QueryObserverOptions<TQueryFnData, TError, TData, TQueryData> & {
     queryKey: QueryKey

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -11,12 +11,12 @@ import type { Getter, PrimitiveAtom, WritableAtom } from 'jotai'
 import { queryClientAtom } from './queryClientAtom'
 
 export type AtomWithQueryAction = { type: 'refetch' }
-
+export type CreateQueryOptions<Options> = Options | ((get: Getter) => Options)
+export type GetQueryClient = (get: Getter) => QueryClient
 export type AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData> =
   QueryObserverOptions<TQueryFnData, TError, TData, TQueryData> & {
     queryKey: QueryKey
   }
-
 export type AtomWithQueryOptionsWithEnabled<
   TQueryFnData,
   TError,
@@ -35,17 +35,10 @@ export function atomWithQuery<
   TData = TQueryFnData,
   TQueryData = TQueryFnData
 >(
-  createQuery:
-    | AtomWithQueryOptionsWithEnabled<TQueryFnData, TError, TData, TQueryData>
-    | ((
-        get: Getter
-      ) => AtomWithQueryOptionsWithEnabled<
-        TQueryFnData,
-        TError,
-        TData,
-        TQueryData
-      >),
-  getQueryClient?: (get: Getter) => QueryClient
+  createQuery: CreateQueryOptions<
+    AtomWithQueryOptionsWithEnabled<TQueryFnData, TError, TData, TQueryData>
+  >,
+  getQueryClient?: GetQueryClient
 ): WritableAtom<TData | TQueryData | undefined, AtomWithQueryAction>
 export function atomWithQuery<
   TQueryFnData,
@@ -53,12 +46,10 @@ export function atomWithQuery<
   TData = TQueryFnData,
   TQueryData = TQueryFnData
 >(
-  createQuery:
-    | AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>
-    | ((
-        get: Getter
-      ) => AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>),
-  getQueryClient?: (get: Getter) => QueryClient
+  createQuery: CreateQueryOptions<
+    AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>
+  >,
+  getQueryClient?: GetQueryClient
 ): WritableAtom<TData | TQueryData, AtomWithQueryAction>
 export function atomWithQuery<
   TQueryFnData,
@@ -66,12 +57,10 @@ export function atomWithQuery<
   TData = TQueryFnData,
   TQueryData = TQueryFnData
 >(
-  createQuery:
-    | AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>
-    | ((
-        get: Getter
-      ) => AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>),
-  getQueryClient: (get: Getter) => QueryClient = (get) => get(queryClientAtom)
+  createQuery: CreateQueryOptions<
+    AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>
+  >,
+  getQueryClient: GetQueryClient = (get) => get(queryClientAtom)
 ): WritableAtom<TData | TQueryData | undefined, AtomWithQueryAction> {
   const queryDataAtom: WritableAtom<
     {

--- a/src/query/types.ts
+++ b/src/query/types.ts
@@ -1,0 +1,5 @@
+import { QueryClient } from 'react-query'
+import { Getter } from 'jotai'
+
+export type CreateQueryOptions<Options> = Options | ((get: Getter) => Options)
+export type GetQueryClient = (get: Getter) => QueryClient

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -213,14 +213,14 @@ it('query loading 2', async () => {
 
 it('query with enabled', async () => {
   const slugAtom = atom<string | null>(null)
-
+  const mockFetch = jest.fn(fakeFetch)
   const slugQueryAtom = atomWithQuery((get) => {
     const slug = get(slugAtom)
     return {
       enabled: !!slug,
       queryKey: ['disabled_until_value', slug],
       queryFn: async () => {
-        return await fakeFetch({ slug: `hello-${slug}` })
+        return await mockFetch({ slug: `hello-${slug}` })
       },
     }
   })
@@ -255,12 +255,15 @@ it('query with enabled', async () => {
   )
 
   await findByText('not enabled')
+  expect(mockFetch).toHaveBeenCalledTimes(0)
   fireEvent.click(getByText('set slug'))
   await findByText('loading')
   await findByText('slug: hello-world')
+  expect(mockFetch).toHaveBeenCalledTimes(1)
 })
 
 it('query with enabled 2', async () => {
+  const mockFetch = jest.fn(fakeFetch)
   const enabledAtom = atom<boolean>(true)
   const slugAtom = atom<string | null>('first')
 
@@ -271,7 +274,7 @@ it('query with enabled 2', async () => {
       enabled: isEnabled,
       queryKey: ['enabled_toggle'],
       queryFn: async () => {
-        return await fakeFetch({ slug: `hello-${slug}` })
+        return await mockFetch({ slug: `hello-${slug}` })
       },
     }
   })
@@ -317,14 +320,16 @@ it('query with enabled 2', async () => {
       </Suspense>
     </Provider>
   )
-
   await findByText('loading')
+  expect(mockFetch).toHaveBeenCalledTimes(1)
   await findByText('slug: hello-first')
   fireEvent.click(getByText('set disabled'))
   fireEvent.click(getByText('set slug'))
   await findByText('slug: hello-first')
+  expect(mockFetch).toHaveBeenCalledTimes(1)
   fireEvent.click(getByText('set enabled'))
   await findByText('slug: hello-world')
+  expect(mockFetch).toHaveBeenCalledTimes(2)
 })
 
 it('query with enabled (#500)', async () => {

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -333,7 +333,7 @@ it('query with enabled (#500)', async () => {
     const enabled = get(enabledAtom)
     return {
       enabled,
-      queryKey: 'count',
+      queryKey: 'count_500_issue',
       queryFn: async () => {
         return await fakeFetch({ count: 1 })
       },

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -212,7 +212,6 @@ it('query loading 2', async () => {
 })
 
 it('query with enabled', async () => {
-  type Update = (prev: boolean) => boolean
   const slugAtom = atom<string | null>(null)
 
   const slugQueryAtom = atomWithQuery((get) => {


### PR DESCRIPTION
This adds the `enabled` functionality described here -> https://react-query.tanstack.com/guides/disabling-queries#_top

When the user passes any value for `enabled`, the data value becomes potentially undefined. I've added two tests, one for disabled at start, and one for toggling enabled functionality.

@dai-shi lmk what you think of this implementation, and if it's good I'll do it to the infinity query atom too!