### PR TITLE
Update readme with a CTA for jotai egghead course

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -168,7 +168,7 @@ yarn add jotai react
 
 ## Learn Jotai
 
-[![egghead course by Daishi](https://res.cloudinary.com/dg3gyk0gu/image/upload/v1636388460/egghead-next-pages/jotai/github--jotai-atoms.png)](https://egghead.io/courses/manage-application-state-with-jotai-atoms-2c3a29f0?utm_source=github&utm_medium=cta&utm_term=jotai)
+[![free egghead Jotai introduction course by Daishi](https://res.cloudinary.com/dg3gyk0gu/image/upload/v1636388460/egghead-next-pages/jotai/github--jotai-atoms.png)](https://egghead.io/courses/manage-application-state-with-jotai-atoms-2c3a29f0?utm_source=github&utm_medium=cta&utm_term=jotai)
 
 ## More documents
 

--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,10 @@ yourself.
 yarn add jotai react
 ```
 
+## Learn Jotai
+
+[![egghead course by Daishi](https://res.cloudinary.com/dg3gyk0gu/image/upload/v1636388460/egghead-next-pages/jotai/github--jotai-atoms.png)](https://egghead.io/courses/manage-application-state-with-jotai-atoms-2c3a29f0?utm_source=github&utm_medium=cta&utm_term=jotai)
+
 ## More documents
 
 - Basics


### PR DESCRIPTION
This updates the readme with a link to Daishi's [egghead course on Jotai](https://egghead.io/courses/manage-application-state-with-jotai-atoms-2c3a29f0) with a nice banner.


![zacjones93jotai  Primitive and flexible state management for Re](https://user-images.githubusercontent.com/6188161/140779914-b6c5367b-120b-4761-aafd-60cb4e02a816.png)

![ghost](https://media0.giphy.com/media/aTf4PONtSYB1e/giphy.gif?cid=74e95743p0ednat9htrj2fzhkfxa8gc2xvkggeq2h3y56lyz&rid=giphy.gif&ct=g)