### PR TITLE
feat(devtools): enabled option in useAtomDevtools

### DIFF
--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -31,12 +31,11 @@ export function useAtomDevtools<Value, Result extends void | Promise<void>>(
   if (typeof options !== 'undefined' && typeof options !== 'object') {
     console.warn('[useAtomDevtools] Please use object options (DevtoolOptions)')
     options = { name: options }
-    if (scope) {
-      options.scope = scope
+    if (deprecatedScope) {
+      options.scope = deprecatedScope
     }
   }
-  const { enabled, name } = options || {}
-  scope ??= options?.scope
+  const { enabled, name, scope } = { scope: deprecatedScope, ...options }
 
   let extension: typeof window['__REDUX_DEVTOOLS_EXTENSION__'] | false
 

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -139,8 +139,8 @@ export function useAtomDevtools<Value, Result extends void | Promise<void>>(
       return
     }
     lastValue.current = value
+    console.log('init', value)
     if (devtools.current.shouldInit) {
-      console.log('init', value)
       devtools.current.init(value)
       devtools.current.shouldInit = false
     } else if (isTimeTraveling.current) {

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -9,6 +9,7 @@ interface DevtoolOptions {
   scope?: Scope
   enabled?: boolean
 }
+
 export function useAtomDevtools<Value, Result extends void | Promise<void>>(
   anAtom: WritableAtom<Value, Value, Result> | Atom<Value>,
   options?: DevtoolOptions
@@ -19,7 +20,7 @@ export function useAtomDevtools<Value, Result extends void | Promise<void>>(
  */
 export function useAtomDevtools<Value, Result extends void | Promise<void>>(
   anAtom: WritableAtom<Value, Value, Result> | Atom<Value>,
-  options?: string,
+  name?: string,
   scope?: Scope
 ): void
 
@@ -28,14 +29,14 @@ export function useAtomDevtools<Value, Result extends void | Promise<void>>(
   options?: DevtoolOptions | string,
   deprecatedScope?: Scope
 ): void {
-  if (typeof options !== 'undefined' && typeof options !== 'object') {
-    console.warn('[useAtomDevtools] Please use object options (DevtoolOptions)')
-    options = { name: options }
-    if (deprecatedScope) {
-      options.scope = deprecatedScope
-    }
+  if (typeof options === 'string' || typeof deprecatedScope !== 'undefined') {
+    console.warn('DEPRECATED [useAtomDevtools] use DevtoolOptions')
+    options = {
+      name: options,
+      scope: deprecatedScope,
+    } as DevtoolOptions // we intentionally lie the type a little bit here
   }
-  const { enabled, name, scope } = { scope: deprecatedScope, ...options }
+  const { enabled, name, scope } = options || {}
 
   let extension: typeof window['__REDUX_DEVTOOLS_EXTENSION__'] | false
 

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -140,6 +140,7 @@ export function useAtomDevtools<Value, Result extends void | Promise<void>>(
     }
     lastValue.current = value
     if (devtools.current.shouldInit) {
+      console.log('init', value)
       devtools.current.init(value)
       devtools.current.shouldInit = false
     } else if (isTimeTraveling.current) {

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -139,7 +139,6 @@ export function useAtomDevtools<Value, Result extends void | Promise<void>>(
       return
     }
     lastValue.current = value
-    console.log('init', value)
     if (devtools.current.shouldInit) {
       devtools.current.init(value)
       devtools.current.shouldInit = false

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -26,7 +26,7 @@ export function useAtomDevtools<Value, Result extends void | Promise<void>>(
 export function useAtomDevtools<Value, Result extends void | Promise<void>>(
   anAtom: WritableAtom<Value, Value, Result> | Atom<Value>,
   options?: DevtoolOptions | string,
-  scope?: Scope
+  deprecatedScope?: Scope
 ): void {
   if (typeof options !== 'undefined' && typeof options !== 'object') {
     console.warn('[useAtomDevtools] Please use object options (DevtoolOptions)')

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -4,21 +4,50 @@ import type { Atom, WritableAtom } from 'jotai'
 import type { Scope, SetAtom } from '../core/atom'
 import { Message } from './types'
 
+interface DevtoolOptions {
+  name?: string
+  scope?: Scope
+  enabled?: boolean
+}
 export function useAtomDevtools<Value, Result extends void | Promise<void>>(
   anAtom: WritableAtom<Value, Value, Result> | Atom<Value>,
-  name?: string,
+  options?: DevtoolOptions
+): void
+
+/*
+ * @deprecated Please use object options (DevtoolsOptions)
+ */
+export function useAtomDevtools<Value, Result extends void | Promise<void>>(
+  anAtom: WritableAtom<Value, Value, Result> | Atom<Value>,
+  options?: string,
+  scope?: Scope
+): void
+
+export function useAtomDevtools<Value, Result extends void | Promise<void>>(
+  anAtom: WritableAtom<Value, Value, Result> | Atom<Value>,
+  options?: DevtoolOptions | string,
   scope?: Scope
 ): void {
-  let extension: typeof window['__REDUX_DEVTOOLS_EXTENSION__']
+  if (typeof options !== 'undefined' && typeof options !== 'object') {
+    console.warn('[useAtomDevtools] Please use object options (DevtoolOptions)')
+    options = { name: options }
+    if (scope) {
+      options.scope = scope
+    }
+  }
+  const { enabled, name } = options || {}
+  scope ??= options?.scope
+
+  let extension: typeof window['__REDUX_DEVTOOLS_EXTENSION__'] | false
 
   try {
-    extension = window.__REDUX_DEVTOOLS_EXTENSION__
+    extension = (enabled ?? __DEV__) && window.__REDUX_DEVTOOLS_EXTENSION__
   } catch {
     // ignored
   }
 
   if (!extension) {
-    if (__DEV__ && typeof window !== 'undefined') {
+    if (__DEV__ && enabled) {
       console.warn('Please install/enable Redux devtools extension')
     }
   }
@@ -28,7 +57,9 @@ export function useAtomDevtools<Value, Result extends void | Promise<void>>(
   const lastValue = useRef(value)
   const isTimeTraveling = useRef(false)
   const devtools = useRef<
-    ReturnType<NonNullable<typeof extension>['connect']> & {
+    ReturnType<
+      NonNullable<typeof window['__REDUX_DEVTOOLS_EXTENSION__']>['connect']
+    > & {
       shouldInit?: boolean
     }
   >()
@@ -36,88 +67,88 @@ export function useAtomDevtools<Value, Result extends void | Promise<void>>(
   const atomName = name || anAtom.debugLabel || anAtom.toString()
 
   useEffect(() => {
-    if (extension) {
-      const setValueIfWritable = (value: Value) => {
-        if (typeof setValue === 'function') {
-          ;(setValue as SetAtom<Value, void>)(value)
-          return
-        }
-        console.warn(
-          '[Warn] you cannot do write operations (Time-travelling, etc) in read-only atoms\n',
-          anAtom
-        )
+    if (!extension) {
+      return
+    }
+    const setValueIfWritable = (value: Value) => {
+      if (typeof setValue === 'function') {
+        ;(setValue as SetAtom<Value, void>)(value)
+        return
       }
+      console.warn(
+        '[Warn] you cannot do write operations (Time-travelling, etc) in read-only atoms\n',
+        anAtom
+      )
+    }
 
-      devtools.current = extension.connect({ name: atomName })
+    devtools.current = extension.connect({ name: atomName })
 
-      const unsubscribe = (
-        devtools.current as unknown as {
-          // FIXME https://github.com/reduxjs/redux-devtools/issues/1097
-          subscribe: (
-            listener: (message: Message) => void
-          ) => (() => void) | undefined
-        }
-      ).subscribe((message) => {
-        if (message.type === 'ACTION' && message.payload) {
-          try {
-            setValueIfWritable(JSON.parse(message.payload))
-          } catch (e) {
-            console.error(
-              'please dispatch a serializable value that JSON.parse() support\n',
-              e
-            )
-          }
-        } else if (message.type === 'DISPATCH' && message.state) {
-          if (
-            message.payload?.type === 'JUMP_TO_ACTION' ||
-            message.payload?.type === 'JUMP_TO_STATE'
-          ) {
-            isTimeTraveling.current = true
-
-            setValueIfWritable(JSON.parse(message.state))
-          }
-        } else if (
-          message.type === 'DISPATCH' &&
-          message.payload?.type === 'COMMIT'
-        ) {
-          devtools.current?.init(lastValue.current)
-        } else if (
-          message.type === 'DISPATCH' &&
-          message.payload?.type === 'IMPORT_STATE'
-        ) {
-          const computedStates =
-            message.payload.nextLiftedState?.computedStates || []
-
-          computedStates.forEach(
-            ({ state }: { state: Value }, index: number) => {
-              if (index === 0) {
-                devtools.current?.init(state)
-              } else {
-                setValueIfWritable(state)
-              }
-            }
+    const unsubscribe = (
+      devtools.current as unknown as {
+        // FIXME https://github.com/reduxjs/redux-devtools/issues/1097
+        subscribe: (
+          listener: (message: Message) => void
+        ) => (() => void) | undefined
+      }
+    ).subscribe((message) => {
+      if (message.type === 'ACTION' && message.payload) {
+        try {
+          setValueIfWritable(JSON.parse(message.payload))
+        } catch (e) {
+          console.error(
+            'please dispatch a serializable value that JSON.parse() support\n',
+            e
           )
         }
-      })
-      devtools.current.shouldInit = true
-      return unsubscribe
-    }
+      } else if (message.type === 'DISPATCH' && message.state) {
+        if (
+          message.payload?.type === 'JUMP_TO_ACTION' ||
+          message.payload?.type === 'JUMP_TO_STATE'
+        ) {
+          isTimeTraveling.current = true
+
+          setValueIfWritable(JSON.parse(message.state))
+        }
+      } else if (
+        message.type === 'DISPATCH' &&
+        message.payload?.type === 'COMMIT'
+      ) {
+        devtools.current?.init(lastValue.current)
+      } else if (
+        message.type === 'DISPATCH' &&
+        message.payload?.type === 'IMPORT_STATE'
+      ) {
+        const computedStates =
+          message.payload.nextLiftedState?.computedStates || []
+
+        computedStates.forEach(({ state }: { state: Value }, index: number) => {
+          if (index === 0) {
+            devtools.current?.init(state)
+          } else {
+            setValueIfWritable(state)
+          }
+        })
+      }
+    })
+    devtools.current.shouldInit = true
+    return unsubscribe
   }, [anAtom, extension, atomName, setValue])
 
   useEffect(() => {
-    if (devtools.current) {
-      lastValue.current = value
-      if (devtools.current.shouldInit) {
-        devtools.current.init(value)
-        devtools.current.shouldInit = false
-      } else if (isTimeTraveling.current) {
-        isTimeTraveling.current = false
-      } else {
-        devtools.current.send(
-          `${atomName} - ${new Date().toLocaleString()}` as any,
-          value
-        )
-      }
+    if (!devtools.current) {
+      return
+    }
+    lastValue.current = value
+    if (devtools.current.shouldInit) {
+      devtools.current.init(value)
+      devtools.current.shouldInit = false
+    } else if (isTimeTraveling.current) {
+      isTimeTraveling.current = false
+    } else {
+      devtools.current.send(
+        `${atomName} - ${new Date().toLocaleString()}` as any,
+        value
+      )
     }
   }, [anAtom, extension, atomName, value])
 }

--- a/tests/devtools/useAtomDevtools.test.tsx
+++ b/tests/devtools/useAtomDevtools.test.tsx
@@ -59,7 +59,7 @@ describe('If there is no extension installed...', () => {
     savedDEV = __DEV__
     ;(window as any).__REDUX_DEVTOOLS_EXTENSION__ = undefined
   })
-  afterAll(() => {
+  afterEach(() => {
     __DEV__ = savedDEV
     ;(window as any).__REDUX_DEVTOOLS_EXTENSION__ = extensionConnector
   })

--- a/tests/devtools/useAtomDevtools.test.tsx
+++ b/tests/devtools/useAtomDevtools.test.tsx
@@ -66,8 +66,8 @@ describe('If there is no extension installed...', () => {
 
   const countAtom = atom(0)
 
-  const Counter = () => {
-    useAtomDevtools(countAtom)
+  const Counter = ({ enabled }: { enabled?: boolean }) => {
+    useAtomDevtools(countAtom, { enabled })
     const [count, setCount] = useAtom(countAtom)
     return (
       <>
@@ -87,17 +87,35 @@ describe('If there is no extension installed...', () => {
     }).not.toThrow()
   })
 
-  it('[DEV-ONLY] warns in dev env', () => {
+  it('[DEV-ONLY] warns in dev env only if enabled', () => {
     __DEV__ = true
     const originalConsoleWarn = console.warn
     console.warn = jest.fn()
 
     render(
       <Provider>
-        <Counter />
+        <Counter enabled={true} />
       </Provider>
     )
     expect(console.warn).toHaveBeenLastCalledWith(
+      'Please install/enable Redux devtools extension'
+    )
+
+    console.warn = originalConsoleWarn
+  })
+
+  it('[PRD-ONLY] does not warn in prod env even if enabled is true', () => {
+    __DEV__ = false
+    const originalConsoleWarn = console.warn
+    console.warn = jest.fn()
+
+    render(
+      <Provider>
+        <Counter enabled={true} />
+      </Provider>
+    )
+
+    expect(console.warn).not.toHaveBeenLastCalledWith(
       'Please install/enable Redux devtools extension'
     )
 

--- a/tests/devtools/useAtomDevtools.test.tsx
+++ b/tests/devtools/useAtomDevtools.test.tsx
@@ -21,6 +21,8 @@ const extension = {
 const extensionConnector = { connect: jest.fn(() => extension) }
 ;(window as any).__REDUX_DEVTOOLS_EXTENSION__ = extensionConnector
 
+const savedDev = __DEV__
+
 beforeAll(() => {
   extensionConnector.connect.mockClear()
   extension.subscribe.mockClear()
@@ -29,6 +31,10 @@ beforeAll(() => {
   extension.init.mockClear()
   extension.error.mockClear()
   extensionSubscriber = undefined
+})
+
+afterEach(() => {
+  __DEV__ = savedDev
 })
 
 it('connects to the extension by initialiing', () => {

--- a/tests/devtools/useAtomDevtools.test.tsx
+++ b/tests/devtools/useAtomDevtools.test.tsx
@@ -32,6 +32,7 @@ beforeAll(() => {
 })
 
 it('connects to the extension by initialiing', () => {
+  __DEV__ = true
   const countAtom = atom(0)
 
   const Counter = () => {

--- a/tests/devtools/useAtomDevtools.test.tsx
+++ b/tests/devtools/useAtomDevtools.test.tsx
@@ -21,7 +21,7 @@ const extension = {
 const extensionConnector = { connect: jest.fn(() => extension) }
 ;(window as any).__REDUX_DEVTOOLS_EXTENSION__ = extensionConnector
 
-beforeEach(() => {
+beforeAll(() => {
   extensionConnector.connect.mockClear()
   extension.subscribe.mockClear()
   extension.unsubscribe.mockClear()

--- a/tests/devtools/useAtomDevtools.test.tsx
+++ b/tests/devtools/useAtomDevtools.test.tsx
@@ -55,7 +55,7 @@ it('connects to the extension by initialiing', () => {
 
 describe('If there is no extension installed...', () => {
   let savedDEV: boolean
-  beforeAll(() => {
+  beforeEach(() => {
     savedDEV = __DEV__
     ;(window as any).__REDUX_DEVTOOLS_EXTENSION__ = undefined
   })
@@ -138,7 +138,8 @@ describe('If there is no extension installed...', () => {
   })
 })
 
-it('updating state should call devtools.send', async () => {
+it('[DEV-ONLY] updating state should call devtools.send', async () => {
+  __DEV__ = true
   const countAtom = atom(0)
 
   const Counter = () => {
@@ -169,7 +170,8 @@ it('updating state should call devtools.send', async () => {
 })
 
 describe('when it receives an message of type...', () => {
-  it('updating state with ACTION', async () => {
+  it('[DEV-ONLY] updating state with ACTION', async () => {
+    __DEV__ = true
     const countAtom = atom(0)
 
     const Counter = () => {
@@ -207,7 +209,8 @@ describe('when it receives an message of type...', () => {
   })
 
   describe('DISPATCH and payload of type...', () => {
-    it('dispatch & COMMIT', async () => {
+    it('[DEV-ONLY] dispatch & COMMIT', async () => {
+      __DEV__ = true
       const countAtom = atom(0)
 
       const Counter = () => {
@@ -244,7 +247,8 @@ describe('when it receives an message of type...', () => {
       expect(extension.init).toBeCalledWith(2)
     })
 
-    it('dispatch & IMPORT_STATE', async () => {
+    it('[DEV-ONLY] dispatch & IMPORT_STATE', async () => {
+      __DEV__ = true
       const countAtom = atom(0)
 
       const Counter = () => {
@@ -285,7 +289,8 @@ describe('when it receives an message of type...', () => {
     })
 
     describe('JUMP_TO_STATE | JUMP_TO_ACTION...', () => {
-      it('time travelling', async () => {
+      it('[DEV-ONLY] time travelling', async () => {
+        __DEV__ = true
         const countAtom = atom(0)
 
         const Counter = () => {

--- a/tests/devtools/useAtomDevtools.test.tsx
+++ b/tests/devtools/useAtomDevtools.test.tsx
@@ -21,8 +21,6 @@ const extension = {
 const extensionConnector = { connect: jest.fn(() => extension) }
 ;(window as any).__REDUX_DEVTOOLS_EXTENSION__ = extensionConnector
 
-const savedDev = __DEV__
-
 beforeAll(() => {
   extensionConnector.connect.mockClear()
   extension.subscribe.mockClear()
@@ -33,12 +31,7 @@ beforeAll(() => {
   extensionSubscriber = undefined
 })
 
-afterEach(() => {
-  __DEV__ = savedDev
-})
-
-it('connects to the extension by initialiing', () => {
-  __DEV__ = true
+it('[DEV-ONLY] connects to the extension by initialiing', () => {
   const countAtom = atom(0)
 
   const Counter = () => {

--- a/tests/devtools/useAtomDevtools.test.tsx
+++ b/tests/devtools/useAtomDevtools.test.tsx
@@ -67,7 +67,7 @@ describe('If there is no extension installed...', () => {
   const countAtom = atom(0)
 
   const Counter = ({ enabled }: { enabled?: boolean }) => {
-    useAtomDevtools(countAtom, { enabled })
+    useAtomDevtools(countAtom, enabled ? { enabled } : undefined)
     const [count, setCount] = useAtom(countAtom)
     return (
       <>

--- a/tests/devtools/useAtomDevtools.test.tsx
+++ b/tests/devtools/useAtomDevtools.test.tsx
@@ -59,7 +59,7 @@ describe('If there is no extension installed...', () => {
     savedDEV = __DEV__
     ;(window as any).__REDUX_DEVTOOLS_EXTENSION__ = undefined
   })
-  afterEach(() => {
+  afterAll(() => {
     __DEV__ = savedDEV
     ;(window as any).__REDUX_DEVTOOLS_EXTENSION__ = extensionConnector
   })

--- a/tests/devtools/useAtomDevtools.test.tsx
+++ b/tests/devtools/useAtomDevtools.test.tsx
@@ -31,7 +31,8 @@ beforeAll(() => {
   extensionSubscriber = undefined
 })
 
-it('[DEV-ONLY] connects to the extension by initialiing', () => {
+it('[DEV-ONLY] connects to the extension by initializing', () => {
+  __DEV__ = true
   const countAtom = atom(0)
 
   const Counter = () => {

--- a/tests/devtools/useAtomDevtools.test.tsx
+++ b/tests/devtools/useAtomDevtools.test.tsx
@@ -21,7 +21,7 @@ const extension = {
 const extensionConnector = { connect: jest.fn(() => extension) }
 ;(window as any).__REDUX_DEVTOOLS_EXTENSION__ = extensionConnector
 
-beforeAll(() => {
+beforeEach(() => {
   extensionConnector.connect.mockClear()
   extension.subscribe.mockClear()
   extension.unsubscribe.mockClear()


### PR DESCRIPTION
This PR tries to achieve what we achieved in https://github.com/pmndrs/zustand/pull/880 and #1076  so we can add an option called `enabled` for better testing/dev env friendly errors/warnings!

This PR is for useAtomDevtools.