### PR TITLE
fix(core): resume from suspense on derived atom with async atom dependency

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -166,17 +166,22 @@ export const createStore = (
       return
     }
     atomState.c?.() // cancel read promise
-    delete atomState.e // read error
-    delete atomState.p // read promise
-    delete atomState.c // cancel read promise
-    delete atomState.i // invalidated revision
-    if (!('v' in atomState) || !Object.is(atomState.v, value)) {
-      atomState.v = value
+    if (
+      'e' in atomState || // has read error, or
+      atomState.p || // has read promise, or
+      !('v' in atomState) || // new value, or
+      !Object.is(atomState.v, value) // different value
+    ) {
       ++atomState.r // increment revision
       if (atomState.d.has(atom)) {
         atomState.d.set(atom, atomState.r)
       }
     }
+    atomState.v = value // set value anyway
+    delete atomState.e // clear read error
+    delete atomState.p // clear read promise
+    delete atomState.c // clear cancel read promise
+    delete atomState.i // clear invalidated revision
     setAtomState(atom, atomState, dependencies && prevDependencies)
   }
 
@@ -195,10 +200,10 @@ export const createStore = (
       return
     }
     atomState.c?.() // cancel read promise
-    delete atomState.p // read promise
-    delete atomState.c // cancel read promise
-    delete atomState.i // invalidated revision
-    atomState.e = error // read error
+    delete atomState.p // clear read promise
+    delete atomState.c // clear cancel read promise
+    delete atomState.i // clear invalidated revision
+    atomState.e = error // set read error
     setAtomState(atom, atomState, prevDependencies)
   }
 
@@ -216,16 +221,16 @@ export const createStore = (
       return
     }
     atomState.c?.() // cancel read promise
-    delete atomState.e // read error
+    delete atomState.e // clear read error
     const interruptablePromise = createInterruptablePromise(promise)
-    atomState.p = interruptablePromise // read promise
+    atomState.p = interruptablePromise // set read promise
     atomState.c = interruptablePromise[INTERRUPT_PROMISE]
     setAtomState(atom, atomState, prevDependencies)
   }
 
   const setAtomInvalidated = <Value>(atom: Atom<Value>): void => {
     const [atomState] = prepareNextAtomState(atom)
-    atomState.i = atomState.r // invalidated revision
+    atomState.i = atomState.r // set invalidated revision
     setAtomState(atom, atomState)
   }
 
@@ -239,7 +244,7 @@ export const createStore = (
       atomState.w = promise
     } else if (atomState.w === prevPromise) {
       // delete it only if it's not overwritten
-      delete atomState.w // write promise
+      delete atomState.w // clear write promise
     }
     setAtomState(atom, atomState)
   }

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -76,7 +76,6 @@ it('does not show async stale result', async () => {
 })
 
 it('does not show async stale result on derived atom', async () => {
-  const committed: null[] = []
   const countAtom = atom(0)
   const asyncAlwaysNullAtom = atom(async (get) => {
     get(countAtom)
@@ -93,9 +92,6 @@ it('does not show async stale result on derived atom', async () => {
 
   const DisplayDerivedValue = () => {
     const [derivedValue] = useAtom(derivedAtom)
-    useEffect(() => {
-      committed.push(derivedValue)
-    })
     return <div>derived value: {JSON.stringify(derivedValue)}</div>
   }
 
@@ -136,7 +132,6 @@ it('does not show async stale result on derived atom', async () => {
     getByText('async value: null')
     getByText('derived value: null')
   })
-  expect(committed).toEqual([null])
 
   fireEvent.click(getByText('button'))
 
@@ -153,7 +148,6 @@ it('does not show async stale result on derived atom', async () => {
     getByText('async value: null')
     getByText('derived value: null')
   })
-  expect(committed).toEqual([null])
 })
 
 it('works with async get with extra deps', async () => {

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -90,13 +90,13 @@ it('does not show async stale result on derived atom', async () => {
     useEffect(() => {
       committed.push(derivedValue)
     })
-    return <div>derived value:{derivedValue}</div>
+    return <div>derived value: {JSON.stringify(derivedValue)}</div>
   }
 
   const DisplayAsyncValue = () => {
     const [asyncValue] = useAtom(asyncAlwaysNullAtom)
 
-    return <div>async value:{asyncValue}</div>
+    return <div>async value: {JSON.stringify(asyncValue)}</div>
   }
 
   const Test = () => {
@@ -115,7 +115,7 @@ it('does not show async stale result on derived atom', async () => {
     )
   }
 
-  const { getByText, findByText, queryByText } = render(
+  const { getByText, queryByText } = render(
     <StrictMode>
       <Provider>
         <Test />
@@ -123,25 +123,35 @@ it('does not show async stale result on derived atom', async () => {
     </StrictMode>
   )
 
-  await findByText('count: 0')
-  await findByText('loading async value')
-  await findByText('loading derived value')
+  await waitFor(() => {
+    getByText('count: 0')
+    getByText('loading async value')
+    getByText('loading derived value')
+  })
   await waitFor(() => {
     expect(queryByText('loading async value')).toBeNull()
     expect(queryByText('loading derived value')).toBeNull()
   })
-  await findByText('async value:')
-  await findByText('derived value:')
+  await waitFor(() => {
+    getByText('async value: null')
+    getByText('derived value: null')
+  })
   expect(committed).toEqual([null])
 
   fireEvent.click(getByText('button'))
 
-  await findByText('count: 1')
-  await findByText('loading async value')
-  await findByText('loading derived value')
+  await waitFor(() => {
+    getByText('count: 1')
+    getByText('loading async value')
+    getByText('loading derived value')
+  })
   await waitFor(() => {
     expect(queryByText('loading async value')).toBeNull()
     expect(queryByText('loading derived value')).toBeNull()
+  })
+  await waitFor(() => {
+    getByText('async value: null')
+    getByText('derived value: null')
   })
   expect(committed).toEqual([null])
 })

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -85,6 +85,12 @@ it('does not show async stale result on derived atom', async () => {
   })
   const derivedAtom = atom((get) => get(asyncAlwaysNullAtom))
 
+  const DisplayAsyncValue = () => {
+    const [asyncValue] = useAtom(asyncAlwaysNullAtom)
+
+    return <div>async value: {JSON.stringify(asyncValue)}</div>
+  }
+
   const DisplayDerivedValue = () => {
     const [derivedValue] = useAtom(derivedAtom)
     useEffect(() => {
@@ -93,22 +99,16 @@ it('does not show async stale result on derived atom', async () => {
     return <div>derived value: {JSON.stringify(derivedValue)}</div>
   }
 
-  const DisplayAsyncValue = () => {
-    const [asyncValue] = useAtom(asyncAlwaysNullAtom)
-
-    return <div>async value: {JSON.stringify(asyncValue)}</div>
-  }
-
   const Test = () => {
     const [count, setCount] = useAtom(countAtom)
     return (
       <div>
         <div>count: {count}</div>
-        <Suspense fallback={<div>loading derived value</div>}>
-          <DisplayDerivedValue />
-        </Suspense>
         <Suspense fallback={<div>loading async value</div>}>
           <DisplayAsyncValue />
+        </Suspense>
+        <Suspense fallback={<div>loading derived value</div>}>
+          <DisplayDerivedValue />
         </Suspense>
         <button onClick={() => setCount((c) => c + 1)}>button</button>
       </div>


### PR DESCRIPTION
fix #742.
This is actually something I wasn't very confident with in the logic. Happy to have a fix 🎉 .