### PR TITLE
fix(core): handle edge cases, not to mount dependency atoms if the atom is not mounted

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -793,7 +793,10 @@ export const createStore = (
       const mounted = mountedMap.get(a)
       if (mounted) {
         mounted.t.add(atom) // add to dependents
-      } else {
+      } else if (mountedMap.has(atom)) {
+        // we mount dependencies only when atom is already mounted
+        // Note: we should revisit this when you find other issues
+        // https://github.com/pmndrs/jotai/issues/942
         mountAtom(a, atom)
       }
     })

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -953,3 +953,32 @@ it('chained derive atom with onMount and useEffect (#897)', async () => {
 
   await findByText('count: 1')
 })
+
+it('onMount is not called when atom value is accessed from writeGetter in derived atom (#942)', async () => {
+  const onUnmount = jest.fn()
+  const onMount = jest.fn(() => {
+    return onUnmount
+  })
+
+  const aAtom = atom(false)
+  aAtom.onMount = onMount
+
+  const bAtom = atom(null, (get) => {
+    get(aAtom)
+  })
+
+  const App = () => {
+    const [, action] = useAtom(bAtom)
+    useEffect(() => action(), [action])
+    return null
+  }
+
+  render(
+    <Provider>
+      <App />
+    </Provider>
+  )
+
+  expect(onMount).not.toBeCalled()
+  expect(onUnmount).not.toBeCalled()
+})


### PR DESCRIPTION
fix #942.

(edit by @dai-shi) the solution seems a little bit hacky and may break other use cases. we look for more cases and tests.