### PR TITLE
fix(core): no async write suspense (BREAKING CHANGE in behavior)

### DIFF
--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -66,7 +66,7 @@ const stateToPrintable = ([store, atoms]: [Store, Atom<unknown>[]]) =>
         [
           atomToPrintable(atom),
           {
-            value: atomState.e || atomState.p || atomState.w || atomState.v,
+            value: atomState.e || atomState.p || atomState.v,
             dependents: Array.from(dependents).map(atomToPrintable),
           },
         ],

--- a/src/core/useAtom.ts
+++ b/src/core/useAtom.ts
@@ -63,9 +63,6 @@ export function useAtom<Value, Update>(
     if (atomState.p) {
       throw atomState.p // read promise
     }
-    if (atomState.w) {
-      throw atomState.w // write promise
-    }
     if ('v' in atomState) {
       return atomState.v as Value
     }

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -648,9 +648,7 @@ it('async write self atom', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Provider>
-        <Suspense fallback="loading">
-          <Counter />
-        </Suspense>
+        <Counter />
       </Provider>
     </StrictMode>
   )
@@ -658,7 +656,6 @@ it('async write self atom', async () => {
   await findByText('count: 0')
 
   fireEvent.click(getByText('button'))
-  await findByText('loading') // write pending
   await findByText('count: -1')
 })
 
@@ -842,9 +839,7 @@ it('async write chain', async () => {
     <StrictMode>
       <Provider>
         <Counter />
-        <Suspense fallback="loading">
-          <Control />
-        </Suspense>
+        <Control />
       </Provider>
     </StrictMode>
   )
@@ -852,13 +847,7 @@ it('async write chain', async () => {
   await findByText('count: 0')
 
   fireEvent.click(getByText('button'))
-  await waitFor(() => {
-    getByText('count: 1')
-    getByText('loading') // write pending
-  })
-  await waitFor(() => {
-    getByText('count: 2')
-    getByText('loading') // write pending
-  })
+  await findByText('count: 1')
+  await findByText('count: 2')
   await findByText('count: 3')
 })

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -343,44 +343,6 @@ it('works with async get without setTimeout', async () => {
   await findByText('count: 2, delayedCount: 2')
 })
 
-it('shows loading with async set', async () => {
-  const countAtom = atom(0)
-  const asyncCountAtom = atom(
-    (get) => get(countAtom),
-    async (_get, set, value: number) => {
-      await new Promise((r) => setTimeout(r, 10))
-      set(countAtom, value)
-    }
-  )
-
-  const Counter = () => {
-    const [count, setCount] = useAtom(asyncCountAtom)
-    return (
-      <>
-        <div>
-          commits: {useCommitCount()}, count: {count}
-        </div>
-        <button onClick={() => setCount(count + 1)}>button</button>
-      </>
-    )
-  }
-
-  const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
-  )
-
-  await findByText('commits: 1, count: 0')
-
-  fireEvent.click(getByText('button'))
-  await findByText('loading')
-
-  await findByText('commits: 2, count: 1')
-})
-
 it('uses atoms with tree dependencies', async () => {
   const topAtom = atom(0)
   const leftAtom = atom((get) => get(topAtom))
@@ -407,21 +369,17 @@ it('uses atoms with tree dependencies', async () => {
 
   const { getByText, findByText } = render(
     <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
+      <Counter />
     </Provider>
   )
 
   await findByText('commits: 1, count: 0')
 
   fireEvent.click(getByText('button'))
-  await findByText('loading')
-  await findByText('commits: 2, count: 1')
+  await findByText('commits: 3, count: 1')
 
   fireEvent.click(getByText('button'))
-  await findByText('loading')
-  await findByText('commits: 3, count: 2')
+  await findByText('commits: 5, count: 2')
 })
 
 it('runs update only once in StrictMode', async () => {
@@ -486,17 +444,13 @@ it('uses an async write-only atom', async () => {
 
   const { getByText, findByText } = render(
     <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
+      <Counter />
     </Provider>
   )
 
   await findByText('commits: 1, count: 0')
 
   fireEvent.click(getByText('button'))
-  await findByText('loading')
-
   await findByText('commits: 2, count: 1')
 })
 
@@ -521,16 +475,13 @@ it('uses a writable atom without read function', async () => {
 
   const { getByText, findByText } = render(
     <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
+      <Counter />
     </Provider>
   )
 
   await findByText('count: 1')
 
   fireEvent.click(getByText('button'))
-  await findByText('loading')
   await findByText('count: 11')
 })
 


### PR DESCRIPTION
close #726 

Again, this was probably a bad design decision from the beginning.
Now, as I understand, `write` function is executed outside React and `read` function is inside React.
React should only care about `read` and so are ErrorBoundary and Suspense.
This is breaking change in behavior, but API won't change and there should be no errors occurred (If there are, that's a situation they wrongly depend on the bad design, and should be fixed.)

I hope someone to try the codesandbox build but otherwise we will release it and see how it goes.