### PR TITLE
chore(tests): tweak some tests for CI

### DIFF
--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -544,7 +544,7 @@ it('set promise atom value on write (#304)', async () => {
 it('uses async atom double chain (#306)', async () => {
   const countAtom = atom(0)
   const asyncCountAtom = atom(async (get) => {
-    await new Promise((r) => setTimeout(r, 100))
+    await new Promise((r) => setTimeout(r, 500))
     return get(countAtom)
   })
   const delayedCountAtom = atom(async (get) => {

--- a/tests/query/atomWithInfiniteQuery.test.tsx
+++ b/tests/query/atomWithInfiniteQuery.test.tsx
@@ -251,8 +251,6 @@ it('should be able to refetch only specific pages when refetchPages is provided'
       [setState]
     )
 
-    states.push(state)
-
     return (
       <>
         <div>length: {state.pages.length}</div>
@@ -276,7 +274,6 @@ it('should be able to refetch only specific pages when refetchPages is provided'
   await findByText('loading')
   await findByText('length: 1')
   await findByText('page 1: 10')
-  await new Promise((r) => setTimeout(r, 100))
   fireEvent.click(getByText('fetch next page'))
   await findByText('length: 2')
   await findByText('page 2: 11')

--- a/tests/query/atomWithInfiniteQuery.test.tsx
+++ b/tests/query/atomWithInfiniteQuery.test.tsx
@@ -276,7 +276,6 @@ it('should be able to refetch only specific pages when refetchPages is provided'
   await findByText('loading')
   await findByText('length: 1')
   await findByText('page 1: 10')
-  await new Promise((r) => setTimeout(r, 100))
   fireEvent.click(getByText('fetch next page'))
   await findByText('length: 2')
   await findByText('page 2: 11')

--- a/tests/query/atomWithInfiniteQuery.test.tsx
+++ b/tests/query/atomWithInfiniteQuery.test.tsx
@@ -251,8 +251,6 @@ it('should be able to refetch only specific pages when refetchPages is provided'
       [setState]
     )
 
-    states.push(state)
-
     return (
       <>
         <div>length: {state.pages.length}</div>

--- a/tests/query/atomWithInfiniteQuery.test.tsx
+++ b/tests/query/atomWithInfiniteQuery.test.tsx
@@ -251,6 +251,8 @@ it('should be able to refetch only specific pages when refetchPages is provided'
       [setState]
     )
 
+    states.push(state)
+
     return (
       <>
         <div>length: {state.pages.length}</div>
@@ -274,6 +276,7 @@ it('should be able to refetch only specific pages when refetchPages is provided'
   await findByText('loading')
   await findByText('length: 1')
   await findByText('page 1: 10')
+  await new Promise((r) => setTimeout(r, 100))
   fireEvent.click(getByText('fetch next page'))
   await findByText('length: 2')
   await findByText('page 2: 11')

--- a/tests/query/atomWithInfiniteQuery.test.tsx
+++ b/tests/query/atomWithInfiniteQuery.test.tsx
@@ -272,14 +272,19 @@ it('should be able to refetch only specific pages when refetchPages is provided'
   )
 
   await findByText('loading')
+
   await findByText('length: 1')
   await findByText('page 1: 10')
+
+  await new Promise((r) => setTimeout(r, 100)) // not sure how this helps or not
   fireEvent.click(getByText('fetch next page'))
   await findByText('length: 2')
   await findByText('page 2: 11')
+
   fireEvent.click(getByText('fetch next page'))
   await findByText('length: 3')
   await findByText('page 3: 12')
+
   fireEvent.click(getByText('refetch page 1'))
   await findByText('length: 3')
   await findByText('page 1: 20')

--- a/tests/query/atomWithInfiniteQuery.test.tsx
+++ b/tests/query/atomWithInfiniteQuery.test.tsx
@@ -276,6 +276,7 @@ it('should be able to refetch only specific pages when refetchPages is provided'
   await findByText('loading')
   await findByText('length: 1')
   await findByText('page 1: 10')
+  await new Promise((r) => setTimeout(r, 100))
   fireEvent.click(getByText('fetch next page'))
   await findByText('length: 2')
   await findByText('page 2: 11')

--- a/tests/urql/atomWithQuery.test.tsx
+++ b/tests/urql/atomWithQuery.test.tsx
@@ -14,7 +14,7 @@ const clientMock = {
   query: () =>
     withPromise(
       pipe(
-        interval(500),
+        interval(100),
         map((i: number) => ({ data: { count: i } }))
       )
     ),

--- a/tests/urql/atomWithQuery.test.tsx
+++ b/tests/urql/atomWithQuery.test.tsx
@@ -14,7 +14,7 @@ const clientMock = {
   query: () =>
     withPromise(
       pipe(
-        interval(100),
+        interval(500),
         map((i: number) => ({ data: { count: i } }))
       )
     ),


### PR DESCRIPTION
Not pretty sure how this actually helps or not, but not harmful.
We need to find a way to make CI tests stable. Fake timers might do, but I kind of gave up once. Any volunteers?