### PR TITLE
fix(core): unstable_promise option in write getter

### DIFF
--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -7,13 +7,14 @@ type Getter = {
 }
 
 type WriteGetter = Getter & {
-  <Value>(atom: Atom<Value | Promise<Value>>, unstable_promise: true):
+  <Value>(
+    atom: Atom<Value | Promise<Value>>,
+    options: { unstable_promise: true }
+  ): Promise<Value> | Value
+  <Value>(atom: Atom<Promise<Value>>, options: { unstable_promise: true }):
     | Promise<Value>
     | Value
-  <Value>(atom: Atom<Promise<Value>>, unstable_promise: true):
-    | Promise<Value>
-    | Value
-  <Value>(atom: Atom<Value>, unstable_promise: true):
+  <Value>(atom: Atom<Value>, options: { unstable_promise: true }):
     | Promise<ResolveType<Value>>
     | ResolveType<Value>
 }


### PR DESCRIPTION
This experimental feature is first introduced in #539.
We don't get much feedback, and it's still experimental.
But, we hope to make it stable in the future. For now, this makes it an option object and no longer warns.