### PR TITLE
[docs] Update debugging link

### DIFF
--- a/docs/guides/debugging.mdx
+++ b/docs/guides/debugging.mdx
@@ -108,7 +108,7 @@ Every feature of `useAtomDevtools` is supported in this hook, but there's an ext
 ## Frozen Atoms
 
 To find bugs where you accidentally tried to mutate objects stored in atoms you
-could use [`freezeAtom`](../api/utils.mdx#freeze-atom) or
-[`atomFrozenInDev`](../api/utils.mdx#atom-frozen-in-dev) from `jotai/utils` bundle.
+could use [`freezeAtom`](../utils/freeze-atom.mdx) or
+[`freezeAtomCreator`](../utils/freeze-atom-creator.mdx#) from `jotai/utils` bundle.
 Which returns atoms value that is deeply freezed with `Object.freeze`.
 


### PR DESCRIPTION
hyper links in [Frozen Atom](https://jotai.org/docs/guides/debugging#frozen-atoms) is too old, needs some update.