### PR TITLE
fix(babel): Require that atom is in module scope for react refresh

### DIFF
--- a/src/babel/plugin-react-refresh.ts
+++ b/src/babel/plugin-react-refresh.ts
@@ -48,13 +48,16 @@ export default function reactRefreshPlugin({
         }
       },
       VariableDeclarator(nodePath, state) {
+        console.log(nodePath.parentPath.parentPath?.type)
         if (
           t.isIdentifier(nodePath.node.id) &&
           t.isCallExpression(nodePath.node.init) &&
           isAtom(t, nodePath.node.init.callee) &&
           // Make sure atom declaration is in module scope
-          nodePath.parentPath.parentPath?.isProgram()
+          (nodePath.parentPath.parentPath?.isProgram() ||
+            nodePath.parentPath.parentPath?.isExportNamedDeclaration())
         ) {
+          console.log('yay!')
           const filename = state.filename || 'unknown'
           const atomKey = `${filename}/${nodePath.node.id.name}`
 

--- a/src/babel/plugin-react-refresh.ts
+++ b/src/babel/plugin-react-refresh.ts
@@ -48,7 +48,6 @@ export default function reactRefreshPlugin({
         }
       },
       VariableDeclarator(nodePath, state) {
-        console.log(nodePath.parentPath.parentPath?.type)
         if (
           t.isIdentifier(nodePath.node.id) &&
           t.isCallExpression(nodePath.node.init) &&
@@ -57,7 +56,6 @@ export default function reactRefreshPlugin({
           (nodePath.parentPath.parentPath?.isProgram() ||
             nodePath.parentPath.parentPath?.isExportNamedDeclaration())
         ) {
-          console.log('yay!')
           const filename = state.filename || 'unknown'
           const atomKey = `${filename}/${nodePath.node.id.name}`
 

--- a/src/babel/plugin-react-refresh.ts
+++ b/src/babel/plugin-react-refresh.ts
@@ -51,7 +51,9 @@ export default function reactRefreshPlugin({
         if (
           t.isIdentifier(nodePath.node.id) &&
           t.isCallExpression(nodePath.node.init) &&
-          isAtom(t, nodePath.node.init.callee)
+          isAtom(t, nodePath.node.init.callee) &&
+          // Make sure atom declaration is in module scope
+          nodePath.parentPath.parentPath?.isProgram()
         ) {
           const filename = state.filename || 'unknown'
           const atomKey = `${filename}/${nodePath.node.id.name}`

--- a/tests/babel/plugin-react-refresh.test.ts
+++ b/tests/babel/plugin-react-refresh.test.ts
@@ -83,8 +83,8 @@ it('Should add a cache for multiple exported atoms', () => {
       }
 
     };
-    export const countAtom = atom(0);
-    export const doubleAtom = atom(get => get(countAtom) * 2);"
+    export const countAtom = globalThis.jotaiAtomCache.get(\\"/src/atoms/index.ts/countAtom\\", atom(0));
+    export const doubleAtom = globalThis.jotaiAtomCache.get(\\"/src/atoms/index.ts/doubleAtom\\", atom(get => get(countAtom) * 2));"
   `)
 })
 
@@ -131,7 +131,7 @@ it('Should add a cache for mixed exports of atoms', () => {
       }
 
     };
-    export const countAtom = atom(0);
+    export const countAtom = globalThis.jotaiAtomCache.get(\\"/src/atoms/index.ts/countAtom\\", atom(0));
     export default globalThis.jotaiAtomCache.get(\\"/src/atoms/index.ts/defaultExport\\", atom(get => get(countAtom) * 2));"
   `)
 })


### PR DESCRIPTION
Fixes #891.

For simplicity, we require that the atom is in module scope for the cache to work. If we wanted to support the case in #891, we need need to depend on the call order (like hooks), but I think that's too complex for current use cases. If it gets requested, we can investigate what we can do.