### PR TITLE
Rollback to initial exports structures with duplicated .js and .mjs files for additional support of bundlers

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,17 @@
 {
   "index.js": {
-    "bundled": 26044,
-    "minified": 10893,
-    "gzipped": 3839
+    "bundled": 22130,
+    "minified": 8884,
+    "gzipped": 3283,
+    "treeshaked": {
+      "rollup": {
+        "code": 14,
+        "import_statements": 14
+      },
+      "webpack": {
+        "code": 1202
+      }
+    }
   },
   "index.mjs": {
     "bundled": 22130,
@@ -19,9 +28,18 @@
     }
   },
   "utils.js": {
-    "bundled": 19964,
-    "minified": 9745,
-    "gzipped": 3377
+    "bundled": 15954,
+    "minified": 7566,
+    "gzipped": 2795,
+    "treeshaked": {
+      "rollup": {
+        "code": 28,
+        "import_statements": 28
+      },
+      "webpack": {
+        "code": 1317
+      }
+    }
   },
   "utils.mjs": {
     "bundled": 15954,
@@ -38,9 +56,18 @@
     }
   },
   "devtools.js": {
-    "bundled": 24507,
-    "minified": 10144,
-    "gzipped": 3664
+    "bundled": 20426,
+    "minified": 8380,
+    "gzipped": 3171,
+    "treeshaked": {
+      "rollup": {
+        "code": 28,
+        "import_statements": 28
+      },
+      "webpack": {
+        "code": 1241
+      }
+    }
   },
   "devtools.mjs": {
     "bundled": 20426,
@@ -57,9 +84,18 @@
     }
   },
   "immer.js": {
-    "bundled": 2109,
-    "minified": 1135,
-    "gzipped": 490
+    "bundled": 1615,
+    "minified": 844,
+    "gzipped": 407,
+    "treeshaked": {
+      "rollup": {
+        "code": 42,
+        "import_statements": 42
+      },
+      "webpack": {
+        "code": 1104
+      }
+    }
   },
   "immer.mjs": {
     "bundled": 1615,
@@ -76,9 +112,18 @@
     }
   },
   "optics.js": {
-    "bundled": 2527,
-    "minified": 1338,
-    "gzipped": 641
+    "bundled": 1646,
+    "minified": 812,
+    "gzipped": 429,
+    "treeshaked": {
+      "rollup": {
+        "code": 32,
+        "import_statements": 32
+      },
+      "webpack": {
+        "code": 1061
+      }
+    }
   },
   "optics.mjs": {
     "bundled": 1646,
@@ -95,9 +140,18 @@
     }
   },
   "query.js": {
-    "bundled": 7348,
-    "minified": 3028,
-    "gzipped": 935
+    "bundled": 6499,
+    "minified": 2866,
+    "gzipped": 936,
+    "treeshaked": {
+      "rollup": {
+        "code": 80,
+        "import_statements": 71
+      },
+      "webpack": {
+        "code": 1192
+      }
+    }
   },
   "query.mjs": {
     "bundled": 6499,
@@ -114,9 +168,18 @@
     }
   },
   "xstate.js": {
-    "bundled": 3170,
-    "minified": 1365,
-    "gzipped": 670
+    "bundled": 2977,
+    "minified": 1314,
+    "gzipped": 653,
+    "treeshaked": {
+      "rollup": {
+        "code": 29,
+        "import_statements": 29
+      },
+      "webpack": {
+        "code": 1145
+      }
+    }
   },
   "xstate.mjs": {
     "bundled": 2977,
@@ -133,9 +196,18 @@
     }
   },
   "valtio.js": {
-    "bundled": 1457,
-    "minified": 776,
-    "gzipped": 398
+    "bundled": 1235,
+    "minified": 598,
+    "gzipped": 335,
+    "treeshaked": {
+      "rollup": {
+        "code": 37,
+        "import_statements": 37
+      },
+      "webpack": {
+        "code": 1054
+      }
+    }
   },
   "valtio.mjs": {
     "bundled": 1235,
@@ -152,9 +224,18 @@
     }
   },
   "zustand.js": {
-    "bundled": 696,
-    "minified": 394,
-    "gzipped": 245
+    "bundled": 549,
+    "minified": 262,
+    "gzipped": 188,
+    "treeshaked": {
+      "rollup": {
+        "code": 14,
+        "import_statements": 14
+      },
+      "webpack": {
+        "code": 998
+      }
+    }
   },
   "zustand.mjs": {
     "bundled": 549,
@@ -171,9 +252,18 @@
     }
   },
   "redux.js": {
-    "bundled": 607,
-    "minified": 354,
-    "gzipped": 229
+    "bundled": 458,
+    "minified": 220,
+    "gzipped": 167,
+    "treeshaked": {
+      "rollup": {
+        "code": 14,
+        "import_statements": 14
+      },
+      "webpack": {
+        "code": 998
+      }
+    }
   },
   "redux.mjs": {
     "bundled": 458,
@@ -190,9 +280,18 @@
     }
   },
   "urql.js": {
-    "bundled": 6352,
-    "minified": 3105,
-    "gzipped": 1116
+    "bundled": 5643,
+    "minified": 2916,
+    "gzipped": 1121,
+    "treeshaked": {
+      "rollup": {
+        "code": 170,
+        "import_statements": 85
+      },
+      "webpack": {
+        "code": 1355
+      }
+    }
   },
   "urql.mjs": {
     "bundled": 5643,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "types": "./index.d.ts",
   "typesVersions": {
     "<4.0": {
+      "esm/*": [
+        "ts3.4/*"
+      ],
       "*": [
         "ts3.4/*"
       ]
@@ -16,68 +19,68 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./index.d.ts",
-      "module": "./index.mjs",
-      "import": "./index.mjs",
+      "module": "./esm/index.js",
+      "import": "./esm/index.mjs",
       "default": "./index.js"
     },
     "./utils": {
       "types": "./utils.d.ts",
-      "module": "./utils.mjs",
-      "import": "./utils.mjs",
+      "module": "./esm/utils.js",
+      "import": "./esm/utils.mjs",
       "default": "./utils.js"
     },
     "./devtools": {
       "types": "./devtools.d.ts",
-      "module": "./devtools.mjs",
-      "import": "./devtools.mjs",
+      "module": "./esm/devtools.js",
+      "import": "./esm/devtools.mjs",
       "default": "./devtools.js"
     },
     "./immer": {
       "types": "./immer.d.ts",
-      "module": "./immer.mjs",
-      "import": "./immer.mjs",
+      "module": "./esm/immer.js",
+      "import": "./esm/immer.mjs",
       "default": "./immer.js"
     },
     "./optics": {
       "types": "./optics.d.ts",
-      "module": "./optics.mjs",
-      "import": "./optics.mjs",
+      "module": "./esm/optics.js",
+      "import": "./esm/optics.mjs",
       "default": "./optics.js"
     },
     "./query": {
       "types": "./query.d.ts",
-      "module": "./query.mjs",
-      "import": "./query.mjs",
+      "module": "./esm/query.js",
+      "import": "./esm/query.mjs",
       "default": "./query.js"
     },
     "./xstate": {
       "types": "./xstate.d.ts",
-      "module": "./xstate.mjs",
-      "import": "./xstate.mjs",
+      "module": "./esm/xstate.js",
+      "import": "./esm/xstate.mjs",
       "default": "./xstate.js"
     },
     "./valtio": {
       "types": "./valtio.d.ts",
-      "module": "./valtio.mjs",
-      "import": "./valtio.mjs",
+      "module": "./esm/valtio.js",
+      "import": "./esm/valtio.mjs",
       "default": "./valtio.js"
     },
     "./zustand": {
       "types": "./zustand.d.ts",
-      "module": "./zustand.mjs",
-      "import": "./zustand.mjs",
+      "module": "./esm/zustand.js",
+      "import": "./esm/zustand.mjs",
       "default": "./zustand.js"
     },
     "./redux": {
       "types": "./redux.d.ts",
-      "module": "./redux.mjs",
-      "import": "./redux.mjs",
+      "module": "./esm/redux.js",
+      "import": "./esm/redux.mjs",
       "default": "./redux.js"
     },
     "./urql": {
       "types": "./urql.d.ts",
-      "module": "./urql.mjs",
-      "import": "./urql.mjs",
+      "module": "./esm/urql.js",
+      "import": "./esm/urql.mjs",
       "default": "./urql.js"
     }
   },
@@ -107,7 +110,7 @@
     "test": "jest && jest --setupFiles ./tests/setProviderLessMode.ts",
     "test:dev": "jest --watch --no-coverage",
     "test:coverage:watch": "jest --watch",
-    "copy": "shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && downlevel-dts dist dist/ts3.4 && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\""
+    "copy": "shx cp -r dist/src/* dist/esm && shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && downlevel-dts dist dist/ts3.4 && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\""
   },
   "engines": {
     "node": ">=12"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -75,12 +75,14 @@ export default function (args) {
     c = c.slice('config-'.length)
     return [
       createCommonJSConfig(`src/${c}.ts`, `dist/${c}.js`),
-      createESMConfig(`src/${c}.ts`, `dist/${c}.mjs`),
+      createESMConfig(`src/${c}.ts`, `dist/esm/${c}.mjs`),
+      createESMConfig(`src/${c}.ts`, `dist/esm/${c}.js`),
     ]
   }
   return [
     createDeclarationConfig('src/index.ts', 'dist'),
     createCommonJSConfig('src/index.ts', 'dist/index.js'),
-    createESMConfig('src/index.ts', 'dist/index.mjs'),
+    createESMConfig('src/index.ts', 'dist/esm/index.mjs'),
+    createESMConfig('src/index.ts', 'dist/esm/index.js'),
   ]
 }


### PR DESCRIPTION
- Rolls back to the initial /esm folder structure
- adds .mjs files for bundlers that support .mjs
- duplicates .js files for bundlers that don't like .mjs