### PR TITLE
fix(core): refactor atomState in store

### DIFF
--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -66,7 +66,9 @@ const stateToPrintable = ([store, atoms]: [Store, Atom<unknown>[]]) =>
         [
           atomToPrintable(atom),
           {
-            value: atomState.e || atomState.p || atomState.v,
+            ...('e' in atomState && { error: atomState.e }),
+            ...('p' in atomState && { promise: atomState.p }),
+            ...('v' in atomState && { value: atomState.v }),
             dependents: Array.from(dependents).map(atomToPrintable),
           },
         ],

--- a/src/core/useAtom.ts
+++ b/src/core/useAtom.ts
@@ -45,7 +45,7 @@ export function useAtom<Value, Update, Result extends void | Promise<void>>(
     if ('e' in atomState) {
       throw atomState.e // read error
     }
-    if (atomState.p) {
+    if ('p' in atomState) {
       throw atomState.p // read promise
     }
     if ('v' in atomState) {

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -16,7 +16,7 @@ const createAtomsSnapshot = (
 ): AtomsSnapshot => {
   const tuples = atoms.map<[Atom<unknown>, unknown]>((atom) => {
     const atomState = store[DEV_GET_ATOM_STATE]?.(atom) ?? ({} as AtomState)
-    return [atom, atomState.v]
+    return [atom, 'v' in atomState ? atomState.v : undefined]
   })
   return new Map(tuples)
 }


### PR DESCRIPTION
Thanks to @Thisen 's work in #878, it reveals my misconception. It's almost from the beginning and I thought it covered the #877 case, which was wrong. Based on the new tests, this PR fixes my mistake and it works with stricter types.