### PR TITLE
docs: fix typo in `comparison.mdx`

### DIFF
--- a/docs/basics/comparison.mdx
+++ b/docs/basics/comparison.mdx
@@ -69,4 +69,4 @@ Zustand is an external store and the hook is to connect the external world to th
 - If your app heavily requires state serialization (storing state in storage, server, or URL), Recoil comes with good features.
 - If you need React Context alternatives, Jotai comes with enough features.
 - If you would try to create a new library, Jotai might give good primitives.
-- Otherwise, both are pretty similar about the general goals and basic techniques, so please try both and share you feedback with us.
+- Otherwise, both are pretty similar about the general goals and basic techniques, so please try both and share your feedback with us.


### PR DESCRIPTION
This PR closes #1074. 