### PR TITLE
fix(core,utils): support unknown error type

### DIFF
--- a/src/core/useAtom.ts
+++ b/src/core/useAtom.ts
@@ -57,7 +57,7 @@ export function useAtom<Value, Update>(
 
   const getAtomValue = useCallback(() => {
     const atomState = store[READ_ATOM](atom)
-    if (atomState.e) {
+    if ('e' in atomState) {
       throw atomState.e // read error
     }
     if (atomState.p) {

--- a/tests/utils/loadable.test.tsx
+++ b/tests/utils/loadable.test.tsx
@@ -11,49 +11,49 @@ it('loadable turns suspense into values', async () => {
     return new Promise<number>((resolve) => (resolveAsync = resolve))
   })
 
-  const { findByText, getByText } = render(
+  const { findByText } = render(
     <Provider>
       <LoadableComponent asyncAtom={asyncAtom} />
     </Provider>
   )
 
-  getByText('Loading...')
+  await findByText('Loading...')
   resolveAsync(5)
   await findByText('Data: 5')
 })
 
 it('loadable turns errors into values', async () => {
-  let rejectAsync!: (error: Error) => void
+  let rejectAsync!: (error: unknown) => void
   const asyncAtom = atom(() => {
-    return new Promise<number>((resolve, reject) => (rejectAsync = reject))
+    return new Promise<number>((_resolve, reject) => (rejectAsync = reject))
   })
 
-  const { findByText, getByText } = render(
+  const { findByText } = render(
     <Provider>
       <LoadableComponent asyncAtom={asyncAtom} />
     </Provider>
   )
 
-  getByText('Loading...')
+  await findByText('Loading...')
   rejectAsync(new Error('An error occurred'))
   await findByText('Error: An error occurred')
 })
 
 it('loadable turns primitive throws into values', async () => {
-  let rejectAsync!: (errorMessage: string) => void
+  let rejectAsync!: (error: unknown) => void
   const asyncAtom = atom(() => {
-    return new Promise<number>((resolve, reject) => (rejectAsync = reject))
+    return new Promise<number>((_resolve, reject) => (rejectAsync = reject))
   })
 
-  const { findByText, getByText } = render(
+  const { findByText } = render(
     <Provider>
       <LoadableComponent asyncAtom={asyncAtom} />
     </Provider>
   )
 
-  getByText('Loading...')
+  await findByText('Loading...')
   rejectAsync('An error occurred')
-  await findByText('Error: An error occurred')
+  await findByText('An error occurred')
 })
 
 it('loadable goes back to loading after re-fetch', async () => {
@@ -93,7 +93,7 @@ it('loadable goes back to loading after re-fetch', async () => {
 
 it('loadable can recover from error', async () => {
   let resolveAsync!: (x: number) => void
-  let rejectAsync!: (error: Error) => void
+  let rejectAsync!: (error: unknown) => void
   const refreshAtom = atom(0)
   const asyncAtom = atom((get) => {
     get(refreshAtom)


### PR DESCRIPTION
I think the library shouldn't modify thrown errors.
Unfortunately, the implementation of `loadable` gets hacky, but it passes the test (it's refactored, but specs are not changed. cc @Pinpickle )