### PR TITLE
fix(devtools): better types with official devtools extension types

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "@babel/preset-env": "^7.16.11",
     "@babel/template": "^7.16.7",
     "@babel/types": "^7.17.0",
+    "@redux-devtools/extension": "^3.2.2",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@rollup/plugin-replace": "^3.0.1",

--- a/src/devtools/types.ts
+++ b/src/devtools/types.ts
@@ -1,6 +1,6 @@
 import type {} from '@redux-devtools/extension'
 
-export type Message = {
+type Message = {
   type: string
   payload?: any
   state?: any
@@ -13,8 +13,6 @@ interface Action<T = any> {
 export interface ConnectResponse {
   init: (state: unknown) => void
   send: (action: Action<unknown>, state: unknown) => void
-  subscribe?: (
-    listener: (message: any) => void // FIXME no-any
-  ) => (() => void) | undefined
+  subscribe?: (listener: (message: Message) => void) => (() => void) | undefined
   shouldInit?: boolean
 }

--- a/src/devtools/types.ts
+++ b/src/devtools/types.ts
@@ -1,0 +1,20 @@
+import type {} from '@redux-devtools/extension'
+
+export type Message = {
+  type: string
+  payload?: any
+  state?: any
+}
+
+interface Action<T = any> {
+  type: T
+}
+
+export interface ConnectResponse {
+  init: (state: unknown) => void
+  send: (action: Action<unknown>, state: unknown) => void
+  subscribe?: (
+    listener: (message: any) => void // FIXME no-any
+  ) => (() => void) | undefined
+  shouldInit?: boolean
+}

--- a/src/devtools/types.ts
+++ b/src/devtools/types.ts
@@ -1,18 +1,8 @@
 import type {} from '@redux-devtools/extension'
 
-type Message = {
+// FIXME https://github.com/reduxjs/redux-devtools/issues/1097
+export type Message = {
   type: string
   payload?: any
   state?: any
-}
-
-interface Action<T = any> {
-  type: T
-}
-
-export interface ConnectResponse {
-  init: (state: unknown) => void
-  send: (action: Action<unknown>, state: unknown) => void
-  subscribe?: (listener: (message: Message) => void) => (() => void) | undefined
-  shouldInit?: boolean
 }

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -2,14 +2,20 @@ import { useEffect, useRef } from 'react'
 import { useAtom } from 'jotai'
 import type { Atom, WritableAtom } from 'jotai'
 import type { Scope, SetAtom } from '../core/atom'
-import { ConnectResponse, Message } from './types'
+import { ConnectResponse } from './types'
 
 export function useAtomDevtools<Value, Result extends void | Promise<void>>(
   anAtom: WritableAtom<Value, Value, Result> | Atom<Value>,
   name?: string,
   scope?: Scope
 ): void {
-  let extension = window?.__REDUX_DEVTOOLS_EXTENSION__
+  let extension: typeof window['__REDUX_DEVTOOLS_EXTENSION__']
+
+  try {
+    extension = window.__REDUX_DEVTOOLS_EXTENSION__
+  } catch {
+    // ignored
+  }
 
   if (!extension) {
     if (__DEV__ && typeof window !== 'undefined') {
@@ -40,7 +46,7 @@ export function useAtomDevtools<Value, Result extends void | Promise<void>>(
 
       devtools.current = extension.connect({ name: atomName })
 
-      const unsubscribe = devtools.current.subscribe!((message: Message) => {
+      const unsubscribe = devtools.current.subscribe!((message) => {
         if (message.type === 'ACTION' && message.payload) {
           try {
             setValueIfWritable(JSON.parse(message.payload))

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -1,23 +1,8 @@
-import type {} from '@redux-devtools/extension'
 import { useEffect, useRef } from 'react'
 import { useAtom } from 'jotai'
 import type { Atom, WritableAtom } from 'jotai'
 import type { Scope, SetAtom } from '../core/atom'
-
-type Message = {
-  type: string
-  payload?: any
-  state?: any
-}
-
-interface Action<T = any> {
-  type: T
-}
-
-interface ConnectResponse {
-  init: (state: unknown) => void
-  send: (action: Action<unknown>, state: unknown) => void
-}
+import { ConnectResponse, Message } from './types'
 
 export function useAtomDevtools<Value, Result extends void | Promise<void>>(
   anAtom: WritableAtom<Value, Value, Result> | Atom<Value>,
@@ -36,11 +21,7 @@ export function useAtomDevtools<Value, Result extends void | Promise<void>>(
 
   const lastValue = useRef(value)
   const isTimeTraveling = useRef(false)
-  const devtools = useRef<ConnectResponse &  {
-        subscribe?: (
-          listener: (message: any) => void // FIXME no-any
-        ) => (() => void) | undefined
-      }   & { shouldInit?: boolean }>()
+  const devtools = useRef<ConnectResponse>()
 
   const atomName = name || anAtom.debugLabel || anAtom.toString()
 
@@ -58,6 +39,7 @@ export function useAtomDevtools<Value, Result extends void | Promise<void>>(
       }
 
       devtools.current = extension.connect({ name: atomName })
+
       const unsubscribe = devtools.current.subscribe!((message: Message) => {
         if (message.type === 'ACTION' && message.payload) {
           try {

--- a/src/devtools/useAtomsDevtools.ts
+++ b/src/devtools/useAtomsDevtools.ts
@@ -8,7 +8,7 @@ import {
   DEV_SUBSCRIBE_STATE,
   RESTORE_ATOMS,
 } from '../core/store'
-import { ConnectResponse, Message } from './types'
+import { ConnectResponse } from './types'
 
 type AnyAtomValue = unknown
 type AnyAtom = Atom<AnyAtomValue>
@@ -114,7 +114,13 @@ export function useAtomsDevtools(name: string, scope?: Scope) {
     [store, versionedWrite]
   )
 
-  let extension = window?.__REDUX_DEVTOOLS_EXTENSION__
+  let extension: typeof window['__REDUX_DEVTOOLS_EXTENSION__']
+
+  try {
+    extension = window.__REDUX_DEVTOOLS_EXTENSION__
+  } catch {
+    // ignored
+  }
 
   if (!extension) {
     if (__DEV__ && typeof window !== 'undefined') {
@@ -144,7 +150,7 @@ export function useAtomsDevtools(name: string, scope?: Scope) {
       }
       const connection = extension.connect({ name }) as ConnectResponse
 
-      const devtoolsUnsubscribe = connection.subscribe!((message: Message) => {
+      const devtoolsUnsubscribe = connection.subscribe!((message) => {
         switch (message.type) {
           case 'DISPATCH':
             switch (message.payload?.type) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,7 +937,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.17.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.17.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
   integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
@@ -1258,6 +1258,13 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@redux-devtools/extension@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@redux-devtools/extension/-/extension-3.2.2.tgz#2d6da4df2c4d32a0aac54d824e46f52b1fd9fc4d"
+  integrity sha512-fKA2TWNzJF7wXSDwBemwcagBFudaejXCzH5hRszN3Z6B7XEJtEmGD77AjV0wliZpIZjA/fs3U7CejFMQ+ipS7A==
+  dependencies:
+    "@babel/runtime" "^7.17.0"
 
 "@rollup/plugin-babel@^5.3.0":
   version "5.3.0"


### PR DESCRIPTION
This PR tries to bring the native `window.__REDUX_DEVTOOLS_EXTENSION__` types from redux devtools and then avoids some custom types which may be incorrect in some cases!