### PR TITLE
fix(type): Fix types on waitForAll to work with destructuring

### DIFF
--- a/src/utils/waitForAll.ts
+++ b/src/utils/waitForAll.ts
@@ -4,11 +4,15 @@ import { createMemoizeAtom } from './weakCache'
 
 const memoizeAtom = createMemoizeAtom()
 
-type ResolveType<T> = T extends Promise<infer V> ? V : T
+type ResolvePromise<T> = T extends Promise<infer V> ? V : T
+type ResolveAtom<T> = T extends Atom<infer V> ? V : T
+type ResolveType<T> = ResolvePromise<ResolveAtom<T>>
 
 export function waitForAll<
-  Values extends Record<string, unknown> | readonly unknown[]
->(atoms: { [K in keyof Values]: Atom<Values[K]> }): Atom<{
+  Values extends Record<string, Atom<unknown>> | readonly Atom<unknown>[]
+>(
+  atoms: Values
+): Atom<{
   [K in keyof Values]: ResolveType<Values[K]>
 }> {
   const createAtom = () => {
@@ -43,14 +47,18 @@ export function waitForAll<
 }
 
 const unwrapAtoms = <
-  Values extends Record<string, unknown> | unknown[]
->(atoms: { [K in keyof Values]: Atom<Values[K]> }): Atom<unknown>[] =>
+  Values extends Record<string, Atom<unknown>> | readonly Atom<unknown>[]
+>(
+  atoms: Values
+): Atom<unknown>[] =>
   Array.isArray(atoms)
     ? atoms
     : Object.getOwnPropertyNames(atoms).map((key) => atoms[key as keyof Values])
 
-const wrapResults = <Values extends Record<string, unknown> | unknown[]>(
-  atoms: { [K in keyof Values]: Atom<Values[K]> },
+const wrapResults = <
+  Values extends Record<string, Atom<unknown>> | readonly Atom<unknown>[]
+>(
+  atoms: Values,
   results: unknown[]
 ): unknown[] | Record<string, unknown> =>
   Array.isArray(atoms)

--- a/src/utils/waitForAll.ts
+++ b/src/utils/waitForAll.ts
@@ -9,11 +9,11 @@ type ResolveAtom<T> = T extends Atom<infer V> ? V : T
 type ResolveType<T> = ResolvePromise<ResolveAtom<T>>
 
 export function waitForAll<
-  Values extends Record<string, Atom<unknown>> | readonly Atom<unknown>[]
+  Atoms extends Record<string, Atom<unknown>> | readonly Atom<unknown>[]
 >(
-  atoms: Values
+  atoms: Atoms
 ): Atom<{
-  [K in keyof Values]: ResolveType<Values[K]>
+  [K in keyof Atoms]: ResolveType<Atoms[K]>
 }> {
   const createAtom = () => {
     const unwrappedAtoms = unwrapAtoms(atoms)
@@ -34,7 +34,7 @@ export function waitForAll<
         throw Promise.all(promises)
       }
       return wrapResults(atoms, values) as {
-        [K in keyof Values]: ResolveType<Values[K]>
+        [K in keyof Atoms]: ResolveType<Atoms[K]>
       }
     })
     return derivedAtom
@@ -47,18 +47,18 @@ export function waitForAll<
 }
 
 const unwrapAtoms = <
-  Values extends Record<string, Atom<unknown>> | readonly Atom<unknown>[]
+  Atoms extends Record<string, Atom<unknown>> | readonly Atom<unknown>[]
 >(
-  atoms: Values
+  atoms: Atoms
 ): Atom<unknown>[] =>
   Array.isArray(atoms)
     ? atoms
-    : Object.getOwnPropertyNames(atoms).map((key) => atoms[key as keyof Values])
+    : Object.getOwnPropertyNames(atoms).map((key) => atoms[key as keyof Atoms])
 
 const wrapResults = <
-  Values extends Record<string, Atom<unknown>> | readonly Atom<unknown>[]
+  Atoms extends Record<string, Atom<unknown>> | readonly Atom<unknown>[]
 >(
-  atoms: Values,
+  atoms: Atoms,
   results: unknown[]
 ): unknown[] | Record<string, unknown> =>
   Array.isArray(atoms)

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -1,7 +1,26 @@
 import { expectType } from 'ts-expect'
-import { atom, useAtom } from 'jotai'
 import type { Atom, PrimitiveAtom, WritableAtom } from 'jotai'
+import { atom, useAtom } from 'jotai'
+import { useAtomValue, waitForAll } from 'jotai/utils'
 import type { SetAtom } from '../src/core/atom'
+
+it('waitForAll() should return the correct types', () => {
+  function Component() {
+    const numberAtom = atom(async () => 0)
+    const stringAtom = atom(async () => '')
+
+    const [number, string] = useAtomValue(waitForAll([numberAtom, stringAtom]))
+    expectType<number>(number)
+    expectType<string>(string)
+
+    const { numberAtom: number2, stringAtom: string2 } = useAtomValue(
+      waitForAll({ numberAtom, stringAtom })
+    )
+    expectType<number>(number2)
+    expectType<string>(string2)
+  }
+  Component
+})
 
 it('atom() should return the correct types', () => {
   function Component() {

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -1,6 +1,6 @@
 import { expectType } from 'ts-expect'
-import type { Atom, PrimitiveAtom, WritableAtom } from 'jotai'
 import { atom, useAtom } from 'jotai'
+import type { Atom, PrimitiveAtom, WritableAtom } from 'jotai'
 import type { SetAtom } from '../src/core/atom'
 
 it('atom() should return the correct types', () => {

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -1,26 +1,7 @@
 import { expectType } from 'ts-expect'
 import type { Atom, PrimitiveAtom, WritableAtom } from 'jotai'
 import { atom, useAtom } from 'jotai'
-import { useAtomValue, waitForAll } from 'jotai/utils'
 import type { SetAtom } from '../src/core/atom'
-
-it('waitForAll() should return the correct types', () => {
-  function Component() {
-    const numberAtom = atom(async () => 0)
-    const stringAtom = atom(async () => '')
-
-    const [number, string] = useAtomValue(waitForAll([numberAtom, stringAtom]))
-    expectType<number>(number)
-    expectType<string>(string)
-
-    const { numberAtom: number2, stringAtom: string2 } = useAtomValue(
-      waitForAll({ numberAtom, stringAtom })
-    )
-    expectType<number>(number2)
-    expectType<string>(string2)
-  }
-  Component
-})
 
 it('atom() should return the correct types', () => {
   function Component() {

--- a/tests/utils/waitForAll.test.tsx
+++ b/tests/utils/waitForAll.test.tsx
@@ -126,7 +126,7 @@ it('can use named atoms in derived atom', async () => {
         str: anotherAsyncAtom,
       })
     )
-    return { num: num * 2, str: str.toUpperCase() }
+    return { num, str }
   })
 
   const Counter = () => {
@@ -155,7 +155,7 @@ it('can use named atoms in derived atom', async () => {
   })
 
   await waitFor(() => {
-    getByText('num: 2, str: A')
+    getByText('num: 1, str: a')
     expect(isAsyncAtomRunning).toBe(false)
     expect(isAnotherAsyncAtomRunning).toBe(false)
   })

--- a/tests/utils/waitForAll.test.tsx
+++ b/tests/utils/waitForAll.test.tsx
@@ -67,7 +67,7 @@ it('waits for two async atoms', async () => {
     )
     return (
       <div>
-        num: {num * 2}, str: {str.toUpperCase()}
+        num: {num}, str: {str}
       </div>
     )
   }
@@ -89,7 +89,7 @@ it('waits for two async atoms', async () => {
   })
 
   await waitFor(() => {
-    getByText('num: 2, str: A')
+    getByText('num: 1, str: a')
     expect(isAsyncAtomRunning).toBe(false)
     expect(isAnotherAsyncAtomRunning).toBe(false)
   })

--- a/tests/utils/waitForAll.types.test.tsx
+++ b/tests/utils/waitForAll.types.test.tsx
@@ -1,0 +1,21 @@
+import { expectType } from 'ts-expect'
+import { atom } from 'jotai'
+import { useAtomValue, waitForAll } from 'jotai/utils'
+
+it('waitForAll() should return the correct types', () => {
+  function Component() {
+    const numberAtom = atom(async () => 0)
+    const stringAtom = atom(async () => '')
+
+    const [number, string] = useAtomValue(waitForAll([numberAtom, stringAtom]))
+    expectType<number>(number)
+    expectType<string>(string)
+
+    const { numberAtom: number2, stringAtom: string2 } = useAtomValue(
+      waitForAll({ numberAtom, stringAtom })
+    )
+    expectType<number>(number2)
+    expectType<string>(string2)
+  }
+  Component
+})


### PR DESCRIPTION
Example:
```typescript
const numberAtom = atom(0)
const stringAtom = atom('')
const [num, str] = useAtomValue(waitForAll([numberAtom, stringAtom]))
```

Previously, in the code above, both `num` and `str` would have the type `number | string | undefined`. With this fix, `num` has the type `number` and `str` has the type `string`.
