### PR TITLE
chore(package): specify node versions precisely

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "copy": "shx cp -r dist/src/* dist/esm && shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && downlevel-dts dist dist/ts3.4 && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\""
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14.13.0 || ^12.20.0"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
https://nodejs.org/dist/latest-v14.x/docs/api/packages.html#packages_subpath_patterns
Because, currently, we use subpath patterns.