### PR TITLE
refactor(core): improve invalidated revision

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -218,6 +218,7 @@ export const createStore = (
     const interruptablePromise = createInterruptablePromise(promise)
     atomState.p = interruptablePromise // set read promise
     atomState.c = interruptablePromise[INTERRUPT_PROMISE]
+    delete atomState.i // clear invalidated revision
     setAtomState(atom, atomState)
   }
 
@@ -243,8 +244,6 @@ export const createStore = (
               const aState = getAtomState(a)
               if (
                 aState &&
-                !('e' in aState) && // no read error
-                !aState.p && // no read promise
                 aState.r === aState.i // revision is invalidated
               ) {
                 readAtomState(a, true)


### PR DESCRIPTION
we should clear obsoleted invalidated revision, so that we can skip checking.
there would be room for improvement in AtomState types. will revisit it in the future.