### PR TITLE
atomWithObservable options to allow enabled and initialData

### DIFF
--- a/src/utils/atomWithObservable.ts
+++ b/src/utils/atomWithObservable.ts
@@ -118,16 +118,17 @@ export function atomWithObservable<TData>(
     }
 
     const dataAtom = atom<TData | Promise<TData>>(
-      enabled &&
-        new Promise<TData>((resolve, reject) => {
-          settlePromise = (data, err) => {
-            if (err) {
-              reject(err)
-            } else {
-              resolve(data as TData)
+      enabled && initialData === undefined
+        ? new Promise<TData>((resolve, reject) => {
+            settlePromise = (data, err) => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve(data as TData)
+              }
             }
-          }
-        })
+          })
+        : initialData
     )
     let setData: (data: TData | Promise<TData>) => void = () => {
       throw new Error('setting data without mount')

--- a/src/utils/atomWithObservable.ts
+++ b/src/utils/atomWithObservable.ts
@@ -75,7 +75,7 @@ export function atomWithObservable<TData>(
     let observable =
       typeof createObservable === 'function'
         ? createObservable(get)
-        : createObservable
+        : { enabled: true, ...createObservable }
 
     function getInitialData() {
       const initialData = (
@@ -118,17 +118,16 @@ export function atomWithObservable<TData>(
     }
 
     const dataAtom = atom<TData | Promise<TData>>(
-      enabled
-        ? new Promise<TData>((resolve, reject) => {
-            settlePromise = (data, err) => {
-              if (err) {
-                reject(err)
-              } else {
-                resolve(data as TData)
-              }
+      enabled &&
+        new Promise<TData>((resolve, reject) => {
+          settlePromise = (data, err) => {
+            if (err) {
+              reject(err)
+            } else {
+              resolve(data as TData)
             }
-          })
-        : initialData
+          }
+        })
     )
     let setData: (data: TData | Promise<TData>) => void = () => {
       throw new Error('setting data without mount')

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -70,3 +70,29 @@ it('writable count state', async () => {
   fireEvent.click(getByText('button'))
   await findByText('count: 9')
 })
+
+it('count state from disabled', async () => {
+  const observableAtom = atomWithObservable({
+    enabled: false,
+    observableFn: () =>
+      new Observable<number>((subscriber) => {
+        subscriber.next(1)
+      }),
+  })
+
+  const Counter = () => {
+    const [state] = useAtom(observableAtom)
+
+    return <>count: {state}</>
+  }
+
+  const { findByText } = render(
+    <Provider>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+    </Provider>
+  )
+
+  await findByText('count:')
+})

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -71,40 +71,14 @@ it('writable count state', async () => {
   await findByText('count: 9')
 })
 
-it('count state from disabled', async () => {
-  const observableAtom = atomWithObservable({
-    enabled: false,
-    observableFn: () =>
-      new Observable<number>((subscriber) => {
-        subscriber.next(1)
-      }),
-  })
-
-  const Counter = () => {
-    const [state] = useAtom(observableAtom)
-
-    return <>count: {state}</>
-  }
-
-  const { findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
-  )
-
-  await findByText('count:')
-})
-
 it('count state from initial', async () => {
-  const observableAtom = atomWithObservable({
-    initialData: 5,
-    observableFn: () =>
+  const observableAtom = atomWithObservable(
+    () =>
       new Observable<number>((subscriber) => {
         subscriber.next(1)
       }),
-  })
+    { initialData: 5 }
+  )
 
   const Counter = () => {
     const [state] = useAtom(observableAtom)
@@ -124,9 +98,8 @@ it('count state from initial', async () => {
 })
 
 it('writable count state with initialData', async () => {
-  const observableAtom = atomWithObservable({
-    initialData: 5,
-    observableFn: () => {
+  const observableAtom = atomWithObservable(
+    () => {
       const observable = new Observable<number>((subscriber) => {
         subscriber.next(1)
       })
@@ -137,7 +110,8 @@ it('writable count state with initialData', async () => {
       }, 100)
       return subject
     },
-  })
+    { initialData: 5 }
+  )
 
   const Counter = () => {
     const [state, dispatch] = useAtom(observableAtom)


### PR DESCRIPTION
Allow an options object in `atomWithObservable` that provides the ability to enable/disable the atom and provide an initial data value. 

Currently, the enabled flag is working properly and initialData works as a writable atom, but it does not work as a readable atom only. There is a lot of cleanup that can be done with this around overloads and typing. Have been working on getting a working version first and then will clean up types.

https://github.com/pmndrs/jotai/issues/234