### PR TITLE
fix(core,query): handle edge cases with writeAtom returning a promise

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 19951,
-    "minified": 8250,
-    "gzipped": 3053,
+    "bundled": 19738,
+    "minified": 8159,
+    "gzipped": 3036,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,9 +14,9 @@
     }
   },
   "index.mjs": {
-    "bundled": 19951,
-    "minified": 8250,
-    "gzipped": 3053,
+    "bundled": 19738,
+    "minified": 8159,
+    "gzipped": 3036,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -56,9 +56,9 @@
     }
   },
   "devtools.js": {
-    "bundled": 20243,
-    "minified": 8251,
-    "gzipped": 3124,
+    "bundled": 20030,
+    "minified": 8160,
+    "gzipped": 3101,
     "treeshaked": {
       "rollup": {
         "code": 28,
@@ -70,9 +70,9 @@
     }
   },
   "devtools.mjs": {
-    "bundled": 20243,
-    "minified": 8251,
-    "gzipped": 3124,
+    "bundled": 20030,
+    "minified": 8160,
+    "gzipped": 3101,
     "treeshaked": {
       "rollup": {
         "code": 28,
@@ -140,9 +140,9 @@
     }
   },
   "query.js": {
-    "bundled": 6499,
-    "minified": 2866,
-    "gzipped": 936,
+    "bundled": 6518,
+    "minified": 2892,
+    "gzipped": 953,
     "treeshaked": {
       "rollup": {
         "code": 80,
@@ -154,9 +154,9 @@
     }
   },
   "query.mjs": {
-    "bundled": 6499,
-    "minified": 2866,
-    "gzipped": 936,
+    "bundled": 6518,
+    "minified": 2892,
+    "gzipped": 953,
     "treeshaked": {
       "rollup": {
         "code": 80,

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -203,6 +203,7 @@ export const createStore = (
     if (promise) {
       atomState.w = promise
     } else if (atomState.w === prevPromise) {
+      // delete it only if it's not overwritten
       delete atomState.w // write promise
     }
     commitAtomState(atom, atomState)

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -365,11 +365,11 @@ export const createStore = (
   ): void | Promise<void> => {
     const writePromise = getAtomState(atom)?.w
     if (writePromise) {
-      writePromise.then(() => {
-        writeAtomState(atom, update)
+      return writePromise.then(() => {
+        const promiseOrVoid = writeAtomState(atom, update)
         flushPending()
+        return promiseOrVoid
       })
-      return
     }
     const writeGetter: WriteGetter = (
       a: AnyAtom,

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -331,7 +331,6 @@ export const createStore = (
     if (!mounted) {
       mounted = mountAtom(addingAtom)
     }
-    flushPending()
     return mounted
   }
 
@@ -345,7 +344,6 @@ export const createStore = (
     if (mounted && canUnmountAtom(deletingAtom, mounted)) {
       unmountAtom(deletingAtom)
     }
-    flushPending()
   }
 
   const invalidateDependents = <Value>(atom: Atom<Value>): void => {
@@ -365,11 +363,7 @@ export const createStore = (
   ): void | Promise<void> => {
     const writePromise = getAtomState(atom)?.w
     if (writePromise) {
-      return writePromise.then(() => {
-        const promiseOrVoid = writeAtomState(atom, update)
-        flushPending()
-        return promiseOrVoid
-      })
+      return writePromise.then(() => writeAtomState(atom, update))
     }
     const writeGetter: WriteGetter = (
       a: AnyAtom,
@@ -452,6 +446,7 @@ export const createStore = (
       })
       setAtomWritePromise(atom, promise)
     }
+    flushPending()
     return promiseOrVoid
   }
 
@@ -460,7 +455,6 @@ export const createStore = (
     update: Update
   ): void | Promise<void> => {
     const promiseOrVoid = writeAtomState(writingAtom, update)
-    flushPending()
     return promiseOrVoid
   }
 

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -164,7 +164,9 @@ export function atomWithQuery<
         case 'refetch': {
           const { dataAtom, observer } = get(queryDataAtom)
           set(dataAtom, new Promise<TData>(() => {})) // infinite pending
-          const p = observer.refetch({ cancelRefetch: true }).then(() => {})
+          const p = Promise.resolve()
+            .then(() => observer.refetch({ cancelRefetch: true }))
+            .then(() => {})
           return p
         }
       }
@@ -175,9 +177,7 @@ export function atomWithQuery<
       const { dataAtom } = get(queryDataAtom)
       return get(dataAtom)
     },
-    (_get, set, action) => {
-      set(queryDataAtom, action) // delegate action
-    }
+    (_get, set, action) => set(queryDataAtom, action) // delegate action
   )
   return queryAtom
 }

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -109,9 +109,9 @@ it('query refetch', async () => {
   await findByText('count: 0')
   expect(mockFetch).toBeCalledTimes(1)
   fireEvent.click(getByText('refetch'))
-  expect(mockFetch).toBeCalledTimes(2)
   await findByText('loading')
   await findByText('count: 1')
+  expect(mockFetch).toBeCalledTimes(2)
 })
 
 it('query loading', async () => {
@@ -126,9 +126,9 @@ it('query loading', async () => {
     },
   }))
   const derivedAtom = atom((get) => get(countAtom))
-  const dispatchAtom = atom(null, (_get, set, action: any) =>
+  const dispatchAtom = atom(null, (_get, set, action: any) => {
     set(countAtom, action)
-  )
+  })
   const Counter = () => {
     const [
       {


### PR DESCRIPTION
#689 changed `writeAtom` to return a promise. This is a follow-up PR to cover some edge cases.

- remove extra code in code that is basically unnecessary in jotai core
- make atomWithQuery write function to return a promise with fixing tests in jotai/query