### PR TITLE
fix: some language changes and minor typo fixes

### DIFF
--- a/docs/advanced-recipes/atom-creators.mdx
+++ b/docs/advanced-recipes/atom-creators.mdx
@@ -7,7 +7,7 @@ nav: 5.02
 
 > `atomWithToggle` creates a new atom with a boolean as initial state & a setter function to toggle it.
 
-This avoids the boilerplate of having to setup another atom just to update the state of the first.
+This avoids the boilerplate of having to set up another atom just to update the state of the first.
 
 ```ts
 import { WritableAtom, atom } from 'jotai'
@@ -24,9 +24,9 @@ export function atomWithToggle(
 }
 ```
 
-An optional initial state can be provided as first argument.
+An optional initial state can be provided as the first argument.
 
-The setter function can have an optional arg to force a particular state (if you want to make a setActive function out of it for example).
+The setter function can have an optional argument to force a particular state, such as if you want to make a setActive function out of it.
 
 Here is how it's used.
 
@@ -37,7 +37,7 @@ import { atomWithToggle } from 'XXX'
 const isActiveAtom = atomWithToggle(true)
 ```
 
-And in a component :
+And in a component:
 
 ```tsx
 const Toggle = () => {
@@ -57,9 +57,9 @@ const Toggle = () => {
 
 ## atomWithToggleAndStorage
 
-> `atomWithToggleAndStorage` does the same as [`atomWithToggle`](#atom-with-toggle) but also persist the state anytime it changes in given storage using [`atomWithStorage`](../api/utils.mdx#atom-with-storage).
+> `atomWithToggleAndStorage` is like [`atomWithToggle`](#atom-with-toggle) but also persist the state anytime it changes in given storage using [`atomWithStorage`](../api/utils.mdx#atom-with-storage).
 
-Here is the source :
+Here is the source:
 
 ```ts
 import { WritableAtom, atom } from 'jotai'
@@ -83,12 +83,12 @@ export function atomWithToggleAndStorage(
 }
 ```
 
-And how it's used :
+And how it's used:
 
 ```ts
 import { atomWithToggleAndStorage } from 'XXX'
 
-// will have an initial value set to false & be stored in localStorage under the key "isActive"
+// will have an initial value set to false & get stored in localStorage under the key "isActive"
 const isActiveAtom = atomWithToggleAndStorage('isActive')
 ```
 
@@ -96,7 +96,7 @@ The usage in a component is also the same as [`atomWithToggle`](#atom-with-toggl
 
 ## atomWithCompare
 
-> `atomWithCompare` creates atom that only triggers updates when custom compare function `areEqual(prev, next)` is false.
+> `atomWithCompare` creates atom that triggers updates when custom compare function `areEqual(prev, next)` is false.
 
 This can help you avoid unwanted re-renders by ignoring state changes that don't matter to your application.
 
@@ -119,7 +119,7 @@ export function atomWithCompare<Value>(
 }
 ```
 
-Here's how you'd use it to implement an atom that ignores updates that are shallow-equal:
+Here's how you'd use it to make an atom that ignores updates that are shallow-equal:
 
 ```ts
 import { atomWithCompare } from 'XXX'
@@ -182,7 +182,7 @@ export function atomWithRefresh<T>(fn: (get: Getter) => T) {
 }
 ```
 
-Here's how you'd use it to implement an refreshable source of data:
+Here's how you'd use it to implement an refresh-able source of data:
 
 ```ts
 import { atomWithRefresh } from 'XXX'
@@ -219,7 +219,7 @@ const PostsList = () => {
 
 > `atomWithListeners` creates an atom and a hook. The hook can be called to
 > add a new listener. The hook takes as an argument a callback, and that
-> callback will be called every time the atom's value is set. The hook also
+> callback is called every time the atom's value is set. The hook also
 > returns a function to remove the listener.
 
 This can be useful when you want to create a component that can listen to when
@@ -235,7 +235,7 @@ type Callback<Value> = (
   get: Getter,
   set: Setter,
   newVal: Value,
-  prevVal: Value,
+  prevVal: Value
 ) => void
 
 export function atomWithListeners<Value>(initialValue: Value) {
@@ -250,7 +250,7 @@ export function atomWithListeners<Value>(initialValue: Value) {
       get(listenersAtom).forEach((callback) => {
         callback(get, set, newVal, prevVal)
       })
-    },
+    }
   )
   const useListener = (callback: Callback<Value>) => {
     const setListeners = useUpdateAtom(listenersAtom)
@@ -284,8 +284,8 @@ function EvenCounter() {
           setEvenCount((c) => c + 1)
         }
       },
-      [setEvenCount],
-    ),
+      [setEvenCount]
+    )
   )
 
   return <>Count was set to an even number {evenCount} times.</>

--- a/docs/advanced-recipes/large-objects.mdx
+++ b/docs/advanced-recipes/large-objects.mdx
@@ -3,9 +3,9 @@ title: Large objects
 nav: 5.01
 ---
 
-> All of the examples and descriptions below are based on this [codesandbox](https://codesandbox.io/s/zealous-sun-f2qnl?file=/src/App.tsx), so it will give you a better understanding if you check it out along these examples.
+> The examples and descriptions below are based on this [codesandbox](https://codesandbox.io/s/zealous-sun-f2qnl?file=/src/App.tsx), so it will give you a better understanding if you check it out along with these examples.
 
-Sometimes we have big data we need to keep into atoms, we may need to change that data in some levels, or we need to use part of that data, but we can't listen to all these changes or use all that data for just a specific part.
+Sometimes we have nested data we need to store in atoms, and we may need to change that data at different levels, or we need to use part of that data without listening to all changes.
 
 Consider this example:
 
@@ -43,7 +43,7 @@ const initialData = {
 
 > `focusAtom` creates a new atom, based on the focus that you pass to it. [jotai/optics](../integrations/optics.mdx#focus-atom)
 
-We use this utility to focus an atom and create an atom of a specific part of the data. For example we may need to consume the people property of the above data, Here's how we do it.
+We use this utility to focus an atom and create an atom from a specific part of the data. For example we may need to consume the people property of the above data, Here's how we do it:
 
 ```jsx
 import { atom } from 'jotai'
@@ -56,13 +56,13 @@ const peopleAtom = focusAtom(dataAtom, (optic) => optic.prop('people'))
 
 `focusAtom` returns `WritableAtom` which means it's possible to change the `peopleAtom` data.
 
-If we change the `film` property of the above data example, the `peopleAtom` won't cause us a re-render, so that's one of the points of using `focusAtom`.
+If we change the `film` property of the above data example, the `peopleAtom` won't cause a re-render, so that's one of the benefits of using `focusAtom`.
 
 ## splitAtom
 
-> The `splitAtom` utility is useful, when you want to get an atom for each element in a list. [jotai/utils](../api/utils.mdx#split-atom)
+> The `splitAtom` utility is useful when you want to get an atom for each element in a list. [jotai/utils](../api/utils.mdx#split-atom)
 
-We use this utility for atoms that return arrays as their values, for example the `peopleAtom` we made above returns the people property array, so we can return an atom for each item of that array. If the array atom is writable, `splitAtom` returned atoms are going to be writable, if the array atom is read-only, items atoms are going to be read-only too.
+We use this utility for atoms that return arrays as their values. For example, the `peopleAtom` we made above returns the people property array, so we can return an atom for each item of that array. If the array atom is writable, `splitAtom` returned atoms are going to be writable, if the array atom is read-only, the returned atoms will be read-only too.
 
 ```jsx
 import { splitAtom } from 'jotai/utils'
@@ -70,7 +70,7 @@ import { splitAtom } from 'jotai/utils'
 const peopleAtomsAtom = splitAtom(peopleAtom)
 ```
 
-And that's how we use it in components.
+And this is how we use it in components.
 
 ```jsx
 const People = () => {
@@ -89,16 +89,16 @@ const People = () => {
 
 > This function creates a derived atom whose value is a function of the original atom's value. [jotai/utils](../api/utils.mdx#select-atom)
 
-This utility is similar to `focusAtom`, but we use it when we have a read-only atom to select part of it, and it always returns a read-only atom.
+This utility is like `focusAtom`, but we use it when we have a read-only atom to select part of it, and it always returns a read-only atom.
 
-Assume we want to consume the info data, and its data is always unchangeable, so we can make a read-only atom from it and select that created atom.
+Assume we want to consume the info data, and its data is always unchangeable. We can make a read-only atom from it and select that created atom.
 
 ```jsx
 // first we create a read-only atom based on initialData.info
 const readOnlyInfoAtom = atom((get) => get(dataAtom).info)
 ```
 
-Then we are going to consume it in our component:
+Then we use it in our component:
 
 ```jsx
 import { atom, useAtom } from 'jotai'

--- a/docs/api/babel.mdx
+++ b/docs/api/babel.mdx
@@ -8,37 +8,37 @@ nav: 2.04
 
 Jotai is based on object references and not keys (like Recoil). This means there's no identifier for atoms. To identify atoms, it's possible to add a `debugLabel` to an atom, which can be found in React devtools.
 
-However, this can quickly become  cumbersome to add a `debugLabel` to every atom.
+However, this can quickly become cumbersome to add a `debugLabel` to every atom.
 
 This `babel` plugin adds a `debugLabel` to every atom, based on its identifer.
 
 The plugin transforms this code:
 
 ```ts
-export const countAtom = atom(0);
+export const countAtom = atom(0)
 ```
 
 Into:
 
 ```ts
-export const countAtom = atom(0);
-countAtom.debugLabel = "countAtom";
+export const countAtom = atom(0)
+countAtom.debugLabel = 'countAtom'
 ```
 
 Default exports are also handled, based on the file naming:
 
 ```ts
 // countAtom.ts
-export default atom(0);
+export default atom(0)
 ```
 
 Which transform into:
 
 ```ts
 // countAtom.ts
-const countAtom = atom(0);
-countAtom.debugLabel = "countAtom";
-export default countAtom;
+const countAtom = atom(0)
+countAtom.debugLabel = 'countAtom'
+export default countAtom
 ```
 
 ## Usage
@@ -92,4 +92,3 @@ With a `babel` configuration file:
 ### Parcel
 
 <CodeSandbox id="bgf3b" />
-

--- a/docs/api/core.mdx
+++ b/docs/api/core.mdx
@@ -6,7 +6,7 @@ nav: 2.01
 
 ## atom
 
-`atom` is a function to create an atom config. The atom config is an immutable object. The atom config itself doesn't hold an atom value. The atom value is stored in a Provider state.
+Use `atom` to create an atom config. An atom config is an immutable object. The atom config doesn't hold an atom value. The atom value is stored in a Provider state.
 
 ```tsx
 // primitive atom
@@ -28,8 +28,8 @@ function atom<Value, Update>(
 ): WritableAtom<Value, Update>
 ```
 
-- `initialValue`: as the name says, it's an initial value which is the atom's going to return unless its value doesn't get changed.
-- `read`: a function that's going to get called on every re-render. The signature of `read` is `(get) => Value | Promise<Value>`, and `get` is a function that takes an atom config and returns its value stored in Provider described below. Dependency is tracked, so if `get` is used for an atom at least once, the `read` will be reevaluated whenever the atom value is changed.
+- `initialValue`: the initial value that the atom will return until its value is changed.
+- `read`: a function that's called on every re-render. The signature of `read` is `(get) => Value | Promise<Value>`, and `get` is a function that takes an atom config and returns its value stored in Provider as described below. Dependency is tracked, so if `get` is used for an atom at least once, the `read` will be reevaluated whenever the atom value is changed.
 - `write`: a function mostly used for mutating atom's values, for a better description; it gets called whenever we call the second value of the returned pair of `useAtom`, the `useAtom()[1]`. The default value of this function in the primitive atom will change the value of that atom. The signature of `write` is `(get, set, update) => void | Promise<void>`. `get` is similar to the one described above, but it doesn't track the dependency. `set` is a function that takes an atom config and a new value which then updates the atom value in Provider. `update` is an arbitrary value that we receive from the updating function returned by `useAtom` described below.
 
 ```tsx
@@ -43,15 +43,15 @@ There are two kinds of atoms: a writable atom and a read-only atom. Primitive at
 
 ### debugLabel
 
-The created atom config can have an optional property `debugLabel`. The debug label will be used to display the atom in debugging. See [Debugging guide](../guides/debugging.mdx) for more information.
+The created atom config can have an optional property `debugLabel`. The debug label is used to display the atom in debugging. See [Debugging guide](../guides/debugging.mdx) for more information.
 
-Note: Technically, the debug labels don’t have to be unique. However, it’s generally recommended to make them distinguishable.
+Note: While, the debug labels don’t have to be unique, it’s generally recommended to make them distinguishable.
 
 ### onMount
 
 The created atom config can have an optional property `onMount`. `onMount` is a function which takes a function `setAtom` and returns `onUnmount` function optionally.
 
-The `onMount` function will be invoked when the atom is first used in a provider, and `onUnmount` will be invoked when it’s not used. In some edge cases, an atom can be unmounted and then mounted immediately.
+The `onMount` function is called when the atom is first used in a provider, and `onUnmount` is called when it’s no longer used. In some edge cases, an atom can be unmounted and then mounted immediately.
 
 ```tsx
 const anAtom = atom(1)
@@ -62,7 +62,7 @@ anAtom.onMount = (setAtom) => {
 }
 ```
 
-Invoking `setAtom` function will invoke the atom’s `write`. Customizing `write` allows changing the behavior.
+Calling `setAtom` function will invoke the atom’s `write`. Customizing `write` allows changing the behavior.
 
 ```tsx
 const countAtom = atom(1)
@@ -90,7 +90,7 @@ const Provider: React.FC<{
 }>
 ```
 
-Atom configs don't hold values. Atom values reside in separate stores. A Provider is a component that contains a store and provides atom values under the component tree. A Provider works just like React context provider. If you don't use a Provider, it works as provider-less mode with a default store. A Provider will be necessary if we need to hold different atom values for different component trees. Provider also has some capabilities described below, which doesn't exist in the provider-less mode.
+Atom configs don't hold values. Atom values reside in separate stores. A Provider is a component that contains a store and provides atom values under the component tree. A Provider works like React context provider. If you don't use a Provider, it works as provider-less mode with a default store. A Provider will be necessary if we need to hold different atom values for different component trees. Provider also has some capabilities described below, which doesn't exist in the provider-less mode.
 
 ```jsx
 const Root = () => (
@@ -102,7 +102,7 @@ const Root = () => (
 
 ### `initialValues` prop
 
-A Provider accepts an optional prop `initialValues` which you can specify
+A Provider accepts an optional prop `initialValues`, with which you can specify
 some initial atom values.
 The use cases of this are testing and server side rendering.
 
@@ -114,8 +114,7 @@ const TestRoot = () => (
     initialValues={[
       [atom1, 1],
       [atom2, 'b'],
-    ]}
-  >
+    ]}>
     <Component />
   </Provider>
 )
@@ -139,8 +138,8 @@ const createInitialValues = () => {
 
 ### `scope` prop
 
-A Provider accepts an optional prop `scope` which you can use for scoped Provider.
-When using atoms with a scope, the provider with the same scope will be used.
+A Provider accepts an optional prop `scope` that you can use for a scoped Provider.
+When using atoms with a scope, the provider with the same scope is used.
 The recommendation for the scope value is a unique symbol.
 The primary use case of scope is for library usage.
 
@@ -157,9 +156,7 @@ const LibraryComponent = () => {
 }
 
 const LibraryRoot = ({ children }) => (
-  <Provider scope={myScope}>
-    {children}
-  </Provider>
+  <Provider scope={myScope}>{children}</Provider>
 )
 ```
 
@@ -167,19 +164,22 @@ const LibraryRoot = ({ children }) => (
 
 ```ts
 // primitive or writable derived atom
-function useAtom<Value, Update>(atom: WritableAtom<Value, Update>, scope?: Scope): [Value, SetAtom<Update>]
+function useAtom<Value, Update>(
+  atom: WritableAtom<Value, Update>,
+  scope?: Scope
+): [Value, SetAtom<Update>]
 
 // read-only atom
 function useAtom<Value>(atom: Atom<Value>, scope?: Scope): [Value, never]
 ```
 
-The useAtom hook is to read an atom value stored in the Provider. It returns the atom value and an updating function as a tuple, just like useState. It takes an atom config created with `atom()`. Initially, there is no value stored in the Provider. The first time the atom is used via `useAtom`, it will add an initial value in the Provider. If the atom is a derived atom, the read function is executed to compute an initial value. When an atom is no longer used, meaning all the components using it is unmounted, and the atom config no longer exists, the value is removed from the Provider.
+The useAtom hook is to read an atom value stored in the Provider. It returns the atom value and an updating function as a tuple, just like useState. It takes an atom config created with `atom()`. Initially, there is no value stored in the Provider. The first time the atom is used via `useAtom`, it will add an initial value in the Provider. If the atom is a derived atom, the read function is executed to compute an initial value. When an atom is no longer used, meaning all the components using it are unmounted, and the atom config no longer exists, the value is removed from the Provider.
 
 ```js
 const [value, updateValue] = useAtom(anAtom)
 ```
 
-The `updateValue` takes just one argument, which will be passed to the third argument of writeFunction of the atom. The behavior totally depends on how the writeFunction is implemented.
+The `updateValue` takes one argument, which will be passed to the third argument of writeFunction of the atom. The behavior depends on how the writeFunction is implemented.
 
 ---
 
@@ -195,18 +195,18 @@ const uppercaseAtom = atom((get) => get(textAtom).toUpperCase())
 
 The read function is the first parameter of the atom.
 The dependency will initially be empty. On first use, we run the read function and know that `uppercaseAtom` depends on `textAtom`. `textAtom` has a dependency on `uppercaseAtom`. So, add `uppercaseAtom` to the dependents of `textAtom`.
-When we re-run the read function (because its dependency (=textAtom) is updated),
-the dependency is built again, which is the same in this case. We then remove stale dependents and replace with the latest one.
+When we re-run the read function (because its dependency `textAtom` is updated),
+the dependency is created again, which is the same in this case. We then remove stale dependents and replace with the latest one.
 
 ### Atoms can be created on demand
 
-Basic examples in readme only show defining atoms globally outside components.
-There is no restrictions about when we create an atom.
-As long as we know atoms are identified by their object referential identity,
-it's okay to create them at anytime.
+While the basic examples here show defining atoms globally outside components,
+there's no restrictions about where or when we can create an atom.
+As long as we remember that atoms are identified by their object referential identity,
+we can create them anytime.
 
 If you create atoms in render functions, you would typically want to use
-a hook like `useRef` or `useMemo` for memoization. If not, the atom would be created everytime the component renders.
+a hook like `useRef` or `useMemo` for memoization. If not, the atom would be re-created each time the component renders.
 
 You can create an atom and store it with `useState` or even in another atom.
 See an example in [issue #5](https://github.com/pmndrs/jotai/issues/5).

--- a/docs/api/utils.mdx
+++ b/docs/api/utils.mdx
@@ -4,7 +4,7 @@ description: This doc describes `jotai/utils` bundle.
 nav: 2.02
 ---
 
-This is an overview over atom creators/hooks utilities that can found under `jotai/utils`. Each utility is listed below with a link to their description/API.
+This is an overview of the atom creators/hooks utilities that can be found under `jotai/utils`. Each utility is listed below with a link to their description/API.
 
 ## Overview
 
@@ -14,7 +14,7 @@ This is an overview over atom creators/hooks utilities that can found under `jot
 
 2. [atomWithObservable](../utils/atom-with-observable.mdx)
 
-   The `atomWithObservable` function creates an atom from a rxjs (or similar) `subject` or `observable`. Its value will be last value emitted from the stream.
+   The `atomWithObservable` function creates an atom from an RxJS (or similar) `subject` or `observable`. Its value will be last value emitted from the stream.
 
 3. [useUpdateAtom](../utils/use-update-atom.mdx)
 
@@ -62,15 +62,15 @@ This is an overview over atom creators/hooks utilities that can found under `jot
 
 14. [useAtomCallback](../utils/use-atom-callback.mdx)
 
-    This hook allows to interact with atoms imperatively.
+    This hook allows one to interact with atoms imperatively.
 
 15. [freezeAtom](../utils/freeze-atom.mdx)
 
-    The `freezeAtom` takes an existing atom and returns a new derived atom. The value with the new derived atom will be frozen (= not mutable).
+    The `freezeAtom` takes an existing atom and returns a new derived atom. The value with the new derived atom will be frozen (i.e. not mutable).
 
 16. [freezeAtomCreator](../utils/freeze-atom-creator.mdx)
 
-    Instead of create a frozen atom from an existing atom, `freezeAtomCreator` takes an atom creator function and returns a new function.
+    Instead of creating a frozen atom from an existing atom, `freezeAtomCreator` takes an atom creator function and returns a new function.
 
 17. [splitAtom](../utils/split-atom.mdx)
 

--- a/docs/basics/async.mdx
+++ b/docs/basics/async.mdx
@@ -11,7 +11,7 @@ Async support is first class in jotai. It fully leverages React Suspense.
 ## Suspense
 
 To use async atoms, you need to wrap your component tree with `<Suspense>`.
-If you have `<Provider>` at least one `<Suspense>` is placed inside the `<Provider>`.
+If you have `<Provider>`, place at least one `<Suspense>` inside the `<Provider>`.
 
 ```jsx
 const App = () => (
@@ -23,12 +23,12 @@ const App = () => (
 )
 ```
 
-Having more `<Suspense>`s in the component tree is possible.
+Having more `<Suspense>`s in the component tree is also possible.
 
 ## Async read atom
 
 The `read` function of an atom can return a promise.
-It will suspend and re-render when the promise is fulfilled.
+It will suspend and re-render once the promise fulfills.
 
 Most importantly, useAtom only returns a resolved value.
 
@@ -44,12 +44,12 @@ const Component = () => {
 ```
 
 An atom becomes async not only if the atom read function is async,
-but also one or more of its dependencies are async.
+but also if one or more of its dependencies are async.
 
 ```js
 const anotherAtom = atom((get) => get(asyncCountAtom) / 2)
 // even though this atom doesn't return a promise,
-// it is a read async atom because `asyncCountAtom` is async.
+// it's a read async atom because `asyncCountAtom` is async.
 ```
 
 <details>
@@ -59,10 +59,10 @@ const anotherAtom = atom((get) => get(asyncCountAtom) / 2)
 
 ## Async write atom
 
-There are another kind of async atoms, called async write atom.
-When `write` function of atom returns a promise, it may suspend.
-This happens only if the atom is used directly with useAtom,
-regardless of its value. (The atom value can be just `null`.)
+Async write atoms are another kind of async atom.
+When the `write` function of atom returns a promise, it may suspend.
+This happens if the atom is used directly with useAtom,
+regardless of its value. (The atom value can be `null`.)
 
 ```js
 const countAtom = atom(1)
@@ -81,12 +81,12 @@ const Component = () => {
 
 ### Triggering `Suspense` fallback of write atom
 
-This section applies only for "async write atom" not "async read atom", which works different with `Suspense`.
+This section applies only for "async write atom" not "async read atom", which works differently with `Suspense`.
 
-**A write atom will trigger the `Suspense` fallback only if:**
+**A write atom will trigger the `Suspense` fallback if:**
 
-    * the atom's write arg (2nd one) is async
-    * the awaited call is made directly and not from inside another containing function
+    * the atom's write argument (2nd one) is async
+    * the awaited call is made directly, and not from inside another containing function
 
 This _will_ trigger the `Suspense` fallback:
 
@@ -117,6 +117,6 @@ const writeAtom = atom(null, (get, set) => {
 })
 ```
 
-But **_both_** of the above will still properly set `somePrimitiveAtom` to the correct values.
+But **_both_** of the above will still set `somePrimitiveAtom` to the correct values.
 
 </details>

--- a/docs/basics/comparison.mdx
+++ b/docs/basics/comparison.mdx
@@ -12,8 +12,8 @@ Zustand means "state" in German.
 
 ### Analogy
 
-Jotai is close to Recoil.
-Zustand is close to Redux.
+Jotai is like Recoil.
+Zustand is like Redux.
 
 ### Where state resides
 
@@ -27,9 +27,9 @@ Zustand state is one object (i.e. top-down).
 
 ### Technical difference
 
-The major difference is the state model. Zustand is basically a single store (you could create multiple stores, but they are separated.) Jotai is primitive atoms and composing them. In this sense, it's the matter of programming mental model.
+The major difference is the state model. Zustand is a single store (although you could create multiple separate stores), while Jotai consists of primitive atoms and allows composing them together. In this sense, it's the matter of programming mental model.
 
-Jotai can be seen as a replacement for useState+useContext. Instead of creating multiple contexts, atoms share one big context.
+Jotai can be a replacement for useState+useContext. Instead of creating multiple contexts, atoms share one big context.
 
 Zustand is an external store and the hook is to connect the external world to the React world.
 
@@ -45,7 +45,7 @@ Zustand is an external store and the hook is to connect the external world to th
 
 ## How is Jotai different from Recoil?
 
-(Disclaimer: the author is not very familiar with Recoil, this can be biased and not accurate.)
+(Disclaimer: the author is not very familiar with Recoil, this may be biased and inaccurate.)
 
 ### Developer
 
@@ -54,8 +54,8 @@ Zustand is an external store and the hook is to connect the external world to th
 
 ### Basis
 
-- Jotai is focusing on primitive APIs for lean learning, and it's unopinionated. (The same philosophy with Zustand)
-- Recoil is full featured for big apps with various requirements.
+- Jotai is focusing on primitive APIs for easy learning, and it's unopinionated. (The same philosophy with Zustand)
+- Recoil is full featured for big apps with complex requirements.
 
 ### Technical difference
 
@@ -69,4 +69,4 @@ Zustand is an external store and the hook is to connect the external world to th
 - If your app heavily requires state serialization (storing state in storage, server, or URL), Recoil comes with good features.
 - If you need React Context alternatives, Jotai comes with enough features.
 - If you would try to create a new library, Jotai might give good primitives.
-- Otherwise, both are pretty similar about the general goals and basic techniques, so please try both and give us a feedback.
+- Otherwise, both are pretty similar about the general goals and basic techniques, so please try both and share you feedback with us.

--- a/docs/basics/concepts.mdx
+++ b/docs/basics/concepts.mdx
@@ -3,30 +3,30 @@ title: Concepts
 nav: 1.01
 ---
 
-Jotai was born to solve extra re-render issue in React.
-Extra re-render is a render process that produces the same UI result,
-with which users won't see any differences.
+Jotai was born to solve extra re-render issues in React.
+An extra re-render is when the render process produces the same UI result,
+where users won't see any differences.
 
-To tackle this issue naively with React context (useContext + useState),
-one would probably require many contexts and face some issues.
+To tackle this issue with React context (useContext + useState),
+one would require many contexts and face some issues.
 
 - Provider hell: It's likely that your root component has many context providers, which is technically okay, and sometimes desirable to provide context in different subtree.
 - Dynamic addition/deletion: Adding a new context at runtime is not very nice, because you need to add a new provider and its children will be re-mounted.
 
-Traditionally, a top-down solution to this is to use selector interface.
+Traditionally, a top-down solution to this is to use a selector interface.
 The [use-context-selector](https://github.com/dai-shi/use-context-selector) library is one example.
 The issue with this approach is the selector function needs to return
-referentially equal values to prevent re-renders and often requires some memoization technique.
+referentially equal values to prevent re-renders, and this often requires a memoization technique.
 
-Jotai takes a bottom-up approach with atomic model, inspired by [Recoil](https://recoiljs.org/).
-One can build state combining atoms and renders are optimized based on atom dependency.
-This avoids requiring the memoization technique.
+Jotai takes a bottom-up approach with the atomic model, inspired by [Recoil](https://recoiljs.org/).
+One can build state combining atoms, and optimize renders based on atom dependency.
+This avoids the need for memoization.
 
 Jotai has two principles.
 
-- Primitive: Its basic interface is pretty much like `useState`.
-- Flexible: Derived atoms can combine other atoms and also allow `useReducer` style with side effects.
+- Primitive: Its basic interface is simple, like `useState`.
+- Flexible: Derived atoms can combine other atoms and enable `useReducer` style with side effects.
 
-Jotai's core API is minimalistic and allows building various utils based on it.
+Jotai's core API is minimalistic and makes it easy to build utilities based upon it.
 
 Check out [comparison doc](../basics/comparison.mdx) to see some differences with other libraries.

--- a/docs/basics/primitives.mdx
+++ b/docs/basics/primitives.mdx
@@ -12,9 +12,9 @@ Let's see how to define and use atoms.
 
 There's an exported function called `atom`, which is to create
 an atom config. We call it "config" as it's just a definition
-and it doesn't hold a value. We may just call it "atom" if the context is clear.
+and it doesn't yet hold a value. We may also call it "atom" if the context is clear.
 
-To create a primitive atom (config), all you need is pass an initial value.
+To create a primitive atom (config), all you need is to provide an initial value.
 
 ```js
 import { atom } from 'jotai'
@@ -24,7 +24,7 @@ const messageAtom = atom('hello')
 const productAtom = atom({ id: 12, name: 'good stuff' })
 ```
 
-You can also create derived atoms. We have three patterns.
+You can also create derived atoms. We have three patterns:
 
 - Read-only atom
 - Write-only atom
@@ -53,7 +53,7 @@ const readWriteAtom = atom(
 `get` in the read function is to read the atom value.
 It's reactive and read dependencies are tracked.
 
-`get` in the write function is also to read atom value, and it's not tracked.
+`get` in the write function is also to read atom value, but it's not tracked.
 Furthermore, it can't read unresolved async values.
 For async behavior, please refer to the [async](../basics/async.mdx) doc.
 
@@ -62,7 +62,7 @@ It will invoke the write function of the target atom.
 
 Atom configs can be created anywhere, but referential equality is important.
 They can be created dynamically too.
-To create an atom in render function, `useMemo` or `useRef` is required to get a stable reference. If in doubt about using `useMemo` or `useRef` for memorization, use `useMemo`.
+To create an atom in render function, `useMemo` or `useRef` is required to get a stable reference. If in doubt about using `useMemo` or `useRef` for memoization, use `useMemo`.
 
 ```jsx
 const Component = ({ value }) => {
@@ -76,15 +76,15 @@ const Component = ({ value }) => {
 The `useAtom` hook is to read an atom value in the state.
 The state can be seen as a WeakMap of atom configs and atom values.
 
-The `useAtom` function returns the atom value and an updating function as a tuple,
+The `useAtom` function returns the atom value and an update function as a tuple,
 just like React's `useState`.
 It takes an atom config created with `atom()`.
 
-Initially, there is no value stored in the state.
-The first time the atom is used via `useAtom`,
-the initial value is stored in the state.
-If the atom is a derived atom, the read function is executed to compute an initial value.
-When an atom is no longer used, meaning all the components using it is unmounted,
+Initially, there is no value associated with the atom.
+Only once the atom is used via `useAtom`,
+does the initial value get stored in the state.
+If the atom is a derived atom, the read function is called to compute the initial value.
+When an atom is no longer used, meaning all the components using it are unmounted,
 and the atom config no longer exists, the value in the state is garbage collected.
 
 ```js
@@ -92,23 +92,23 @@ const [value, updateValue] = useAtom(anAtom)
 ```
 
 The `updateValue` takes just one argument, which will be passed
-to the third argument of write function of the atom.
-The behavior totally depends on how the write function is implemented.
+to the third argument of the write function of the atom.
+The behavior depends on how the write function is implemented.
 
 ## Provider
 
-Provider is to provide a state for component sub tree.
-Multiple Providers can be used for multiple subtrees, even nested.
-This works just like the normal React Context.
+Provider is to provide state for a component sub tree.
+Multiple Providers can be used for multiple subtrees, and they can even be nested.
+This works just like React Context.
 
-If an atom is used in a tree which no Providers exist,
+If an atom is used in a tree without a Provider,
 it will use the default state. This is so-called provider-less mode.
 
-Providers are useful for some reasons.
+Providers are useful for three reasons:
 
-1. It can provide a different state for each sub tree.
-2. Provider can hold some debug information.
-3. Provider can accept initial values of atoms.
+1. To provide a different state for each sub tree.
+2. To contain some debug information.
+3. To accept initial values of atoms.
 
 ```jsx
 const SubTree = () => (

--- a/docs/basics/showcase.mdx
+++ b/docs/basics/showcase.mdx
@@ -9,19 +9,19 @@ nav: 1.05
 
 - Hacker News example [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://githubbox.com/pmndrs/jotai/tree/main/examples/hacker_news)
 
-  Demonstrate a news articles with Jotai, hit next to see more articles.
+  Demonstrate a news article with Jotai, hit next to see more articles.
 
 - Todos example [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://githubbox.com/pmndrs/jotai/tree/main/examples/todos)
 
-  Record your todo list by typing them into this app, check them if you have completed the task, and switch between `Completed` and `Incompleted` to see the status of your task.
+  Record your todo list by typing them into this app, check them off if you have completed the task, and switch between `Completed` and `Incompleted` to see the status of your task.
 
 - Todos example with atomFamily and localStorage [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://githubbox.com/pmndrs/jotai/tree/main/examples/todos_with_atomFamily)
 
-  Implement a todo list using atomFamily and localStorage, you can store your todo list to localStorage by click `Save to localStorage`, then remove your todo list and restore them by click `Load from localStorage`.
+  Implement a todo list using atomFamily and localStorage. You can store your todo list to localStorage by clicking `Save to localStorage`, then remove your todo list and try restoring them by clicking `Load from localStorage`.
 
 - Clock with Next.js [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://codesandbox.io/s/nextjs-with-jotai-5ylrj)
 
-  An UTC time eletronic clock implement using Next.js and Jotai.
+  An UTC time electronic clock implementation using Next.js and Jotai.
 
 - Tic Tac Toe game [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://codesandbox.io/s/jotai-tic-tac-6cg3h)
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -83,9 +83,7 @@ const atoms = [count1, count2, count3, ...otherAtoms]
 const sum = atom((get) => atoms.map(get).reduce((acc, count) => acc + count))
 ```
 
-### Derived async atoms
-
-<img src="https://img.shields.io/badge/-needs_suspense-black" alt="needs suspense" />
+### Derived async atoms <img src="https://img.shields.io/badge/-needs_suspense-black" alt="needs suspense" />
 
 You can make the read function an async function.
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -85,10 +85,7 @@ const sum = atom((get) => atoms.map(get).reduce((acc, count) => acc + count))
 
 ### Derived async atoms
 
-<img
-  src="https://img.shields.io/badge/-needs_suspense-black"
-  alt="needs suspense"
-/>
+<img src="https://img.shields.io/badge/-needs_suspense-black" alt="needs suspense" />
 
 You can make the read function an async function.
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -8,7 +8,7 @@ nav: 0
 
 Jotai is pronounced "joe-tie" and means "state" in Japanese.
 
-You can try live demos in the following:
+You can try live demos here:
 [Demo 1](https://codesandbox.io/s/jotai-demo-47wvh) |
 [Demo 2](https://codesandbox.io/s/jotai-demo-forked-x2g5d).
 
@@ -21,8 +21,8 @@ You can try live demos in the following:
 ### First create a primitive atom
 
 An atom represents a piece of state. All you need is to specify an initial
-value, which can be primitive values like strings and numbers, objects and
-arrays. You can create as many primitive atoms as you want.
+value, which can be a primitive value like a string, number, object or
+array. You can create as many primitive atoms as you like.
 
 ```jsx
 import { atom } from 'jotai'
@@ -35,7 +35,7 @@ const mangaAtom = atom({ 'Dragon Ball': 1984, 'One Piece': 1997, Naruto: 1999 })
 
 ### Use the atom in your components
 
-It can be used like `React.useState`:
+Use an atom like you'd use `React.useState`:
 
 ```jsx
 import { useAtom } from 'jotai'
@@ -64,9 +64,9 @@ function DoubleCounter() {
 
 ## Recipes
 
-### Creating an atom from multiple atoms
+### Creating an atom from atoms
 
-You can combine multiple atoms to create a derived atom.
+You can combine atoms to create a derived atom.
 
 ```jsx
 const count1 = atom(1)
@@ -84,9 +84,13 @@ const sum = atom((get) => atoms.map(get).reduce((acc, count) => acc + count))
 ```
 
 ### Derived async atoms
-<img src="https://img.shields.io/badge/-needs_suspense-black" alt="needs suspense" />
 
-You can make the read function an async function too.
+<img
+  src="https://img.shields.io/badge/-needs_suspense-black"
+  alt="needs suspense"
+/>
+
+You can make the read function an async function.
 
 ```jsx
 const urlAtom = atom("https://json.host.com")
@@ -105,7 +109,7 @@ function Status() {
 ### You can create a writable derived atom
 
 Specify a write function at the second argument. `get` will return the current
-value of an atom. `set` will update an atoms value.
+value of an atom. `set` will update an atom's value.
 
 ```jsx
 const decrementCountAtom = atom(
@@ -123,7 +127,8 @@ function Counter() {
 
 ### Write only atoms
 
-Just do not define a read function.
+To make a write-only atom, don't define a read function by passing `null` as the
+first argument.
 
 ```jsx
 const multiplyCountAtom = atom(null, (get, set, by) => set(countAtom, get(countAtom) * by))
@@ -135,7 +140,7 @@ function Controls() {
 
 ### Async actions
 
-Just make the write function an async function and call `set` when you're ready.
+Make the write function an async function, and call `set` when you're ready.
 
 ```jsx
 const fetchCountAtom = atom(


### PR DESCRIPTION
I just made a few small changes to the docs, to simplify some of the language and clean it up a little bit.