### PR TITLE
fix(query): Add QueryKey types to atomWithQuery

### DIFF
--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -24,18 +24,33 @@ export type AtomWithInfiniteQueryOptions<
   TQueryFnData,
   TError,
   TData,
-  TQueryData
-> = InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryData> & {
-  queryKey: QueryKey
-}
+  TQueryData,
+  TQueryKey extends QueryKey
+> = Omit<
+  InfiniteQueryObserverOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryData,
+    TQueryKey
+  >,
+  'queryKey'
+> & { queryKey: TQueryKey }
 
 export type AtomWithInfiniteQueryOptionsWithEnabled<
   TQueryFnData,
   TError,
   TData,
-  TQueryData
+  TQueryData,
+  TQueryKey extends QueryKey
 > = Omit<
-  AtomWithInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryData>,
+  AtomWithInfiniteQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryData,
+    TQueryKey
+  >,
   'enabled'
 > & {
   enabled: boolean
@@ -45,14 +60,16 @@ export function atomWithInfiniteQuery<
   TQueryFnData,
   TError,
   TData = TQueryFnData,
-  TQueryData = TQueryFnData
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
 >(
   createQuery: CreateQueryOptions<
     AtomWithInfiniteQueryOptionsWithEnabled<
       TQueryFnData,
       TError,
       TData,
-      TQueryData
+      TQueryData,
+      TQueryKey
     >
   >,
   getQueryClient?: GetQueryClient
@@ -65,10 +82,17 @@ export function atomWithInfiniteQuery<
   TQueryFnData,
   TError,
   TData = TQueryFnData,
-  TQueryData = TQueryFnData
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
 >(
   createQuery: CreateQueryOptions<
-    AtomWithInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryData>
+    AtomWithInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      TQueryKey
+    >
   >,
   getQueryClient?: GetQueryClient
 ): WritableAtom<
@@ -80,10 +104,17 @@ export function atomWithInfiniteQuery<
   TQueryFnData,
   TError,
   TData = TQueryFnData,
-  TQueryData = TQueryFnData
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
 >(
   createQuery: CreateQueryOptions<
-    AtomWithInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryData>
+    AtomWithInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      TQueryKey
+    >
   >,
   getQueryClient: GetQueryClient = (get) => get(queryClientAtom)
 ): WritableAtom<
@@ -166,7 +197,17 @@ export function atomWithInfiniteQuery<
         }
       }
 
-      const defaultedOptions = queryClient.defaultQueryObserverOptions(options)
+      const defaultedOptions = queryClient.defaultQueryObserverOptions(
+        options
+        // For some reason, InfiniteQueryObserver only has 4 type arguments instead of 5, hence the need for a cast.
+        // Even react-query casts in a similar way, see
+        // https://github.com/tannerlinsley/react-query/blob/e328ca0bc3815572114c7c41d4ead0d63cb43b54/src/react/useInfiniteQuery.ts#L97
+      ) as unknown as InfiniteQueryObserverOptions<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryData
+      >
       if (initialData === undefined && options.enabled !== false) {
         if (typeof defaultedOptions.staleTime !== 'number') {
           defaultedOptions.staleTime = 1000

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -11,17 +11,24 @@ import { queryClientAtom } from './queryClientAtom'
 import type { CreateQueryOptions, GetQueryClient } from './types'
 
 export type AtomWithQueryAction = { type: 'refetch' }
-export type AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData> =
-  QueryObserverOptions<TQueryFnData, TError, TData, TQueryData> & {
-    queryKey: QueryKey
-  }
+export type AtomWithQueryOptions<
+  TQueryFnData,
+  TError,
+  TData,
+  TQueryData,
+  TQueryKey extends QueryKey
+> = Omit<
+  QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
+  'queryKey'
+> & { queryKey: TQueryKey }
 export type AtomWithQueryOptionsWithEnabled<
   TQueryFnData,
   TError,
   TData,
-  TQueryData
+  TQueryData,
+  TQueryKey extends QueryKey
 > = Omit<
-  AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>,
+  AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
   'enabled'
 > & {
   enabled: boolean
@@ -31,10 +38,17 @@ export function atomWithQuery<
   TQueryFnData,
   TError,
   TData = TQueryFnData,
-  TQueryData = TQueryFnData
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
 >(
   createQuery: CreateQueryOptions<
-    AtomWithQueryOptionsWithEnabled<TQueryFnData, TError, TData, TQueryData>
+    AtomWithQueryOptionsWithEnabled<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      TQueryKey
+    >
   >,
   getQueryClient?: GetQueryClient
 ): WritableAtom<
@@ -47,10 +61,11 @@ export function atomWithQuery<
   TQueryFnData,
   TError,
   TData = TQueryFnData,
-  TQueryData = TQueryFnData
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
 >(
   createQuery: CreateQueryOptions<
-    AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>
+    AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>
   >,
   getQueryClient?: GetQueryClient
 ): WritableAtom<TData | TQueryData, AtomWithQueryAction, Promise<void>>
@@ -59,10 +74,11 @@ export function atomWithQuery<
   TQueryFnData,
   TError,
   TData = TQueryFnData,
-  TQueryData = TQueryFnData
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
 >(
   createQuery: CreateQueryOptions<
-    AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>
+    AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>
   >,
   getQueryClient: GetQueryClient = (get) => get(queryClientAtom)
 ): WritableAtom<
@@ -75,7 +91,13 @@ export function atomWithQuery<
       dataAtom: PrimitiveAtom<
         TData | TQueryData | Promise<TData | TQueryData> | undefined
       >
-      observer: QueryObserver<TQueryFnData, TError, TData, TQueryData>
+      observer: QueryObserver<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryData,
+        TQueryKey
+      >
     },
     AtomWithQueryAction,
     Promise<void>

--- a/tests/query/atomWithInfiniteQuery.test.tsx
+++ b/tests/query/atomWithInfiniteQuery.test.tsx
@@ -40,6 +40,35 @@ it('infinite query basic test', async () => {
   await findByText('page count: 1')
 })
 
+it('infinite query key object test', async () => {
+  const countAtom = atomWithInfiniteQuery(() => ({
+    queryKey: ['count1Infinite', { countValue: 5 }] as const,
+    queryFn: async ({ queryKey: [, { countValue }] }) => {
+      return fakeFetch({ countValue }, false, 100)
+    },
+  }))
+
+  const Counter = () => {
+    const [data] = useAtom(countAtom)
+    return (
+      <>
+        <div>page count: {data.pages.length}</div>
+      </>
+    )
+  }
+
+  const { findByText } = render(
+    <Provider>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+    </Provider>
+  )
+
+  await findByText('loading')
+  await findByText('page count: 1')
+})
+
 it('infinite query next page test', async () => {
   const mockFetch = jest.fn(fakeFetch)
   const countAtom = atomWithInfiniteQuery<

--- a/tests/query/atomWithInfiniteQuery.test.tsx
+++ b/tests/query/atomWithInfiniteQuery.test.tsx
@@ -41,7 +41,7 @@ it('infinite query basic test', async () => {
 })
 
 it('infinite query key object test', async () => {
-  const countAtom = atomWithInfiniteQuery(() => ({
+  const countAtom = atomWithInfiniteQuery((_get) => ({
     queryKey: ['count1Infinite', { countValue: 5 }] as const,
     queryFn: async ({ queryKey: [, { countValue }] }) => {
       return fakeFetch({ countValue }, false, 100)

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -39,6 +39,38 @@ it('query basic test', async () => {
   await findByText('count: 0')
 })
 
+it('query key object test', async () => {
+  const countAtom = atomWithQuery(() => ({
+    queryKey: ['count1', { countValue: 2 }] as const,
+    queryFn: async ({ queryKey: [, { countValue }] }) => {
+      return await fakeFetch({ count: countValue }, false, 100)
+    },
+  }))
+  const Counter = () => {
+    const [
+      {
+        response: { count },
+      },
+    ] = useAtom(countAtom)
+    return (
+      <>
+        <div>count: {count}</div>
+      </>
+    )
+  }
+
+  const { findByText } = render(
+    <Provider>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+    </Provider>
+  )
+
+  await findByText('loading')
+  await findByText('count: 2')
+})
+
 it('query basic test with object instead of function', async () => {
   const countAtom = atomWithQuery({
     queryKey: 'count2',

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -40,7 +40,7 @@ it('query basic test', async () => {
 })
 
 it('query key object test', async () => {
-  const countAtom = atomWithQuery(() => ({
+  const countAtom = atomWithQuery((_get) => ({
     queryKey: ['count1', { countValue: 2 }] as const,
     queryFn: async ({ queryKey: [, { countValue }] }) => {
       return await fakeFetch({ count: countValue }, false, 100)


### PR DESCRIPTION
Type inference of the query key in `atomWithQuery` wasn't working correctly, so usage like this:

```ts
atomWithQuery(() => ({
  queryKey: ['pages', { page: 2 }] as const,
  queryFn: async ({ queryKey: [, { page }] }) => {
    return (await fetch(`pages/${page}`)).json()
  },
}))
```

Would result in a type error.

This adds the correct types by utilising react-query's fifth type argument, `TQueryKey`.