### PR TITLE
refactor(test): use aliases

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -95,7 +95,10 @@
       },
       "alias": {
         "extensions": [".js", ".jsx", ".ts", ".tsx", ".json"],
-        "map": [["jotai", "./src/index.ts"]]
+        "map": [
+          ["^jotai$", "./src/index.ts"],
+          ["jotai", "./src"]
+        ]
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "rootDir": ".",
     "testEnvironment": "jsdom",
     "moduleNameMapper": {
-      "^jotai$": "<rootDir>/src/index.ts"
+      "^jotai$": "<rootDir>/src/index.ts",
+      "^jotai/(.*)$": "<rootDir>/src/$1.ts"
     },
     "modulePathIgnorePatterns": [
       "dist"

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -7,8 +7,8 @@ import {
   useState,
 } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
+import { atom, useAtom } from 'jotai'
 import type { WritableAtom } from 'jotai'
-import { atom, useAtom } from '../src/index'
 import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()

--- a/tests/dependency.test.tsx
+++ b/tests/dependency.test.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useEffect, useRef, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { atom, useAtom } from '../src/index'
+import { atom, useAtom } from 'jotai'
 import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()

--- a/tests/devtools/useAtomsSnapshot.test.tsx
+++ b/tests/devtools/useAtomsSnapshot.test.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { useAtomsSnapshot } from '../../src/devtools'
-import { Provider, atom, useAtom } from '../../src/index'
+import { Provider, atom, useAtom } from 'jotai'
+import { useAtomsSnapshot } from 'jotai/devtools'
 
 it('should register newly added atoms', async () => {
   const countAtom = atom(1)

--- a/tests/devtools/useGoToAtomsSnapshot.test.tsx
+++ b/tests/devtools/useGoToAtomsSnapshot.test.tsx
@@ -1,8 +1,8 @@
 import { Suspense, useEffect, useRef } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { useAtomsSnapshot, useGotoAtomsSnapshot } from '../../src/devtools'
-import { Provider, atom, useAtom } from '../../src/index'
-import type { Atom } from '../../src/index'
+import { Provider, atom, useAtom } from 'jotai'
+import type { Atom } from 'jotai'
+import { useAtomsSnapshot, useGotoAtomsSnapshot } from 'jotai/devtools'
 
 it('useGotoAtomsSnapshot should modify atoms snapshot', async () => {
   const petAtom = atom('cat')

--- a/tests/error.test.tsx
+++ b/tests/error.test.tsx
@@ -1,6 +1,6 @@
 import { Component, Suspense, useEffect, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { atom, useAtom } from '../src/index'
+import { atom, useAtom } from 'jotai'
 import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()

--- a/tests/immer/atomWithImmer.test.tsx
+++ b/tests/immer/atomWithImmer.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/react'
-import { atomWithImmer } from '../../src/immer'
-import { useAtom } from '../../src/index'
+import { useAtom } from 'jotai'
+import { atomWithImmer } from 'jotai/immer'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/immer/useImmerAtom.test.tsx
+++ b/tests/immer/useImmerAtom.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/react'
-import { atomWithImmer, useImmerAtom, withImmer } from '../../src/immer'
-import { atom } from '../../src/index'
+import { atom } from 'jotai'
+import { atomWithImmer, useImmerAtom, withImmer } from 'jotai/immer'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/immer/withImmer.test.tsx
+++ b/tests/immer/withImmer.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/react'
-import { withImmer } from '../../src/immer'
-import { atom, useAtom } from '../../src/index'
+import { atom, useAtom } from 'jotai'
+import { withImmer } from 'jotai/immer'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/items.test.tsx
+++ b/tests/items.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, waitFor } from '@testing-library/react'
+import { atom, useAtom } from 'jotai'
 import type { PrimitiveAtom } from 'jotai'
-import { atom, useAtom } from '../src/index'
 import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()

--- a/tests/onmount.test.tsx
+++ b/tests/onmount.test.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useState } from 'react'
 import { act, fireEvent, render, waitFor } from '@testing-library/react'
-import { atom, useAtom } from '../src/index'
+import { atom, useAtom } from 'jotai'
 import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()

--- a/tests/optics/focus-lens.test.tsx
+++ b/tests/optics/focus-lens.test.tsx
@@ -3,7 +3,7 @@ import * as rtl from '@testing-library/react'
 import * as O from 'optics-ts'
 import { atom, useAtom } from 'jotai'
 import type { SetStateAction } from 'jotai'
-import { focusAtom } from '../../src/optics/focusAtom'
+import { focusAtom } from 'jotai/optics'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/optics/focus-prism.test.tsx
+++ b/tests/optics/focus-prism.test.tsx
@@ -1,7 +1,7 @@
 import * as rtl from '@testing-library/react'
 import * as O from 'optics-ts'
 import { atom, useAtom } from 'jotai'
-import { focusAtom } from '../../src/optics'
+import { focusAtom } from 'jotai/optics'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/optics/focus-traversal.test.tsx
+++ b/tests/optics/focus-traversal.test.tsx
@@ -1,7 +1,7 @@
 import * as rtl from '@testing-library/react'
 import * as O from 'optics-ts'
 import { atom, useAtom } from 'jotai'
-import { focusAtom } from '../../src/optics/focusAtom'
+import { focusAtom } from 'jotai/optics'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/optimization.test.tsx
+++ b/tests/optimization.test.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { atom, useAtom } from '../src/index'
+import { atom, useAtom } from 'jotai'
 import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()

--- a/tests/provider.test.tsx
+++ b/tests/provider.test.tsx
@@ -1,5 +1,5 @@
 import { render, waitFor } from '@testing-library/react'
-import { Provider, atom, useAtom } from '../src/index'
+import { Provider, atom, useAtom } from 'jotai'
 
 // No PROVIDER_LESS_MODE test for this file, obviously.
 

--- a/tests/query/atomWithInfiniteQuery.test.tsx
+++ b/tests/query/atomWithInfiniteQuery.test.tsx
@@ -1,7 +1,7 @@
-import React, { Suspense, useCallback } from 'react'
+import { Suspense, useCallback } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { atom, useAtom } from '../../src/'
-import { atomWithInfiniteQuery } from '../../src/query/atomWithInfiniteQuery'
+import { atom, useAtom } from 'jotai'
+import { atomWithInfiniteQuery } from 'jotai/query'
 import { getTestProvider } from '../testUtils'
 import fakeFetch from './fakeFetch'
 

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -1,7 +1,7 @@
 import { Suspense, useState } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { atom, useAtom } from '../../src/'
-import { atomWithQuery } from '../../src/query'
+import { atom, useAtom } from 'jotai'
+import { atomWithQuery } from 'jotai/query'
 import { getTestProvider } from '../testUtils'
 import fakeFetch from './fakeFetch'
 

--- a/tests/redux/atomWithStore.test.tsx
+++ b/tests/redux/atomWithStore.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render } from '@testing-library/react'
 import { createStore } from 'redux'
-import { useAtom } from '../../src/index'
-import { atomWithStore } from '../../src/redux'
+import { useAtom } from 'jotai'
+import { atomWithStore } from 'jotai/redux'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/scope.test.tsx
+++ b/tests/scope.test.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { atom, useAtom } from '../src/index'
+import { atom, useAtom } from 'jotai'
 import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -1,4 +1,4 @@
-import { Provider } from '../src/index'
+import { Provider } from 'jotai'
 
 export function getTestProvider() {
   return process.env.PROVIDER_LESS_MODE

--- a/tests/urql/atomWithMutation.test.tsx
+++ b/tests/urql/atomWithMutation.test.tsx
@@ -2,8 +2,8 @@ import { Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import type { Client } from '@urql/core'
 import { delay, fromValue, pipe, take, toPromise } from 'wonka'
-import { atom, useAtom } from '../../src/'
-import { atomWithMutation } from '../../src/urql'
+import { atom, useAtom } from 'jotai'
+import { atomWithMutation } from 'jotai/urql'
 import { getTestProvider } from '../testUtils'
 
 const withPromise = (source$: any) => {

--- a/tests/urql/atomWithQuery.test.tsx
+++ b/tests/urql/atomWithQuery.test.tsx
@@ -2,8 +2,8 @@ import { Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import type { Client } from '@urql/core'
 import { fromValue, interval, map, pipe, take, toPromise } from 'wonka'
-import { atom, useAtom } from '../../src/'
-import { atomWithQuery } from '../../src/urql'
+import { atom, useAtom } from 'jotai'
+import { atomWithQuery } from 'jotai/urql'
 import { getTestProvider } from '../testUtils'
 
 const withPromise = (source$: any) => {

--- a/tests/urql/atomWithSubscription.test.tsx
+++ b/tests/urql/atomWithSubscription.test.tsx
@@ -2,8 +2,8 @@ import { Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import type { Client, TypedDocumentNode } from '@urql/core'
 import { interval, map, pipe } from 'wonka'
-import { atom, useAtom } from '../../src/'
-import { atomWithSubscription } from '../../src/urql'
+import { atom, useAtom } from 'jotai'
+import { atomWithSubscription } from 'jotai/urql'
 import { getTestProvider } from '../testUtils'
 
 const generateClient = (id = 'default') =>

--- a/tests/utils/atomFamily.test.tsx
+++ b/tests/utils/atomFamily.test.tsx
@@ -1,8 +1,8 @@
 import { StrictMode, Suspense, useEffect, useRef, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { atom, useAtom } from '../../src/index'
-import type { SetStateAction, WritableAtom } from '../../src/index'
-import { atomFamily, useUpdateAtom } from '../../src/utils'
+import { atom, useAtom } from 'jotai'
+import type { SetStateAction, WritableAtom } from 'jotai'
+import { atomFamily, useUpdateAtom } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/atomWithDefault.test.tsx
+++ b/tests/utils/atomWithDefault.test.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { atom, useAtom } from '../../src/index'
-import { RESET, atomWithDefault } from '../../src/utils'
+import { atom, useAtom } from 'jotai'
+import { RESET, atomWithDefault } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { Observable, Subject } from 'rxjs'
-import { useAtom } from '../../src/index'
-import { atomWithObservable } from '../../src/utils'
+import { useAtom } from 'jotai'
+import { atomWithObservable } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/atomWithReducer.test.tsx
+++ b/tests/utils/atomWithReducer.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/react'
-import { useAtom } from '../../src/index'
-import { atomWithReducer } from '../../src/utils'
+import { useAtom } from 'jotai'
+import { atomWithReducer } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/atomWithStorage.test.tsx
+++ b/tests/utils/atomWithStorage.test.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { useAtom } from '../../src/index'
-import { atomWithHash, atomWithStorage } from '../../src/utils'
+import { useAtom } from 'jotai'
+import { atomWithHash, atomWithStorage } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/atomWithStorage.test.tsx
+++ b/tests/utils/atomWithStorage.test.tsx
@@ -101,7 +101,7 @@ describe('atomWithStorage (async)', () => {
 
     fireEvent.click(getByText('button'))
     await findByText('count: 11')
-    waitFor(() => {
+    await waitFor(() => {
       expect(asyncStorageData.count).toBe(11)
     })
   })
@@ -132,7 +132,7 @@ describe('atomWithStorage (async)', () => {
 
     fireEvent.click(getByText('button'))
     await findByText('count: 21')
-    waitFor(() => {
+    await waitFor(() => {
       expect(asyncStorageData.count2).toBe(21)
     })
   })
@@ -163,7 +163,7 @@ describe('atomWithStorage (async)', () => {
 
     fireEvent.click(getByText('button'))
     await findByText('count: 31')
-    waitFor(() => {
+    await waitFor(() => {
       expect(asyncStorageData.count3).toBe(31)
     })
   })

--- a/tests/utils/freezeAtom.test.tsx
+++ b/tests/utils/freezeAtom.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react'
-import { atom, useAtom } from '../../src/index'
-import { freezeAtom, freezeAtomCreator } from '../../src/utils'
+import { atom, useAtom } from 'jotai'
+import { freezeAtom, freezeAtomCreator } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/loadable.test.tsx
+++ b/tests/utils/loadable.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/react'
-import { Atom, atom } from '../../src/index'
-import { loadable, useAtomValue, useUpdateAtom } from '../../src/utils'
+import { Atom, atom } from 'jotai'
+import { loadable, useAtomValue, useUpdateAtom } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/selectAtom.test.tsx
+++ b/tests/utils/selectAtom.test.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { atom } from '../../src/index'
-import { selectAtom, useAtomValue, useUpdateAtom } from '../../src/utils'
+import { atom } from 'jotai'
+import { selectAtom, useAtomValue, useUpdateAtom } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/splitAtom.test.tsx
+++ b/tests/utils/splitAtom.test.tsx
@@ -3,7 +3,7 @@ import type { ChangeEvent } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
 import type { Atom, PrimitiveAtom } from 'jotai'
-import { splitAtom } from '../../src/utils'
+import { splitAtom } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/useAtomCallback.test.tsx
+++ b/tests/utils/useAtomCallback.test.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { atom, useAtom } from '../../src/index'
-import { useAtomCallback } from '../../src/utils'
+import { atom, useAtom } from 'jotai'
+import { useAtomCallback } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/useAtomValue.test.tsx
+++ b/tests/utils/useAtomValue.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/react'
-import { atom } from '../../src/index'
-import { useAtomValue, useUpdateAtom } from '../../src/utils'
+import { atom } from 'jotai'
+import { useAtomValue, useUpdateAtom } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/useHydrateAtoms.test.tsx
+++ b/tests/utils/useHydrateAtoms.test.tsx
@@ -1,7 +1,7 @@
 import { FC, useRef } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { atom, useAtom } from '../../src/index'
-import { useHydrateAtoms } from '../../src/utils'
+import { atom, useAtom } from 'jotai'
+import { useHydrateAtoms } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/useReducerAtom.test.tsx
+++ b/tests/utils/useReducerAtom.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/react'
-import { atom } from '../../src/index'
-import { useReducerAtom } from '../../src/utils'
+import { atom } from 'jotai'
+import { useReducerAtom } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/useResetAtom.test.tsx
+++ b/tests/utils/useResetAtom.test.tsx
@@ -1,11 +1,11 @@
 import { fireEvent, render } from '@testing-library/react'
-import { atom, useAtom } from '../../src/index'
+import { atom, useAtom } from 'jotai'
 import {
   RESET,
   atomWithReducer,
   atomWithReset,
   useResetAtom,
-} from '../../src/utils'
+} from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/useUpdateAtom.test.tsx
+++ b/tests/utils/useUpdateAtom.test.tsx
@@ -1,8 +1,8 @@
 import { StrictMode, useEffect, useRef } from 'react'
 import type { PropsWithChildren } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { atom, useAtom } from '../../src/index'
-import { useUpdateAtom } from '../../src/utils'
+import { atom, useAtom } from 'jotai'
+import { useUpdateAtom } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/utils/waitForAll.test.tsx
+++ b/tests/utils/waitForAll.test.tsx
@@ -1,7 +1,7 @@
 import { Component, StrictMode, Suspense, useEffect } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { atom, useAtom } from '../../src/index'
-import { atomFamily, useUpdateAtom, waitForAll } from '../../src/utils'
+import { atom, useAtom } from 'jotai'
+import { atomFamily, useUpdateAtom, waitForAll } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/valtio/atomWithProxy.test.tsx
+++ b/tests/valtio/atomWithProxy.test.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { proxy, snapshot } from 'valtio/vanilla'
-import { useAtom } from '../../src/index'
-import { atomWithProxy } from '../../src/valtio'
+import { useAtom } from 'jotai'
+import { atomWithProxy } from 'jotai/valtio'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/xstate/atomWithMachine.test.tsx
+++ b/tests/xstate/atomWithMachine.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/react'
 import { createMachine } from 'xstate'
-import { useAtom } from '../../src/index'
-import { atomWithMachine } from '../../src/xstate'
+import { useAtom } from 'jotai'
+import { atomWithMachine } from 'jotai/xstate'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tests/zustand/atomWithStore.test.tsx
+++ b/tests/zustand/atomWithStore.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render } from '@testing-library/react'
 import create from 'zustand/vanilla'
-import { useAtom } from '../../src/index'
-import { atomWithStore } from '../../src/zustand'
+import { useAtom } from 'jotai'
+import { atomWithStore } from 'jotai/zustand'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "noUncheckedIndexedAccess": true,
     "baseUrl": ".",
     "paths": {
-      "jotai": ["./src/index.ts"]
+      "jotai": ["./src/index.ts"],
+      "jotai/*": ["./src/*.ts"]
     }
   },
   "include": ["src/**/*", "tests/**/*"],


### PR DESCRIPTION
I did this in #737 trying to test against builds.
Anyway, it looks cleaner and should be filed separately.