### PR TITLE
chore: extend gitignore directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ node_modules
 # testing
 coverage
 
+# development
+.devcontainer
+.vscode
+
 # production
 dist
 build
@@ -25,3 +29,4 @@ yarn-error.log*
 # misc
 .DS_Store
 .idea
+


### PR DESCRIPTION
The new directives are for files generated by [GitHub Codespaces](https://github.com/features/codespaces). 😀