### PR TITLE
feat(devtools): read-only atom support in useAtomDevtools

### DIFF
--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -75,7 +75,7 @@ export function useAtomDevtools<Value>(
       return
     }
     console.warn(
-      '[Warn] you cannot do write operations (Time-travelling, etc) in read-only atoms ',
+      '[Warn] you cannot do write operations (Time-travelling, etc) in read-only atoms\n',
       anAtom
     )
   }

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { useAtom } from 'jotai'
-import type { WritableAtom } from '../'
-import type { Atom, Scope, SetAtom } from '../core/atom'
+import type { Atom, Scope, SetAtom, WritableAtom } from '../core/atom'
 
 type Config = {
   instanceID?: number

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useAtom } from 'jotai'
-import type { Atom, Scope, SetAtom, WritableAtom } from '../core/atom'
+import type { Atom, WritableAtom } from 'jotai'
+import type { Scope, SetAtom } from '../core/atom'
 
 type Config = {
   instanceID?: number

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -31,8 +31,8 @@ type Extension = {
   connect: (options?: Config) => ConnectionResult
 }
 
-export function useAtomDevtools<Value>(
-  anAtom: WritableAtom<Value, Value>,
+export function useAtomDevtools<Value, Result extends void | Promise<void>>(
+  anAtom: WritableAtom<Value, Value, Result>,
   name?: string,
   scope?: Scope
 ): void
@@ -43,8 +43,8 @@ export function useAtomDevtools<Value>(
   scope?: Scope
 ): void
 
-export function useAtomDevtools<Value>(
-  anAtom: WritableAtom<Value, Value> | Atom<Value>,
+export function useAtomDevtools<Value, Result extends void | Promise<void>>(
+  anAtom: WritableAtom<Value, Value, Result> | Atom<Value>,
   name?: string,
   scope?: Scope
 ): void {

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -32,18 +32,6 @@ type Extension = {
 }
 
 export function useAtomDevtools<Value, Result extends void | Promise<void>>(
-  anAtom: WritableAtom<Value, Value, Result>,
-  name?: string,
-  scope?: Scope
-): void
-
-export function useAtomDevtools<Value>(
-  anAtom: Atom<Value>,
-  name?: string,
-  scope?: Scope
-): void
-
-export function useAtomDevtools<Value, Result extends void | Promise<void>>(
   anAtom: WritableAtom<Value, Value, Result> | Atom<Value>,
   name?: string,
   scope?: Scope


### PR DESCRIPTION
Previously, `useAtomDevtools` only accepts primitive atoms (more precisely `WritableAtom<Value, Value>` type). Now, with this PR, it supports read-only atoms (`Atom<Value>` type).

close #808 
