### PR TITLE
docs(website): enable atomWithObservable CodeSandbox sample

### DIFF
--- a/docs/api/utils.mdx
+++ b/docs/api/utils.mdx
@@ -70,9 +70,8 @@ Its value will be last value emitted from the stream.
 
 To use this atom, you need to wrap your component with `<Suspense>`. Check out [basics/async](../basics/async.mdx).
 
-<!-- TODO: uncomment when fix #760 -->
-<!-- ### Codesandbox -->
-<!-- <CodeSandbox id="88pnt" /> -->
+### Codesandbox
+<CodeSandbox id="88pnt" />
 
 ## useUpdateAtom
 


### PR DESCRIPTION
Enable CodeSandbox sample for `atomWithObservable` since #760 is fixed.