### PR TITLE
docs: Minor language change for more accurate reading

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -20,9 +20,9 @@ You can try live demos here:
 
 ### First create a primitive atom
 
-An atom represents a piece of state. All you need is to specify an initial
-value, which can be a primitive value like a string or number, or an object or
-array. You can create as many primitive atoms as you like.
+A piece of state in Jotai is represented by an atom. All you need is to specify
+an initial value, be it a primitive type like a number, string, or more complex
+structures like arrays and objects. You can create as many primitive atoms as you like.
 
 ```jsx
 import { atom } from 'jotai'

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -21,7 +21,7 @@ You can try live demos here:
 ### First create a primitive atom
 
 An atom represents a piece of state. All you need is to specify an initial
-value, which can be a primitive value like a string, number, object or
+value, which can be a primitive value like a string or number, or an object or
 array. You can create as many primitive atoms as you like.
 
 ```jsx


### PR DESCRIPTION
Hi, I added a small improvement to the docs to make the below sentence a little more accurate (Objects and Arrays aren't primitive types in JS). 

from

"First create a primitive atom.
An atom represents a piece of state. All you need is to specify an initial value, which can be a primitive value like a string, number, object or array. You can create as many primitive atoms as you like."

to

"First create a primitive atom.
An atom represents a piece of state. All you need is to specify an initial
value, which can be a **primitive value like a string or number, or an object or
array.** You can create as many primitive atoms as you like."

More info: I'm new to Jotai, and are going to use it for a project upgrade, and found myself wondering about the usage of the term 'primitive' here.