### PR TITLE
Switch back to Node 12

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -9,5 +9,5 @@
     "next-js-with-custom-babel-config-kc8sd",
     "react-with-custom-babel-config-2dpyh"
   ],
-  "node": "14"
+  "node": "12"
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "copy": "shx cp -r dist/src/* dist/esm && shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && downlevel-dts dist dist/ts3.4 && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\""
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=12"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
Since Vercel is default on Node 12, lets use that for now to avoid errors on default deployments.