### PR TITLE
fix(urql): atomWithQuery for edge cases

### DIFF
--- a/src/urql/atomWithQuery.ts
+++ b/src/urql/atomWithQuery.ts
@@ -5,7 +5,7 @@ import type {
   RequestPolicy,
   TypedDocumentNode,
 } from '@urql/core'
-import { pipe, subscribe } from 'wonka'
+import { pipe, skip, subscribe } from 'wonka'
 import { atom } from 'jotai'
 import type { Getter, PrimitiveAtom, WritableAtom } from 'jotai'
 import { clientAtom } from './clientAtom'
@@ -110,6 +110,7 @@ export function atomWithQuery<Data, Variables extends object>(
           ...(args.requestPolicy && { requestPolicy: args.requestPolicy }),
           ...args.context,
         }),
+        skip(1), // handled by toPromise
         subscribe(listener)
       )
       return () => subscription.unsubscribe()

--- a/tests/urql/atomWithQuery.test.tsx
+++ b/tests/urql/atomWithQuery.test.tsx
@@ -97,10 +97,14 @@ it('query dependency test', async () => {
 
   await findByText('loading')
   await findByText('count: 0')
+  await findByText('count: 1')
+  await findByText('count: 2')
 
   fireEvent.click(getByText('dummy'))
   await findByText('loading')
+  await findByText('count: 0')
   await findByText('count: 1')
+  await findByText('count: 2')
 })
 
 it('query change client at runtime', async () => {


### PR DESCRIPTION
This is a minor fix to avoid duplicated listener invocations.
Tests are passing, but I might be misunderstanding the expected behavior.
We would like to revisit it in the future. Contributor wanted.