### PR TITLE
Replace useAtom w/ useSetAtom for write only

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -136,7 +136,8 @@ Just do not define a read function.
 const multiplyCountAtom = atom(null, (get, set, by) => set(countAtom, get(countAtom) * by))
 
 function Controls() {
-  const [, multiply] = useAtom(multiplyCountAtom)
+  // causes unnecessary re-render: const [, multiply] = useAtom(multiplyCountAtom)
+  const nultiply = useSetAtom(multiplyCountAtom)
   return <button onClick={() => multiply(3)}>triple</button>
 ```
 


### PR DESCRIPTION
Updated the "write only atoms" example in the README to use the `useSetAtom` instead of the `useAtom` hook.

I decided to keep the original code commented out with explanation why it's not longer recommended. Maintainers might want to delete this altogether if they think it clutters up the docs.

I did not scour the whole docs to change any other outdated examples, but I can do that if the maintainers feel my initial edit is on the right track. 