### PR TITLE
Add documentation for react-native

### DIFF
--- a/docs/guides/atoms-in-atom.mdx
+++ b/docs/guides/atoms-in-atom.mdx
@@ -1,6 +1,6 @@
 ---
 title: Atoms in atom
-nav: 3.07
+nav: 3.08
 ---
 
 `atom()` creates an atom config, which is an object, but it doesn't hold a value.

--- a/docs/guides/no-suspense.mdx
+++ b/docs/guides/no-suspense.mdx
@@ -1,6 +1,6 @@
 ---
 title: No Suspense
-nav: 3.06
+nav: 3.07
 ---
 
 > The content of this page will be easier to follow if you have taken a look at the [basics/async](../basics/async.mdx) part of the docs.

--- a/docs/guides/react-native.mdx
+++ b/docs/guides/react-native.mdx
@@ -1,0 +1,49 @@
+---
+title: React Native
+description: Using Jotai in React Native
+nav: 3.5
+---
+
+Jotai atoms can be used in React Native applications with very few changes except for the use of persistence.
+
+Jotai has an [atomWithStorage function in the utils bundle](../api/utils.mdx#atom-with-storage) for persistance that supports persisting state in `sessionStorage`, `localStorage`, `AsyncStorage`, or the URL hash.
+
+Because react-native only supports AsyncStorage, you need to tell Jotai to use AsyncStorage instead of the default.
+
+Then, depending on what you are storing, you may need to take additional steps.  By default, AsyncStorage stores strings.  So, if you are simply storing a string, just passing AsyncStorage in is enough.
+
+## A simple pattern with AsyncStorage
+
+```js
+export const strAtom = atomWithStorage('string', undefined, AsyncStorage)
+```
+
+If you want to store objects and booleans, however, there are a series of helper functions that make this easier.
+
+## Storing non-string items in AsyncStorage
+
+First, create a storage item using the createJSONStorage function.  This automatically stringifies and parses objects before writing to AsyncStorage.
+
+```js
+export const storage = createJSONStorage(() => AsyncStorage)
+```
+
+Now you can pass an object into the store just by passing storage as the storage type.
+
+```js
+export const storage = createJSONStorage(() => AsyncStorage)
+export const objectAtom = atomWithStorage('object', undefined, storage)
+```
+
+## Storing booleans in AsyncStorage
+
+To store a boolean, there is an additional helper function atomWithToggleAndStorage.
+
+```js
+export const storage = createJSONStorage(() => AsyncStorage)
+export const booleanAtom = atomWithToggleAndStorage('boolean', false, storage)
+```
+
+With these three functions you should be able to easily manage persistent storage in React Native.
+
+And remember, atoms that don't require AsyncStorage can simply use the standard atom() function.

--- a/docs/guides/react-native.mdx
+++ b/docs/guides/react-native.mdx
@@ -1,7 +1,7 @@
 ---
 title: React Native
 description: Using Jotai in React Native
-nav: 3.5
+nav: 3.05
 ---
 
 Jotai atoms can be used in React Native applications with very few changes except for the use of persistence.

--- a/docs/guides/react-native.mdx
+++ b/docs/guides/react-native.mdx
@@ -22,26 +22,24 @@ If you want to store objects and booleans, however, there are a series of helper
 
 ## Storing non-string items in AsyncStorage
 
-First, create a storage item using the createJSONStorage function.  This automatically stringifies and parses objects before writing to AsyncStorage.
+First, create a storage item using the createJSONStorage function.  This automatically stringifies and parses objects before writing to AsyncStorage.   If you use atoms throughout your codebase, you can define storage in one place and export it for use everywhere.
 
 ```js
-export const storage = createJSONStorage(() => AsyncStorage)
+const storage = createJSONStorage(() => AsyncStorage)
 ```
 
-Now you can pass an object into the store just by passing storage as the storage type.
+Now you can pass an object into the store just by passing storage as the storage type. The rest of the examples assume you have declared storage locally or imported it as a utility.
 
 ```js
-export const storage = createJSONStorage(() => AsyncStorage)
-export const objectAtom = atomWithStorage('object', undefined, storage)
+const objectAtom = atomWithStorage('object', undefined, storage)
 ```
 
 ## Storing booleans in AsyncStorage
 
-To store a boolean, there is an additional helper function atomWithToggleAndStorage.
+To store a boolean, there is an additional advanced recipe for [atomWithToggleAndStorage](../advanced-recipes/atom-creators.mdx#atom-with-toggle-and-storage).
 
 ```js
-export const storage = createJSONStorage(() => AsyncStorage)
-export const booleanAtom = atomWithToggleAndStorage('boolean', false, storage)
+const booleanAtom = atomWithToggleAndStorage('boolean', false, storage)
 ```
 
 With these three functions you should be able to easily manage persistent storage in React Native.

--- a/docs/guides/resettable.mdx
+++ b/docs/guides/resettable.mdx
@@ -1,7 +1,7 @@
 ---
 title: Resettable
 description: How to use resettable atoms
-nav: 3.05
+nav: 3.06
 ---
 
 The Jotai core doesn't support resettable atoms.

--- a/readme.md
+++ b/readme.md
@@ -184,6 +184,7 @@ yarn add jotai react
   - [Testing](./docs/guides/testing.mdx)
   - [Persistence](./docs/guides/persistence.mdx)
   - [Next.js](./docs/guides/nextjs.mdx)
+  - [React Native](./docs/guides/react-native.mdx)
   - [Resettable](./docs/guides/resettable.mdx)
   - [No Suspense](./docs/guides/no-suspense.mdx)
   - [Atoms in atom](./docs/guides/atoms-in-atom.mdx)


### PR DESCRIPTION
Based on recent conversation I've written out documentation on the functions I used to get AtomWithStorage working effectively on React Native.