### PR TITLE
fix(core): Allow retries for errored async reads

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -177,6 +177,7 @@ export const createStore = (
       return
     }
     atomState.c?.() // cancel read promise
+    delete atomState.e // read error
     if (isInterruptablePromise(promise)) {
       atomState.p = promise // read promise
       delete atomState.c // this promise is from another atom state, shouldn't be canceled here

--- a/tests/error.test.tsx
+++ b/tests/error.test.tsx
@@ -492,7 +492,7 @@ describe('error recovery', () => {
     await findByText('Value: 1')
   })
 
-  it.only('recovers from async errors', async () => {
+  it('recovers from async errors', async () => {
     const asyncAtom = atom(async (get) => {
       const value = get(counter)
       await new Promise((resolve) => {

--- a/tests/error.test.tsx
+++ b/tests/error.test.tsx
@@ -454,16 +454,22 @@ describe('throws an error while updating in effect cleanup', () => {
 })
 
 describe('error recovery', () => {
-  const counter = atom(0)
+  const createCounter = () => {
+    const counterAtom = atom(0)
 
-  const Counter = () => {
-    const [count, setCount] = useAtom(counter)
-    return <button onClick={() => setCount(count + 1)}>increment</button>
+    const Counter = () => {
+      const [count, setCount] = useAtom(counterAtom)
+      return <button onClick={() => setCount(count + 1)}>increment</button>
+    }
+
+    return { Counter, counterAtom }
   }
 
   it('recovers from sync errors', async () => {
+    const { counterAtom, Counter } = createCounter()
+
     const syncAtom = atom((get) => {
-      const value = get(counter)
+      const value = get(counterAtom)
 
       if (value === 0) {
         throw new Error('An error occurred')
@@ -493,8 +499,9 @@ describe('error recovery', () => {
   })
 
   it('recovers from async errors', async () => {
+    const { counterAtom, Counter } = createCounter()
     const asyncAtom = atom(async (get) => {
-      const value = get(counter)
+      const value = get(counterAtom)
       await new Promise((resolve) => {
         setTimeout(resolve, 50)
       })

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -1,4 +1,4 @@
-import { Component, Suspense } from 'react'
+import { Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { Observable, Subject } from 'rxjs'
 import { useAtom } from '../../src/index'
@@ -6,31 +6,6 @@ import { atomWithObservable } from '../../src/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
-
-class ErrorBoundary extends Component<
-  { message?: string },
-  { hasError: boolean }
-> {
-  constructor(props: { message?: string }) {
-    super(props)
-    this.state = { hasError: false }
-  }
-  static getDerivedStateFromError() {
-    return { hasError: true }
-  }
-  render() {
-    return this.state.hasError ? (
-      <div>
-        <div>{this.props.message || 'errored'}</div>
-        <button onClick={() => this.setState({ hasError: false })}>
-          retry
-        </button>
-      </div>
-    ) : (
-      this.props.children
-    )
-  }
-}
 
 it('count state', async () => {
   const observableAtom = atomWithObservable(
@@ -94,33 +69,4 @@ it('writable count state', async () => {
 
   fireEvent.click(getByText('button'))
   await findByText('count: 9')
-})
-
-// FIXME we would like to support retry
-it.skip('count state with error', async () => {
-  const myObservable = new Observable<number>((subscriber) => {
-    subscriber.error('err1')
-    subscriber.next(1)
-  })
-  const observableAtom = atomWithObservable(() => myObservable)
-
-  const Counter = () => {
-    const [state] = useAtom(observableAtom)
-
-    return <div>count: {state}</div>
-  }
-
-  const { findByText, getByText } = render(
-    <Provider>
-      <ErrorBoundary>
-        <Suspense fallback="loading">
-          <Counter />
-        </Suspense>
-      </ErrorBoundary>
-    </Provider>
-  )
-
-  await findByText('errored')
-  fireEvent.click(getByText('retry'))
-  await findByText('count: 1')
 })


### PR DESCRIPTION
When changing a dependency for an atom in an error state, the derived atom's read function is re-run.

We'd expect that if that re-run is successful, `useAtom` will return the new value.

This is currently the case with sync atoms, but not async atoms. This PR fixes that, and adds tests (the async variant was failing, but the sync one wasn't).

Fixes #601 