### PR TITLE
chore(types): refactor imports and add comments

### DIFF
--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -43,6 +43,7 @@ type WithInitialValue<Value> = {
 
 export type Scope = symbol | string | number
 
+// Not exported for public API
 // Are there better typings?
 export type SetAtom<
   Update,

--- a/src/core/suspensePromise.ts
+++ b/src/core/suspensePromise.ts
@@ -1,5 +1,6 @@
 const SUSPENSE_PROMISE = Symbol()
 
+// Not exported for public API
 export type SuspensePromise = Promise<void> & {
   [SUSPENSE_PROMISE]: {
     o: Promise<void> // original promise

--- a/src/core/useSetAtom.ts
+++ b/src/core/useSetAtom.ts
@@ -1,8 +1,8 @@
 import { useCallback, useContext } from 'react'
-import type { Scope, SetAtom, WritableAtom } from '../core/atom'
-import { WRITE_ATOM } from '../core/store'
-import type { VersionObject } from '../core/store'
+import type { Scope, SetAtom, WritableAtom } from './atom'
 import { getScopeContext } from './contexts'
+import { WRITE_ATOM } from './store'
+import type { VersionObject } from './store'
 
 export function useSetAtom<Value, Update, Result extends void | Promise<void>>(
   atom: WritableAtom<Value, Update, Result>,

--- a/src/utils/weakCache.ts
+++ b/src/utils/weakCache.ts
@@ -1,6 +1,6 @@
 import type { Atom } from 'jotai'
 
-export type WeakCache<T> = WeakMap<object, [WeakCache<T>] | [WeakCache<T>, T]>
+type WeakCache<T> = WeakMap<object, [WeakCache<T>] | [WeakCache<T>, T]>
 
 const getWeakCacheItem = <T>(
   cache: WeakCache<T>,


### PR DESCRIPTION
Just minor refactoring.
I noticed some of types are exported but not considered as public api, so commented. (inspired by #1012)