### PR TITLE
Add support for debugLabels for atom utils

### DIFF
--- a/src/babel/plugin-debug-label.ts
+++ b/src/babel/plugin-debug-label.ts
@@ -1,6 +1,7 @@
 import path from 'path'
-import babel, { PluginObj, types } from '@babel/core'
+import babel, { PluginObj } from '@babel/core'
 import templateBuilder from '@babel/template'
+import { isAtom } from './utils'
 
 export default function debugLabelPlugin({
   types: t,
@@ -56,34 +57,3 @@ export default function debugLabelPlugin({
     },
   }
 }
-
-function isAtom(
-  t: typeof types,
-  callee: babel.types.Expression | babel.types.V8IntrinsicIdentifier
-) {
-  if (t.isIdentifier(callee) && atomFunctionNames.includes(callee.name)) {
-    return true
-  }
-
-  if (t.isMemberExpression(callee)) {
-    const { property } = callee
-    if (t.isIdentifier(property) && atomFunctionNames.includes(property.name)) {
-      return true
-    }
-  }
-  return false
-}
-
-const atomFunctionNames = [
-  'atom',
-  'atomFamily',
-  'atomWithDefault',
-  'atomWithObservable',
-  'atomWithReducer',
-  'atomWithReset',
-  'atomWithStorage',
-  'freezeAtom',
-  'loadable',
-  'selectAtom',
-  'splitAtom',
-]

--- a/src/babel/plugin-debug-label.ts
+++ b/src/babel/plugin-debug-label.ts
@@ -61,15 +61,29 @@ function isAtom(
   t: typeof types,
   callee: babel.types.Expression | babel.types.V8IntrinsicIdentifier
 ) {
-  if (t.isIdentifier(callee) && callee.name === 'atom') {
+  if (t.isIdentifier(callee) && atomFunctionNames.includes(callee.name)) {
     return true
   }
 
   if (t.isMemberExpression(callee)) {
     const { property } = callee
-    if (t.isIdentifier(property) && property.name === 'atom') {
+    if (t.isIdentifier(property) && atomFunctionNames.includes(property.name)) {
       return true
     }
   }
   return false
 }
+
+const atomFunctionNames = [
+  'atom',
+  'atomFamily',
+  'atomWithDefault',
+  'atomWithObservable',
+  'atomWithReducer',
+  'atomWithReset',
+  'atomWithStorage',
+  'freezeAtom',
+  'loadable',
+  'selectAtom',
+  'splitAtom',
+]

--- a/src/babel/utils.ts
+++ b/src/babel/utils.ts
@@ -4,15 +4,29 @@ export function isAtom(
   t: typeof types,
   callee: babel.types.Expression | babel.types.V8IntrinsicIdentifier
 ) {
-  if (t.isIdentifier(callee) && callee.name === 'atom') {
+  if (t.isIdentifier(callee) && atomFunctionNames.includes(callee.name)) {
     return true
   }
 
   if (t.isMemberExpression(callee)) {
     const { property } = callee
-    if (t.isIdentifier(property) && property.name === 'atom') {
+    if (t.isIdentifier(property) && atomFunctionNames.includes(property.name)) {
       return true
     }
   }
   return false
 }
+
+const atomFunctionNames = [
+  'atom',
+  'atomFamily',
+  'atomWithDefault',
+  'atomWithObservable',
+  'atomWithReducer',
+  'atomWithReset',
+  'atomWithStorage',
+  'freezeAtom',
+  'loadable',
+  'selectAtom',
+  'splitAtom',
+]

--- a/tests/babel/plugin-debug-label.test.ts
+++ b/tests/babel/plugin-debug-label.test.ts
@@ -67,3 +67,62 @@ it('Should handle all types of exports', () => {
     export default atoms;"
   `)
 })
+
+it('Should handle all atom types', () => {
+  expect(
+    transform(
+      `
+      export const countAtom = atom(0);
+
+      const myFamily = atomFamily((param) => atom(param));
+
+      const countAtomWithDefault = atomWithDefault((get) => get(countAtom) * 2);
+
+      const observableAtom = atomWithObservable(() => {});
+
+      const reducerAtom = atomWithReducer(0, () => {});
+
+      const resetAtom = atomWithReset(0);
+
+      const storageAtom = atomWithStorage('count', 1);
+
+      const freezedAtom = freezeAtom(atom({ count: 0 }));
+
+      const loadedAtom = loadable(countAtom);
+
+      const selectedValueAtom = selectAtom(atom({ a: 0, b: 'othervalue' }), (v) => v.a);
+
+      const splittedAtom = splitAtom(atom([]));
+    `,
+      'atoms/index.ts'
+    )
+  ).toMatchInlineSnapshot(`
+    "export const countAtom = atom(0);
+    countAtom.debugLabel = \\"countAtom\\";
+    const myFamily = atomFamily(param => atom(param));
+    myFamily.debugLabel = \\"myFamily\\";
+    const countAtomWithDefault = atomWithDefault(get => get(countAtom) * 2);
+    countAtomWithDefault.debugLabel = \\"countAtomWithDefault\\";
+    const observableAtom = atomWithObservable(() => {});
+    observableAtom.debugLabel = \\"observableAtom\\";
+    const reducerAtom = atomWithReducer(0, () => {});
+    reducerAtom.debugLabel = \\"reducerAtom\\";
+    const resetAtom = atomWithReset(0);
+    resetAtom.debugLabel = \\"resetAtom\\";
+    const storageAtom = atomWithStorage('count', 1);
+    storageAtom.debugLabel = \\"storageAtom\\";
+    const freezedAtom = freezeAtom(atom({
+      count: 0
+    }));
+    freezedAtom.debugLabel = \\"freezedAtom\\";
+    const loadedAtom = loadable(countAtom);
+    loadedAtom.debugLabel = \\"loadedAtom\\";
+    const selectedValueAtom = selectAtom(atom({
+      a: 0,
+      b: 'othervalue'
+    }), v => v.a);
+    selectedValueAtom.debugLabel = \\"selectedValueAtom\\";
+    const splittedAtom = splitAtom(atom([]));
+    splittedAtom.debugLabel = \\"splittedAtom\\";"
+  `)
+})


### PR DESCRIPTION
This PR adds support for the babel plugin to add `debugLabel` for our atom utils.

Closes #1038.