### PR TITLE
fix(utils): Unwrap loadable/selectAtom promise types

### DIFF
--- a/src/utils/loadable.ts
+++ b/src/utils/loadable.ts
@@ -2,12 +2,14 @@ import { atom } from 'jotai'
 import type { Atom } from 'jotai'
 import { createMemoizeAtom } from './weakCache'
 
+type ResolveType<T> = T extends Promise<infer V> ? V : T
+
 const memoizeAtom = createMemoizeAtom()
 
 type Loadable<Value> =
   | { state: 'loading' }
   | { state: 'hasError'; error: unknown }
-  | { state: 'hasData'; data: Value }
+  | { state: 'hasData'; data: ResolveType<Value> }
 
 export function loadable<Value>(anAtom: Atom<Value>): Atom<Loadable<Value>> {
   return memoizeAtom(() => {
@@ -18,7 +20,7 @@ export function loadable<Value>(anAtom: Atom<Value>): Atom<Loadable<Value>> {
       const ref = get(refAtom)
       let curr = ref.prev
       try {
-        const value = get(anAtom)
+        const value = get(anAtom) as ResolveType<Value>
         if (curr?.state !== 'hasData' || !Object.is(curr.data, value)) {
           curr = { state: 'hasData', data: value }
         }

--- a/src/utils/selectAtom.ts
+++ b/src/utils/selectAtom.ts
@@ -2,18 +2,20 @@ import { atom } from 'jotai'
 import type { Atom } from 'jotai'
 import { createMemoizeAtom } from './weakCache'
 
+type ResolveType<T> = T extends Promise<infer V> ? V : T
+
 const memoizeAtom = createMemoizeAtom()
 
 export function selectAtom<Value, Slice>(
   anAtom: Atom<Value>,
-  selector: (v: Value) => Slice,
+  selector: (v: ResolveType<Value>) => Slice,
   equalityFn: (a: Slice, b: Slice) => boolean = Object.is
 ): Atom<Slice> {
   return memoizeAtom(() => {
     // TODO we should revisit this for a better solution than refAtom
     const refAtom = atom(() => ({} as { prev?: Slice }))
     const derivedAtom = atom((get) => {
-      const slice = selector(get(anAtom))
+      const slice = selector(get(anAtom) as ResolveType<Value>)
       const ref = get(refAtom)
       if ('prev' in ref && equalityFn(ref.prev as Slice, slice)) {
         return ref.prev as Slice

--- a/tests/utils/loadable.test.tsx
+++ b/tests/utils/loadable.test.tsx
@@ -145,5 +145,8 @@ const LoadableComponent = ({ asyncAtom }: LoadableComponentProps) => {
     return <>{String(value.error)}</>
   }
 
-  return <>Data: {value.data}</>
+  // this is to ensure correct typing
+  const data: number | string = value.data
+
+  return <>Data: {data}</>
 }


### PR DESCRIPTION
#713 changed the type signature for atoms. The `data` field for a loadable ended up incorrectly typed with a promise, when it should be unwrapped.

A similar issue occurred with `selectAtom`

This adds a `ResolveType` (used in other files) to fix it.