### PR TITLE
fix(core): promise handling in store

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -333,10 +333,10 @@ export const createStore = (
                 // schedule another read later
                 e.finally(() => readAtomState(atom, true))
               }
-            } else {
-              setAtomReadError(atom, e, dependencies, promise as Promise<void>)
-              flushPending()
+              return e
             }
+            setAtomReadError(atom, e, dependencies, promise as Promise<void>)
+            flushPending()
           })
       } else {
         value = promiseOrValue as NonPromise<Value>


### PR DESCRIPTION
This is to revert a change in #766. The `return e` statement is required to let tests pass in react 16.8.6.