### PR TITLE
useAtomsDevtools: Show all atoms updated by a write

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -919,6 +919,11 @@ export const createStore = (
   }
 }
 
+export type Store = ReturnType<typeof createStore>
+
+// TODO: make the following code development mode only, and dead-code eliminated in production:
+
+// TODO: inline this
 const isDebugMode = () =>
   typeof process === 'object' && process.env.NODE_ENV !== 'production'
 
@@ -944,14 +949,10 @@ class BaseEvent {
     }
   }
 }
+
+/** Records all the atoms and their update values as a write fans out. */
 export class WriteEvent extends BaseEvent {
   type = 'set' as const
-  static getRootEvent(writeEvent: WriteEvent) {
-    while (writeEvent.parent) {
-      writeEvent = writeEvent.parent
-    }
-    return writeEvent
-  }
 
   update: unknown
   parent: WriteEvent | undefined
@@ -968,12 +969,20 @@ export class WriteEvent extends BaseEvent {
     this.children.push(child)
     return child
   }
+
+  getRoot() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let writeEvent: WriteEvent = this
+    while (writeEvent.parent) {
+      writeEvent = writeEvent.parent
+    }
+    return writeEvent
+  }
 }
 
-export class ReadEvent extends DevtoolsEvent {}
+// TODO: attach the read event to ReadDependencies
+export class ReadEvent extends BaseEvent {
+  type = 'get' as const
+}
 
 export type DevtoolsEvent = ReadEvent | WriteEvent
-
-// Debug-only
-
-export type Store = ReturnType<typeof createStore>

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -94,7 +94,7 @@ type Mounted = {
 }
 
 // for debugging purpose only
-type StateListener = () => void
+type StateListener = (write?: WriteEvent) => void
 type MountedAtoms = Set<AnyAtom>
 
 // store methods (not for public API)
@@ -602,7 +602,8 @@ export const createStore = (
   const writeAtomState = <Value, Update, Result extends void | Promise<void>>(
     version: VersionObject | undefined,
     atom: WritableAtom<Value, Update, Result>,
-    update: Update
+    update: Update,
+    event?: WriteEvent
   ): void | Promise<void> => {
     let isSync = true
     const writeGetter: WriteGetter = <V>(
@@ -669,7 +670,12 @@ export const createStore = (
         setAtomPromiseOrValue(version, a, v)
         invalidateDependents(version, a)
       } else {
-        promiseOrVoid = writeAtomState(version, a as AnyWritableAtom, v)
+        promiseOrVoid = writeAtomState(
+          version,
+          a as AnyWritableAtom,
+          v,
+          event?.newChildWrite(a, v)
+        )
       }
       if (!isSync) {
         flushPending(version)
@@ -687,7 +693,10 @@ export const createStore = (
     update: Update,
     version?: VersionObject
   ): void | Promise<void> => {
-    const promiseOrVoid = writeAtomState(version, writingAtom, update)
+    const event = isDebugMode()
+      ? new WriteEvent(writingAtom, update)
+      : undefined
+    const promiseOrVoid = writeAtomState(version, writingAtom, update, event)
     flushPending(version)
     return promiseOrVoid
   }
@@ -793,7 +802,10 @@ export const createStore = (
     })
   }
 
-  const flushPending = (version: VersionObject | undefined): void => {
+  const flushPending = (
+    version: VersionObject | undefined,
+    writeEvent?: WriteEvent
+  ): void => {
     if (version) {
       const versionedAtomStateMap = getVersionedAtomStateMap(version)
       versionedAtomStateMap.forEach((atomState, atom) => {
@@ -815,7 +827,7 @@ export const createStore = (
       mounted?.l.forEach((listener) => listener())
     })
     if (typeof process === 'object' && process.env.NODE_ENV !== 'production') {
-      stateListeners.forEach((l) => l())
+      stateListeners.forEach((l) => l(writeEvent))
     }
   }
 
@@ -896,5 +908,54 @@ export const createStore = (
     [RESTORE_ATOMS]: restoreAtoms,
   }
 }
+
+const isDebugMode = () =>
+  typeof process === 'object' && process.env.NODE_ENV !== 'production'
+export class DevtoolsEvent {
+  atom: AnyAtom
+  stack: string[]
+  ts: number
+  constructor(atom: AnyAtom) {
+    this.ts = Date.now()
+    this.atom = atom
+    try {
+      throw new Error()
+    } catch (error) {
+      if (error && error instanceof Error && error.stack) {
+        this.stack = error.stack.split('\n')
+      } else {
+        this.stack = []
+      }
+    }
+  }
+}
+export class WriteEvent extends DevtoolsEvent {
+  static getRootEvent(writeEvent: WriteEvent) {
+    while (writeEvent.parent) {
+      writeEvent = writeEvent.parent
+    }
+    return writeEvent
+  }
+
+  update: unknown
+  parent: WriteEvent | undefined
+  children: WriteEvent[] = []
+
+  constructor(atom: AnyAtom, update: unknown) {
+    super(atom)
+    this.update = update
+  }
+
+  newChildWrite(atom: AnyAtom, update: unknown) {
+    const child = new WriteEvent(atom, update)
+    child.parent = this
+    this.children.push(child)
+    return child
+  }
+}
+
+export class ReadEvent extends DevtoolsEvent {}
+
+// Debug-only
 
 export type Store = ReturnType<typeof createStore>

--- a/src/devtools/useAtomsDevtools.ts
+++ b/src/devtools/useAtomsDevtools.ts
@@ -153,7 +153,7 @@ export function useAtomsDevtools(name: string, scope?: Scope) {
           return prev
         }
         return event
-          ? [values, dependents, WriteEvent.getRootEvent(event)]
+          ? [values, dependents, event.getRoot()]
           : [values, dependents]
       })
     }


### PR DESCRIPTION
Draft PR to address one idea in https://github.com/pmndrs/jotai/issues/931.

The idea of this PR is to records all the atoms changed during an atom write into an event, and then uses that event data to enhance redux devtools.

I think I need to propagate the write event through all codepaths that call flushPending.

Here's a screenshot of the goal:

![image](https://user-images.githubusercontent.com/296279/148695420-7f912559-8337-48e3-b688-d329822de70c.png)

for this example component:

![image](https://user-images.githubusercontent.com/296279/148695485-188ce350-60e5-4e55-8e1d-8756491bab16.png)

