### PR TITLE
Fix `atomWithObservable` is not resubscribed after remount

### DIFF
--- a/src/utils/atomWithObservable.ts
+++ b/src/utils/atomWithObservable.ts
@@ -97,7 +97,10 @@ export function atomWithObservable<TData>(
       if (!subscription) {
         subscription = observable.subscribe(dataListener, errorListener)
       }
-      return () => subscription?.unsubscribe()
+      return () => {
+        subscription?.unsubscribe()
+        subscription = null
+      }
     }
     return { dataAtom, observable }
   })


### PR DESCRIPTION
`atomWithObservable` seems to be not resubscribing to observable when a component is being hidden and then shown again. 

There is a test reproducing it and also a [codesandbox](https://codesandbox.io/s/wizardly-resonance-28rvue?file=/src/App.js): atom value updates when clicking on a document, but if you hide/show component, it doesn't update anymore.