### PR TITLE
feat(utils/atomWithStorage): Add subscribe to storage events in defaultStorage

### DIFF
--- a/docs/utils/atom-with-storage.mdx
+++ b/docs/utils/atom-with-storage.mdx
@@ -30,7 +30,8 @@ The `atomWithStorage` function creates an atom with a value persisted in `localS
 
 **initialValue** (required): the initial value of the atom
 
-**storage** (optional): an object with `getItem` and `setItem` methods for storing/retreiving persisted state; defaults to using `localStorage` for storage/retreival and `JSON.stringify()`/`JSON.parse()` for serialization/deserialization
+**storage** (optional): an object with `getItem` and `setItem` methods for storing/retreiving persisted state; defaults to using `localStorage` for storage/retreival and `JSON.stringify()`/`JSON.parse()` for serialization/deserialization.
+Optionally, the storage has a `subscribe` property, which can be used to synchronize storage. The default `localStorage` handles `storage` events for cross-tab synchronization.
 
 <CodeSandbox id="7dfib" />
 

--- a/docs/utils/atom-with-storage.mdx
+++ b/docs/utils/atom-with-storage.mdx
@@ -33,7 +33,7 @@ The `atomWithStorage` function creates an atom with a value persisted in `localS
 **storage** (optional): an object with `getItem` and `setItem` methods for storing/retreiving persisted state; defaults to using `localStorage` for storage/retreival and `JSON.stringify()`/`JSON.parse()` for serialization/deserialization.
 Optionally, the storage has a `subscribe` property, which can be used to synchronize storage. The default `localStorage` handles `storage` events for cross-tab synchronization.
 
-<CodeSandbox id="7dfib" />
+<CodeSandbox id="vuwi7" />
 
 ## Server-side rendering
 

--- a/src/utils/atomWithStorage.ts
+++ b/src/utils/atomWithStorage.ts
@@ -75,6 +75,17 @@ export function createJSONStorage<Value>(
     setItem: (key, newValue) =>
       getStringStorage().setItem(key, JSON.stringify(newValue)),
     removeItem: (key) => getStringStorage().removeItem?.(key), // TODO remove optional chaining
+    subscribe: (key, callback) => {
+      const storageEventCallback = (e: StorageEvent) => {
+        if (e.key === key && e.newValue) {
+          callback(JSON.parse(e.newValue))
+        }
+      }
+      window.addEventListener('storage', storageEventCallback)
+      return () => {
+        window.removeEventListener('storage', storageEventCallback)
+      }
+    },
   }
 }
 

--- a/src/utils/atomWithStorage.ts
+++ b/src/utils/atomWithStorage.ts
@@ -75,21 +75,21 @@ export function createJSONStorage<Value>(
     setItem: (key, newValue) =>
       getStringStorage().setItem(key, JSON.stringify(newValue)),
     removeItem: (key) => getStringStorage().removeItem?.(key), // TODO remove optional chaining
-    subscribe: (key, callback) => {
-      const storageEventCallback = (e: StorageEvent) => {
-        if (e.key === key && e.newValue) {
-          callback(JSON.parse(e.newValue))
-        }
-      }
-      window.addEventListener('storage', storageEventCallback)
-      return () => {
-        window.removeEventListener('storage', storageEventCallback)
-      }
-    },
   }
 }
 
 const defaultStorage = createJSONStorage(() => localStorage)
+defaultStorage.subscribe = (key, callback) => {
+  const storageEventCallback = (e: StorageEvent) => {
+    if (e.key === key && e.newValue) {
+      callback(JSON.parse(e.newValue))
+    }
+  }
+  window.addEventListener('storage', storageEventCallback)
+  return () => {
+    window.removeEventListener('storage', storageEventCallback)
+  }
+}
 
 export function atomWithStorage<Value>(
   key: string,


### PR DESCRIPTION
Adds `subscribe` to `defaultStorage` for `atomWithStorage`.
The `subscribe` listens to `storage` events.

Closes #882.