### PR TITLE
fix(type): improve core typing

### DIFF
--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -13,6 +13,9 @@ type WriteGetter = Getter & {
   <Value>(atom: Atom<Promise<Value>>, unstable_promise: true):
     | Promise<Value>
     | Value
+  <Value>(atom: Atom<Value>, unstable_promise: true):
+    | Promise<ResolveType<Value>>
+    | ResolveType<Value>
 }
 
 type Setter = {

--- a/src/core/useAtom.ts
+++ b/src/core/useAtom.ts
@@ -73,8 +73,6 @@ export function useAtom<Value, Update, Result extends void | Promise<void>>(
   )
 
   if (atomFromUseReducer !== atom) {
-    // Note: This seems like a useReducer bug, doesn't it?
-    // https://github.com/pmndrs/jotai/issues/827
     forceUpdate()
   }
 


### PR DESCRIPTION
Just for a little more consistency. (In the future, we would be refactoring all async typing with `Awaited`.)