### PR TITLE
fix(core,urql): useDebugState and some envvar handling

### DIFF
--- a/src/core/useDebugState.ts
+++ b/src/core/useDebugState.ts
@@ -1,0 +1,52 @@
+import { useDebugValue, useEffect, useState } from 'react'
+import type { Atom } from './atom'
+import type { ScopeContainer } from './contexts'
+import {
+  DEV_GET_ATOM_STATE,
+  DEV_GET_MOUNTED,
+  DEV_GET_MOUNTED_ATOMS,
+  DEV_SUBSCRIBE_STATE,
+} from './store'
+import type { AtomState, Store } from './store'
+
+const atomToPrintable = (atom: Atom<unknown>) =>
+  atom.debugLabel || atom.toString()
+
+const stateToPrintable = ([store, atoms]: [Store, Atom<unknown>[]]) =>
+  Object.fromEntries(
+    atoms.flatMap((atom) => {
+      const mounted = store[DEV_GET_MOUNTED]?.(atom)
+      if (!mounted) {
+        return []
+      }
+      const dependents = mounted.t
+      const atomState = store[DEV_GET_ATOM_STATE]?.(atom) || ({} as AtomState)
+      return [
+        [
+          atomToPrintable(atom),
+          {
+            ...('e' in atomState && { error: atomState.e }),
+            ...('p' in atomState && { promise: atomState.p }),
+            ...('v' in atomState && { value: atomState.v }),
+            dependents: Array.from(dependents).map(atomToPrintable),
+          },
+        ],
+      ]
+    })
+  )
+
+// We keep a reference to the atoms in Provider's registeredAtoms in dev mode,
+// so atoms aren't garbage collected by the WeakMap of mounted atoms
+export const useDebugState = (scopeContainer: ScopeContainer) => {
+  const { s: store } = scopeContainer
+  const [atoms, setAtoms] = useState<Atom<unknown>[]>([])
+  useEffect(() => {
+    const callback = () => {
+      setAtoms(Array.from(store[DEV_GET_MOUNTED_ATOMS]?.() || []))
+    }
+    const unsubscribe = store[DEV_SUBSCRIBE_STATE]?.(callback)
+    callback()
+    return unsubscribe
+  }, [store])
+  useDebugValue([store, atoms], stateToPrintable)
+}

--- a/src/core/useSetAtom.ts
+++ b/src/core/useSetAtom.ts
@@ -12,11 +12,7 @@ export function useSetAtom<Value, Update, Result extends void | Promise<void>>(
   const { s: store, w: versionedWrite } = useContext(ScopeContext)
   const setAtom = useCallback(
     (update: Update) => {
-      if (
-        !('write' in atom) &&
-        typeof process === 'object' &&
-        process.env.NODE_ENV !== 'production'
-      ) {
+      if (__DEV__ && !('write' in atom)) {
         // useAtom can pass non writable atom with wrong type assertion,
         // so we should check here.
         throw new Error('not writable atom')

--- a/src/urql/clientAtom.ts
+++ b/src/urql/clientAtom.ts
@@ -2,7 +2,12 @@ import { createClient } from '@urql/core'
 import { atom } from 'jotai'
 
 const DEFAULT_URL =
-  (typeof process === 'object' && process.env.JOTAI_URQL_DEFAULT_URL) ||
-  '/graphql'
+  (() => {
+    try {
+      return process.env.JOTAI_URQL_DEFAULT_URL
+    } catch {
+      return undefined
+    }
+  })() || '/graphql'
 
 export const clientAtom = atom(createClient({ url: DEFAULT_URL }))

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -6,6 +6,8 @@ import { getTestProvider, itSkipIfVersionedWrite } from './testUtils'
 
 const Provider = getTestProvider()
 
+jest.mock('../src/core/useDebugState.ts')
+
 const useCommitCount = () => {
   const commitCountRef = useRef(1)
   useEffect(() => {

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -14,6 +14,8 @@ import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()
 
+jest.mock('../src/core/useDebugState.ts')
+
 // FIXME this is a hacky workaround temporarily
 const IS_REACT18 = !!(ReactDOM as any).createRoot
 

--- a/tests/dependency.test.tsx
+++ b/tests/dependency.test.tsx
@@ -5,6 +5,8 @@ import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()
 
+jest.mock('../src/core/useDebugState.ts')
+
 const useCommitCount = () => {
   const commitCountRef = useRef(1)
   useEffect(() => {

--- a/tests/utils/atomFamily.test.tsx
+++ b/tests/utils/atomFamily.test.tsx
@@ -8,6 +8,8 @@ import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
 
+jest.mock('../../src/core/useDebugState.ts')
+
 // FIXME this is a hacky workaround temporarily
 const IS_REACT18 = !!(ReactDOM as any).createRoot
 

--- a/tests/utils/waitForAll.test.tsx
+++ b/tests/utils/waitForAll.test.tsx
@@ -6,6 +6,8 @@ import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
 
+jest.mock('../../src/core/useDebugState.ts')
+
 const consoleWarn = console.warn
 const consoleError = console.error
 beforeEach(() => {


### PR DESCRIPTION
Looks like I overlooked some changes in #968 (and a slight one in #989).
This separates `useDebugState.ts` and fixes `__DEV__` usage. Our source code shouldn't depend on `process.env`.
For `jotai/urql`, the fix might not be ideal, but at least it avoids errors. Hope to find a better solution in the future.