### PR TITLE
fix(utils): Initial data for atomWithObservable 

### DIFF
--- a/docs/utils/atom-with-observable.mdx
+++ b/docs/utils/atom-with-observable.mdx
@@ -9,6 +9,7 @@ Ref: https://github.com/pmndrs/jotai/pull/341
 import { useAtom } from 'jotai'
 import { atomWithObservable } from 'jotai/utils'
 import { interval } from 'rxjs'
+import { map } from "rxjs/operators"
 
 const counterSubject = interval(1000).pipe(map((i) => `#${i}`));
 const counterAtom = atomWithObservable(() => counterSubject);
@@ -23,6 +24,15 @@ The `atomWithObservable` function creates an atom from a rxjs (or similar) `subj
 Its value will be last value emitted from the stream.
 
 To use this atom, you need to wrap your component with `<Suspense>`. Check out [basics/async](../basics/async.mdx).
+
+## Initial value
+`atomWithObservable` takes second optional parameter `{ initialData }` that allows to specify initial data for the atom. If `initialData` is provided then `atomWithObservable` will not suspend and will show initial value before receiving first value from observable. `initialData` can be either a value or a function that returns a value
+
+```ts
+const counterAtom = atomWithObservable(() => counterSubject, {initialData: 10});
+
+const counterAtom2 = atomWithObservable(() => counterSubject, {initialData: () => Math.random()});
+```
 
 ### Codesandbox
 <CodeSandbox id="88pnt" />

--- a/docs/utils/atom-with-observable.mdx
+++ b/docs/utils/atom-with-observable.mdx
@@ -26,12 +26,12 @@ Its value will be last value emitted from the stream.
 To use this atom, you need to wrap your component with `<Suspense>`. Check out [basics/async](../basics/async.mdx).
 
 ## Initial value
-`atomWithObservable` takes second optional parameter `{ initialData }` that allows to specify initial data for the atom. If `initialData` is provided then `atomWithObservable` will not suspend and will show initial value before receiving first value from observable. `initialData` can be either a value or a function that returns a value
+`atomWithObservable` takes second optional parameter `{ initialValue }` that allows to specify initial value for the atom. If `initialValue` is provided then `atomWithObservable` will not suspend and will show initial value before receiving first value from observable. `initialValue` can be either a value or a function that returns a value
 
 ```ts
-const counterAtom = atomWithObservable(() => counterSubject, {initialData: 10});
+const counterAtom = atomWithObservable(() => counterSubject, {initialValue: 10});
 
-const counterAtom2 = atomWithObservable(() => counterSubject, {initialData: () => Math.random()});
+const counterAtom2 = atomWithObservable(() => counterSubject, {initialValue: () => Math.random()});
 ```
 
 ### Codesandbox

--- a/src/utils/atomWithObservable.ts
+++ b/src/utils/atomWithObservable.ts
@@ -72,6 +72,8 @@ export function atomWithObservable<TData>(
     }
     let subscription: Subscription | null = null
 
+    // FIXME this implementation is not fully compatible with concurrent rendering.
+    // we need to deal with the case `onMount` is not invoked after the atom is initialized.
     dataAtom.onMount = (update) => {
       setData = update
       if (!subscription) {

--- a/src/utils/atomWithObservable.ts
+++ b/src/utils/atomWithObservable.ts
@@ -74,6 +74,7 @@ export function atomWithObservable<TData>(
 
     // FIXME this implementation is not fully compatible with concurrent rendering.
     // we need to deal with the case `onMount` is not invoked after the atom is initialized.
+    // Ref: https://github.com/pmndrs/jotai/pull/1058
     dataAtom.onMount = (update) => {
       setData = update
       if (!subscription) {

--- a/src/utils/atomWithObservable.ts
+++ b/src/utils/atomWithObservable.ts
@@ -107,13 +107,17 @@ function getInitialValue<TData>(options: AtomWithObservableOptions<TData>) {
   return initialValue instanceof Function ? initialValue() : initialValue
 }
 
-// Limitation
-// Unless the source emit a new value,
-// the subscription will never be destroyed.
-// So, there's a risk of memory leaks, especially because
-// the atom `read` function can be called multiple times without mounting.
-// Ref: https://github.com/pmndrs/jotai/pull/1058
-// (This was present even before #1058.)
+// FIXME There are two fatal issues in the current implememtation.
+// See also: https://github.com/pmndrs/jotai/pull/1058
+// - There's a risk of memory leaks.
+//   Unless the source emit a new value,
+//   the subscription will never be destroyed.
+//   atom `read` function can be called multiple times without mounting.
+//   This issue has existed even before #1058.
+// - The second value before mounting the atom is dropped.
+//   There's no guarantee that `onMount` is invoked in a short period.
+//   So, by the time we invoke `subscribe`, the value can be changed.
+//   Before #1058, an error was thrown, but currently it's silently dropped.
 function firstValueFrom<T>(source: ObservableLike<T>): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     let resolved = false

--- a/src/utils/atomWithObservable.ts
+++ b/src/utils/atomWithObservable.ts
@@ -29,13 +29,10 @@ type ObservableLike<T> = {
 
 type SubjectLike<T> = ObservableLike<T> & Observer<T>
 
-type InitialDataFunction<T> = () => T | undefined
+type InitialValueFunction<T> = () => T | undefined
 
-export type AtomWithObservableOptions<TData> = {
-  initialData?: TData | InitialDataFunction<TData>
-}
-export type CreateObservableOptions<TData> = {
-  initialData?: TData
+type AtomWithObservableOptions<TData> = {
+  initialValue?: TData | InitialValueFunction<TData>
 }
 
 export function atomWithObservable<TData>(
@@ -60,8 +57,8 @@ export function atomWithObservable<TData>(
     }
 
     const dataAtom = atom(
-      options?.initialData
-        ? getInitialData(options)
+      options?.initialValue
+        ? getInitialValue(options)
         : firstValueFrom(observable)
     )
     let setData: (data: TData | Promise<TData>) => void = () => {
@@ -105,9 +102,9 @@ export function atomWithObservable<TData>(
   return observableAtom
 }
 
-function getInitialData<TData>(options: AtomWithObservableOptions<TData>) {
-  const initialData = options.initialData
-  return initialData instanceof Function ? initialData() : initialData
+function getInitialValue<TData>(options: AtomWithObservableOptions<TData>) {
+  const initialValue = options.initialValue
+  return initialValue instanceof Function ? initialValue() : initialValue
 }
 
 function firstValueFrom<T>(source: ObservableLike<T>): Promise<T> {

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -1,8 +1,8 @@
 import { ReactElement, Suspense, useState } from 'react'
 import { act, fireEvent, render } from '@testing-library/react'
-import { Observable, Subject } from 'rxjs'
 import { useAtom } from 'jotai'
 import { atomWithObservable } from 'jotai/utils'
+import { Observable, Subject } from 'rxjs'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
@@ -110,4 +110,94 @@ it('resubscribe on remount', async () => {
 
   act(() => subject.next(2))
   await findByText('count: 2')
+})
+
+it("count state with initialData doesn't suspend", async () => {
+  const subject = new Subject<number>()
+  const observableAtom = atomWithObservable(() => subject, { initialData: 5 })
+
+  const Counter = () => {
+    const [state] = useAtom(observableAtom)
+
+    return <>count: {state}</>
+  }
+
+  const { findByText } = render(
+    <Provider>
+      <Counter />
+    </Provider>
+  )
+
+  await findByText('count: 5')
+
+  act(() => subject.next(10))
+
+  await findByText('count: 10')
+})
+
+it('writable count state with initialData', async () => {
+  const observableAtom = atomWithObservable(
+    () => {
+      const observable = new Observable<number>((subscriber) => {
+        subscriber.next(1)
+      })
+      const subject = new Subject<number>()
+      // is this usual to delay the subscription?
+      setTimeout(() => {
+        observable.subscribe(subject)
+      }, 100)
+      return subject
+    },
+    { initialData: 5 }
+  )
+
+  const Counter = () => {
+    const [state, dispatch] = useAtom(observableAtom)
+
+    return (
+      <>
+        count: {state}
+        <button onClick={() => dispatch(9)}>button</button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+    </Provider>
+  )
+
+  await findByText('count: 5')
+
+  await findByText('count: 1')
+
+  fireEvent.click(getByText('button'))
+  await findByText('count: 9')
+})
+
+it('with initial data and synchronous subscription', async () => {
+  const observableAtom = atomWithObservable(
+    () =>
+      new Observable<number>((subscriber) => {
+        subscriber.next(1)
+      }),
+    { initialData: 5 }
+  )
+
+  const Counter = () => {
+    const [state] = useAtom(observableAtom)
+
+    return <>count: {state}</>
+  }
+
+  const { findByText } = render(
+    <Provider>
+      <Counter />
+    </Provider>
+  )
+
+  await findByText('count: 1')
 })

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -112,9 +112,9 @@ it('resubscribe on remount', async () => {
   await findByText('count: 2')
 })
 
-it("count state with initialData doesn't suspend", async () => {
+it("count state with initialValue doesn't suspend", async () => {
   const subject = new Subject<number>()
-  const observableAtom = atomWithObservable(() => subject, { initialData: 5 })
+  const observableAtom = atomWithObservable(() => subject, { initialValue: 5 })
 
   const Counter = () => {
     const [state] = useAtom(observableAtom)
@@ -135,7 +135,7 @@ it("count state with initialData doesn't suspend", async () => {
   await findByText('count: 10')
 })
 
-it('writable count state with initialData', async () => {
+it('writable count state with initialValue', async () => {
   const observableAtom = atomWithObservable(
     () => {
       const observable = new Observable<number>((subscriber) => {
@@ -148,7 +148,7 @@ it('writable count state with initialData', async () => {
       }, 100)
       return subject
     },
-    { initialData: 5 }
+    { initialValue: 5 }
   )
 
   const Counter = () => {
@@ -178,13 +178,13 @@ it('writable count state with initialData', async () => {
   await findByText('count: 9')
 })
 
-it('with initial data and synchronous subscription', async () => {
+it('with initial value and synchronous subscription', async () => {
   const observableAtom = atomWithObservable(
     () =>
       new Observable<number>((subscriber) => {
         subscriber.next(1)
       }),
-    { initialData: 5 }
+    { initialValue: 5 }
   )
 
   const Counter = () => {

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -1,8 +1,8 @@
 import { ReactElement, Suspense, useState } from 'react'
 import { act, fireEvent, render } from '@testing-library/react'
+import { Observable, Subject } from 'rxjs'
 import { useAtom } from 'jotai'
 import { atomWithObservable } from 'jotai/utils'
-import { Observable, Subject } from 'rxjs'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()


### PR DESCRIPTION
Reimplementation of initial data option for `atomWIthObservable` inspired by #875 + some refactoring and simplification of `atomWithObservable` code
