### PR TITLE
feat(breaking-change): return dependants with useAtomsSnapshot

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -84,7 +84,7 @@ type Dependents = Set<AnyAtom>
  *
  * The mounted state of an atom is freed once it is no longer mounted.
  */
-type Mounted = {
+export type Mounted = {
   /** The list of subscriber functions. */
   l: Listeners
   /** Atoms that depend on *this* atom. Used to fan out invalidation. */

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -6,9 +6,8 @@ import {
   DEV_GET_MOUNTED,
   DEV_GET_MOUNTED_ATOMS,
   DEV_SUBSCRIBE_STATE,
-  Mounted,
 } from '../core/store'
-import type { AtomState, Store } from '../core/store'
+import type { AtomState, Mounted, Store } from '../core/store'
 
 type AtomsValues = Map<Atom<unknown>, unknown>
 type AtomsDependants = Map<Atom<unknown>, Set<Atom<unknown>>>

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -3,12 +3,16 @@ import { SECRET_INTERNAL_getScopeContext as getScopeContext } from 'jotai'
 import type { Atom, Scope } from '../core/atom'
 import {
   DEV_GET_ATOM_STATE,
+  DEV_GET_MOUNTED,
   DEV_GET_MOUNTED_ATOMS,
   DEV_SUBSCRIBE_STATE,
+  Mounted,
 } from '../core/store'
 import type { AtomState, Store } from '../core/store'
 
-type AtomsSnapshot = Map<Atom<unknown>, unknown>
+type AtomsValues = Map<Atom<unknown>, unknown>
+type AtomsDependants = Map<Atom<unknown>, Set<Atom<unknown>>>
+type AtomsSnapshot = readonly [AtomsValues, AtomsDependants]
 
 const createAtomsSnapshot = (
   store: Store,
@@ -18,7 +22,12 @@ const createAtomsSnapshot = (
     const atomState = store[DEV_GET_ATOM_STATE]?.(atom) ?? ({} as AtomState)
     return [atom, 'v' in atomState ? atomState.v : undefined]
   })
-  return new Map(tuples)
+  const dependants = atoms.map<[Atom<unknown>, Set<Atom<unknown>>]>((atom) => {
+    const mounted = store[DEV_GET_MOUNTED]?.(atom) ?? ({} as Mounted)
+    return [atom, mounted.t]
+  })
+
+  return [new Map(tuples), new Map(dependants)]
 }
 
 export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
@@ -30,9 +39,10 @@ export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
     throw new Error('useAtomsSnapshot can only be used in dev mode.')
   }
 
-  const [atomsSnapshot, setAtomsSnapshot] = useState<AtomsSnapshot>(
-    () => new Map()
-  )
+  const [atomsSnapshot, setAtomsSnapshot] = useState<AtomsSnapshot>(() => [
+    new Map(),
+    new Map(),
+  ])
 
   useEffect(() => {
     const callback = () => {

--- a/tests/devtools/useGoToAtomsSnapshot.test.tsx
+++ b/tests/devtools/useGoToAtomsSnapshot.test.tsx
@@ -20,7 +20,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should modify atoms snapshot', async () => {
   }
 
   const UpdateSnapshot = () => {
-    const snapshot = useAtomsSnapshot()
+    const [snapshot] = useAtomsSnapshot()
     const goToSnapshot = useGotoAtomsSnapshot()
     return (
       <button
@@ -65,7 +65,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with derived atoms', async () =>
   }
 
   const UpdateSnapshot = () => {
-    const snapshot = useAtomsSnapshot()
+    const [snapshot] = useAtomsSnapshot()
     const goToSnapshot = useGotoAtomsSnapshot()
     return (
       <button
@@ -116,7 +116,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with async derived atoms', async
   }
 
   const UpdateSnapshot = () => {
-    const snapshot = useAtomsSnapshot()
+    const [snapshot] = useAtomsSnapshot()
     const goToSnapshot = useGotoAtomsSnapshot()
     return (
       <button
@@ -170,7 +170,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with original snapshot', async (
   }
 
   const UpdateSnapshot = () => {
-    const snapshot = useAtomsSnapshot()
+    const [snapshot] = useAtomsSnapshot()
     const snapshotRef = useRef<Map<Atom<unknown>, unknown>>()
     useEffect(() => {
       if (snapshot.size && !snapshotRef.current) {
@@ -226,7 +226,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should respect atom scope', async () => {
   }
 
   const UpdateSnapshot = () => {
-    const snapshot = useAtomsSnapshot(scope)
+    const [snapshot] = useAtomsSnapshot(scope)
     const goToSnapshot = useGotoAtomsSnapshot(scope)
     return (
       <button


### PR DESCRIPTION
This issue address this in #911 
> Maybe we should somehow return dependents too. (Provider's useDebugState does it)
