### PR TITLE
atomWithStorageAtom

### DIFF
--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -1,10 +1,10 @@
-type Getter = {
+export type Getter = {
   <Value>(atom: Atom<Value | Promise<Value>>): Value
   <Value>(atom: Atom<Promise<Value>>): Value
   <Value>(atom: Atom<Value>): Value
 }
 
-type WriteGetter = Getter & {
+export type WriteGetter = Getter & {
   <Value>(atom: Atom<Value | Promise<Value>>, unstable_promise: true):
     | Value
     | Promise<Value>
@@ -14,14 +14,14 @@ type WriteGetter = Getter & {
   <Value>(atom: Atom<Value>, unstable_promise: true): Value | Promise<Value>
 }
 
-type Setter = {
+export type Setter = {
   <Value>(atom: WritableAtom<Value, undefined>): void
   <Value, Update>(atom: WritableAtom<Value, Update>, update: Update): void
 }
 
-type Read<Value> = (get: Getter) => Value | Promise<Value>
+export type Read<Value> = (get: Getter) => Value | Promise<Value>
 
-type Write<Update> = (
+export type Write<Update> = (
   get: WriteGetter,
   set: Setter,
   update: Update

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,7 @@ export {
   atomWithStorage,
   atomWithHash,
   createJSONStorage,
+  atomWithStorageAtom,
 } from './utils/atomWithStorage'
 export { atomWithObservable } from './utils/atomWithObservable'
 export { useHydrateAtoms } from './utils/useHydrateAtoms'

--- a/src/utils/atomWithStorage.ts
+++ b/src/utils/atomWithStorage.ts
@@ -1,7 +1,7 @@
 import { atom } from 'jotai'
 import type { PrimitiveAtom, SetStateAction } from 'jotai'
 import { atomWithDefault } from './atomWithDefault'
-import { Atom, Getter, Read } from 'src/core/atom'
+import { Atom, Getter, Read } from '../core/atom'
 
 type Unsubscribe = () => void
 


### PR DESCRIPTION
I had the situation where the storage was dependant on something I had to retrieve from an atom. Thats why i changed atomWithStorage to receive a storage from an atom and get the initialValue from a Read<Value> function.

It worked for me, but I thought i might be good be be discussed open and add to the official utils.