### PR TITLE
doc: Added TOC to Utils page

### DIFF
--- a/docs/api/utils.mdx
+++ b/docs/api/utils.mdx
@@ -64,7 +64,7 @@ nav: 2.2
 
 15. [freezeAtom](#freezeAtom)
     
-    The freezeAtom takes an existing atom and returns a new derived atom.
+    The freezeAtom takes an existing atom and returns a new derived atom. The value with the new derived atom will be frozen (= not mutable).
 
 16. [freezeAtomCreator](#freezeAtomCreator)
     

--- a/docs/api/utils.mdx
+++ b/docs/api/utils.mdx
@@ -4,6 +4,86 @@ description: This doc describes `jotai/utils` bundle.
 nav: 2.2
 ---
 
+## Table of Contents
+
+1. [atomWithStorage](#atomWithStorage)
+
+   The atomWithStorage function creates an atom with a value persisted in localStorage or sessionStorage for React or AsyncStorage for React Native.
+
+2. [atomWithObservable](#atomWithObservable)
+   
+   The atomWithObservable function creates an atom from a rxjs (or similar) subject or observable. Its value will be last value emitted from the stream.
+
+3. [useUpdateAtom](#useUpdateAtom)
+   
+   Use useUpdateAtom and write-only atoms to avoid re-render.
+
+4. [useAtomValue](#useAtomValue)
+   
+   Returns the value of the given atom.
+
+5. [atomWithReset](#atomWithReset)
+   
+   Creates an atom that could be reset to its initialValue with useResetAtom hook.
+
+6. [useResetAtom](#useResetAtom)
+   
+   Resets a Resettable atom to its initial value.
+
+7. [RESET](#RESET)
+   
+   Special value that is accepted by Resettable atoms created with atomWithReset, atomWithDefault or writable atom created with atom if it accepts RESET symbol.
+
+8. [useReducerAtom](#useReducerAtom)
+   
+   Use this hook to update an atom value with a reducer function.
+
+9.  [atomWithReducer](#atomWithReducer)
+    
+    This is a function to create an atom with an embeded reducer function to update the value.
+
+10. [atomWithDefault](#atomWithDefault)
+    
+    This is a function to create a resettable primitive atom. Its default value can be specified with a read function instead of a static initial value.
+
+11. [atomWithHash](#atomWithHash)
+    
+    This creates a new atom that is connected with URL hash.
+
+12. [atomFamily](#atomFamily)
+    
+    This will create a function that takes param and returns an atom.
+
+13. [selectAtom](#selectAtom)
+    
+    This function creates a derived atom whose value is a function of the original atom's value, determined by selector.
+
+14. [useAtomCallback](#useAtomCallback)
+    
+    This hook allows to interact with atoms imperatively.
+
+15. [freezeAtom](#freezeAtom)
+    
+    The freezeAtom takes an existing atom and returns a new derived atom.
+
+16. [freezeAtomCreator](#freezeAtomCreator)
+    
+    Instead of create a frozen atom from an existing atom, freezeAtomCreator takes an atom creator function and returns a new function.
+
+17. [splitAtom](#splitAtom)
+    
+    The splitAtom utility is useful for when you want to get an atom for each element in a list.
+
+18. [waitForAll](#waitForAll)
+    
+    The waitForAll utility is a concurrency helper, which allows us to evaluate multiple async atoms.
+
+19. [useHydrateAtoms](#useHydrateAtoms)
+    
+    The primary use case for useHydrateAtoms are SSR apps like Next.js, where an initial value is e.g. fetched on the server, which can be passed to a component by props.
+
+---
+
 ## atomWithStorage
 
 Ref: https://github.com/pmndrs/jotai/pull/394

--- a/docs/api/utils.mdx
+++ b/docs/api/utils.mdx
@@ -44,7 +44,7 @@ nav: 2.2
 
 10. [atomWithDefault](#atomWithDefault)
     
-    This is a function to create a resettable primitive atom. Its default value can be specified with a read function instead of a static initial value.
+    This is a function to create an overwritable primitive atom. Its default value can be specified with a read function instead of a static initial value.
 
 11. [atomWithHash](#atomWithHash)
     


### PR DESCRIPTION
Adding a table of content to the Utils doc page. Added a one line description of each utility to make it easier to find the one someone is looking for.

As discussed [here on Twitter](https://twitter.com/dai_shi/status/1468926381195415555?s=20)