### PR TITLE
feat(query): infinite query page refresh

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -70,9 +70,9 @@
     }
   },
   "query.js": {
-    "bundled": 5842,
-    "minified": 2461,
-    "gzipped": 760,
+    "bundled": 5957,
+    "minified": 2520,
+    "gzipped": 775,
     "treeshaked": {
       "rollup": {
         "code": 80,

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "prettier": "^2.3.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-query": "^3.13.2",
+    "react-query": "^3.21.0",
     "redux": "^4.1.1",
     "rollup": "^2.56.2",
     "rollup-plugin-esbuild": "^4.5.0",

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -13,8 +13,10 @@ import type { WritableAtom } from 'jotai'
 import { queryClientAtom } from './queryClientAtom'
 import { CreateQueryOptions, GetQueryClient } from './types'
 
-export type AtomWithInfiniteQueryAction<TData> =
-  | ({ type: 'refetch' } & Partial<RefetchOptions & RefetchQueryFilters<TData>>)
+export type AtomWithInfiniteQueryAction<TQueryFnData> =
+  | ({ type: 'refetch' } & Partial<
+      RefetchOptions & RefetchQueryFilters<TQueryFnData>
+    >)
   | { type: 'fetchNextPage' }
   | { type: 'fetchPreviousPage' }
 
@@ -56,7 +58,7 @@ export function atomWithInfiniteQuery<
   getQueryClient?: GetQueryClient
 ): WritableAtom<
   InfiniteData<TData | TQueryData> | undefined,
-  AtomWithInfiniteQueryAction<InfiniteData<TData>>
+  AtomWithInfiniteQueryAction<TQueryFnData>
 >
 
 export function atomWithInfiniteQuery<
@@ -71,7 +73,7 @@ export function atomWithInfiniteQuery<
   getQueryClient?: GetQueryClient
 ): WritableAtom<
   InfiniteData<TData | TQueryData>,
-  AtomWithInfiniteQueryAction<InfiniteData<TData>>
+  AtomWithInfiniteQueryAction<TQueryFnData>
 >
 
 export function atomWithInfiniteQuery<
@@ -86,7 +88,7 @@ export function atomWithInfiniteQuery<
   getQueryClient: GetQueryClient = (get) => get(queryClientAtom)
 ): WritableAtom<
   InfiniteData<TData | TQueryData> | undefined,
-  AtomWithInfiniteQueryAction<InfiniteData<TData>>
+  AtomWithInfiniteQueryAction<TQueryFnData>
 > {
   const queryDataAtom = atom(
     (get) => {
@@ -192,7 +194,7 @@ export function atomWithInfiniteQuery<
       }
       return { dataAtom, observer, options }
     },
-    (get, _set, action: AtomWithInfiniteQueryAction<InfiniteData<TData>>) => {
+    (get, _set, action: AtomWithInfiniteQueryAction<TQueryFnData>) => {
       const { observer } = get(queryDataAtom)
       switch (action.type) {
         case 'refetch': {
@@ -214,7 +216,7 @@ export function atomWithInfiniteQuery<
 
   const queryAtom = atom<
     InfiniteData<TData | TQueryData> | undefined,
-    AtomWithInfiniteQueryAction<InfiniteData<TData>>
+    AtomWithInfiniteQueryAction<TQueryFnData>
   >(
     (get) => {
       const { dataAtom } = get(queryDataAtom)

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -5,24 +5,26 @@ import type {
   InitialDataFunction,
   QueryKey,
   QueryObserverResult,
+  RefetchOptions,
+  RefetchQueryFilters,
 } from 'react-query'
 import { atom } from 'jotai'
 import type { WritableAtom } from 'jotai'
 import { queryClientAtom } from './queryClientAtom'
 import { CreateQueryOptions, GetQueryClient } from './types'
 
-export interface AtomWithInfiniteQueryRefetchPageAction<TData> {
-  type: 'refetchPage'
-  payload: (page: TData, index: number, allPages: TData[]) => boolean
+export interface AtomWithInfiniteQueryRefetchAction<TData>
+  extends Partial<RefetchOptions & RefetchQueryFilters<TData>> {
+  type: 'refetch'
 }
 
-export interface AtomWithInfiniteQueryActionBase {
-  type: 'refetch' | 'fetchNextPage' | 'fetchPreviousPage'
+export interface AtomWithInfiniteQueryPageActions {
+  type: 'fetchNextPage' | 'fetchPreviousPage'
 }
 
 export type AtomWithInfiniteQueryAction<TData> =
-  | AtomWithInfiniteQueryActionBase
-  | AtomWithInfiniteQueryRefetchPageAction<TData>
+  | AtomWithInfiniteQueryPageActions
+  | AtomWithInfiniteQueryRefetchAction<TData>
 
 export type AtomWithInfiniteQueryOptions<
   TQueryFnData,
@@ -197,13 +199,10 @@ export function atomWithInfiniteQuery<
     },
     (get, _set, action: AtomWithInfiniteQueryAction<TData>) => {
       const { observer } = get(queryDataAtom)
-      switch (action.type) {
+      const { type, ...options } = action
+      switch (type) {
         case 'refetch': {
-          void observer.refetch()
-          break
-        }
-        case 'refetchPage': {
-          void observer.refetch({ refetchPage: action.payload as any })
+          void observer.refetch(options as any)
           break
         }
         case 'fetchPreviousPage': {

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -26,6 +26,7 @@ export type AtomWithInfiniteQueryOptions<
 > = InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryData> & {
   queryKey: QueryKey
 }
+
 export type AtomWithInfiniteQueryOptionsWithEnabled<
   TQueryFnData,
   TError,
@@ -55,8 +56,9 @@ export function atomWithInfiniteQuery<
   getQueryClient?: GetQueryClient
 ): WritableAtom<
   InfiniteData<TData | TQueryData> | undefined,
-  AtomWithInfiniteQueryAction<TData>
+  AtomWithInfiniteQueryAction<InfiniteData<TData>>
 >
+
 export function atomWithInfiniteQuery<
   TQueryFnData,
   TError,
@@ -69,8 +71,9 @@ export function atomWithInfiniteQuery<
   getQueryClient?: GetQueryClient
 ): WritableAtom<
   InfiniteData<TData | TQueryData>,
-  AtomWithInfiniteQueryAction<TData>
+  AtomWithInfiniteQueryAction<InfiniteData<TData>>
 >
+
 export function atomWithInfiniteQuery<
   TQueryFnData,
   TError,
@@ -83,7 +86,7 @@ export function atomWithInfiniteQuery<
   getQueryClient: GetQueryClient = (get) => get(queryClientAtom)
 ): WritableAtom<
   InfiniteData<TData | TQueryData> | undefined,
-  AtomWithInfiniteQueryAction<TData>
+  AtomWithInfiniteQueryAction<InfiniteData<TData>>
 > {
   const queryDataAtom = atom(
     (get) => {
@@ -95,7 +98,7 @@ export function atomWithInfiniteQuery<
         | null = null
 
       const getInitialData = () => {
-        let data: InfiniteData<TQueryData> | InfiniteData<TData> | undefined =
+        let data: InfiniteData<TQueryData | TData> | undefined =
           queryClient.getQueryData<InfiniteData<TData>>(options.queryKey)
 
         if (data === undefined && options.initialData) {
@@ -189,12 +192,11 @@ export function atomWithInfiniteQuery<
       }
       return { dataAtom, observer, options }
     },
-    (get, _set, action: AtomWithInfiniteQueryAction<TData>) => {
+    (get, _set, action: AtomWithInfiniteQueryAction<InfiniteData<TData>>) => {
       const { observer } = get(queryDataAtom)
       switch (action.type) {
         case 'refetch': {
-          const { type: _type, ...options } =
-            action as AtomWithInfiniteQueryAction<InfiniteData<TData>>
+          const { type: _type, ...options } = action
           void observer.refetch(options)
           break
         }
@@ -212,7 +214,7 @@ export function atomWithInfiniteQuery<
 
   const queryAtom = atom<
     InfiniteData<TData | TQueryData> | undefined,
-    AtomWithInfiniteQueryAction<TData>
+    AtomWithInfiniteQueryAction<InfiniteData<TData>>
   >(
     (get) => {
       const { dataAtom } = get(queryDataAtom)

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -199,7 +199,12 @@ export function atomWithInfiniteQuery<
       switch (action.type) {
         case 'refetch': {
           const { type: _type, ...options } = action
-          void observer.refetch(options)
+          void (
+            observer.refetch as (
+              // FIXME is this correct type assertion?
+              options?: RefetchOptions & RefetchQueryFilters<TQueryFnData>
+            ) => Promise<QueryObserverResult<TData, TError>>
+          )(options)
           break
         }
         case 'fetchPreviousPage': {

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -13,18 +13,10 @@ import type { WritableAtom } from 'jotai'
 import { queryClientAtom } from './queryClientAtom'
 import { CreateQueryOptions, GetQueryClient } from './types'
 
-export interface AtomWithInfiniteQueryRefetchAction<TData>
-  extends Partial<RefetchOptions & RefetchQueryFilters<TData>> {
-  type: 'refetch'
-}
-
-export interface AtomWithInfiniteQueryPageActions {
-  type: 'fetchNextPage' | 'fetchPreviousPage'
-}
-
 export type AtomWithInfiniteQueryAction<TData> =
-  | AtomWithInfiniteQueryPageActions
-  | AtomWithInfiniteQueryRefetchAction<TData>
+  | ({ type: 'refetch' } & Partial<RefetchOptions & RefetchQueryFilters<TData>>)
+  | { type: 'fetchNextPage' }
+  | { type: 'fetchPreviousPage' }
 
 export type AtomWithInfiniteQueryOptions<
   TQueryFnData,
@@ -199,10 +191,11 @@ export function atomWithInfiniteQuery<
     },
     (get, _set, action: AtomWithInfiniteQueryAction<TData>) => {
       const { observer } = get(queryDataAtom)
-      const { type, ...options } = action
-      switch (type) {
+      switch (action.type) {
         case 'refetch': {
-          void observer.refetch(options as any)
+          const { type: _type, ...options } =
+            action as AtomWithInfiniteQueryAction<InfiniteData<TData>>
+          void observer.refetch(options)
           break
         }
         case 'fetchPreviousPage': {

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -20,7 +20,7 @@ export interface AtomWithInfiniteQueryActionBase {
   type: 'refetch' | 'fetchNextPage' | 'fetchPreviousPage'
 }
 
-type AtomWithInfiniteQueryAction<TData> =
+export type AtomWithInfiniteQueryAction<TData> =
   | AtomWithInfiniteQueryActionBase
   | AtomWithInfiniteQueryRefetchPageAction<TData>
 

--- a/tests/query/atomWithInfiniteQuery.test.tsx
+++ b/tests/query/atomWithInfiniteQuery.test.tsx
@@ -242,8 +242,8 @@ it('should be able to refetch only specific pages when refetchPages is provided'
       (value: number) => {
         multiplier = 2
         setState({
-          type: 'refetchPage',
-          payload: (_, index) => index === value,
+          type: 'refetch',
+          refetchPage: (_, index) => index === value,
         })
       },
       [setState]

--- a/yarn.lock
+++ b/yarn.lock
@@ -6010,10 +6010,10 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-query@^3.13.2:
-  version "3.19.4"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.19.4.tgz#67b97470446bd0315d02066debec7775cac83f29"
-  integrity sha512-/jQXoYv2IqWnYx665M1da/M6EFaaSDtP8jVqcCFk3vhpJsNYYwFG9vPjqIUv/GRpKp4qzk+qwTkJfF/bHeBuZQ==
+react-query@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.21.0.tgz#2e099a7906c38eeeb750e8b9b12121a21fa8d9ef"
+  integrity sha512-5rY5J8OD9f4EdkytjSsdCO+pqbJWKwSIMETfh/UyxqyjLURHE0IhlB+IPNPrzzu/dzK0rRxi5p0IkcCdSfizDQ==
   dependencies:
     "@babel/runtime" "^7.5.5"
     broadcast-channel "^3.4.1"


### PR DESCRIPTION
This enables support of the new feature where you can refetch a given page for an infinite query, see https://github.com/tannerlinsley/react-query/pull/2557