### PR TITLE
feat(breaking-change): return dependants with useAtomsSnapshot (v2)

### DIFF
--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -6,9 +6,8 @@ import {
   DEV_GET_MOUNTED,
   DEV_GET_MOUNTED_ATOMS,
   DEV_SUBSCRIBE_STATE,
-  Mounted,
 } from '../core/store'
-import type { AtomState, Store } from '../core/store'
+import type { AtomState, Mounted, Store } from '../core/store'
 
 type AtomsValues = Map<Atom<unknown>, unknown>
 type AtomsDependants = Map<Atom<unknown>, Set<Atom<unknown>>>

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -3,12 +3,16 @@ import { SECRET_INTERNAL_getScopeContext as getScopeContext } from 'jotai'
 import type { Atom, Scope } from '../core/atom'
 import {
   DEV_GET_ATOM_STATE,
+  DEV_GET_MOUNTED,
   DEV_GET_MOUNTED_ATOMS,
   DEV_SUBSCRIBE_STATE,
+  Mounted,
 } from '../core/store'
 import type { AtomState, Store } from '../core/store'
 
-type AtomsSnapshot = Map<Atom<unknown>, unknown>
+type AtomsValues = Map<Atom<unknown>, unknown>
+type AtomsDependants = Map<Atom<unknown>, Set<Atom<unknown>>>
+type AtomsSnapshot = readonly [AtomsValues, AtomsDependants]
 
 const createAtomsSnapshot = (
   store: Store,
@@ -18,7 +22,12 @@ const createAtomsSnapshot = (
     const atomState = store[DEV_GET_ATOM_STATE]?.(atom) ?? ({} as AtomState)
     return [atom, 'v' in atomState ? atomState.v : undefined]
   })
-  return new Map(tuples)
+  const dependants = atoms.map<[Atom<unknown>, Set<Atom<unknown>>]>((atom) => {
+    const mounted = store[DEV_GET_MOUNTED]?.(atom) ?? ({} as Mounted)
+    return [atom, mounted.t]
+  })
+
+  return [new Map(tuples), new Map(dependants)]
 }
 
 export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
@@ -30,9 +39,10 @@ export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
     throw new Error('useAtomsSnapshot can only be used in dev mode.')
   }
 
-  const [atomsSnapshot, setAtomsSnapshot] = useState<AtomsSnapshot>(
-    () => new Map()
-  )
+  const [atomsSnapshot, setAtomsSnapshot] = useState<AtomsSnapshot>(() => [
+    new Map(),
+    new Map(),
+  ])
 
   useEffect(() => {
     const callback = () => {

--- a/src/devtools/useGotoAtomsSnapshot.ts
+++ b/src/devtools/useGotoAtomsSnapshot.ts
@@ -24,6 +24,9 @@ export function useGotoAtomsSnapshot(scope?: Scope) {
   return useCallback(
     (values: Iterable<readonly [Atom<unknown>, unknown]> | AtomsSnapshot) => {
       if (isIterable(values)) {
+        if (__DEV__) {
+          console.warn('snapshot as iterable is no longer supported. use an object instead.')
+        }
         store[RESTORE_ATOMS](values)
         return
       }

--- a/src/devtools/useGotoAtomsSnapshot.ts
+++ b/src/devtools/useGotoAtomsSnapshot.ts
@@ -3,6 +3,15 @@ import { SECRET_INTERNAL_getScopeContext as getScopeContext } from 'jotai'
 import type { Atom, Scope } from '../core/atom'
 import { DEV_SUBSCRIBE_STATE, RESTORE_ATOMS } from '../core/store'
 
+type AnyAtomValue = unknown
+type AnyAtom = Atom<AnyAtomValue>
+type AtomsValues = Map<AnyAtom, AnyAtomValue> // immutable
+type AtomsDependents = Map<AnyAtom, Set<AnyAtom>> // immutable
+type AtomsSnapshot = Readonly<{
+  values: AtomsValues
+  dependents: AtomsDependents
+}>
+
 export function useGotoAtomsSnapshot(scope?: Scope) {
   const ScopeContext = getScopeContext(scope)
   const scopeContainer = useContext(ScopeContext)
@@ -13,9 +22,17 @@ export function useGotoAtomsSnapshot(scope?: Scope) {
   }
 
   return useCallback(
-    (values: Iterable<readonly [Atom<unknown>, unknown]>) => {
-      store[RESTORE_ATOMS](values)
+    (values: Iterable<readonly [Atom<unknown>, unknown]> | AtomsSnapshot) => {
+      if (isIterable(values)) {
+        store[RESTORE_ATOMS](values)
+        return
+      }
+      store[RESTORE_ATOMS](values.values)
     },
     [store]
   )
+}
+
+function isIterable(item: any): item is Iterable<any> {
+  return typeof item[Symbol.iterator] === 'function'
 }

--- a/src/devtools/useGotoAtomsSnapshot.ts
+++ b/src/devtools/useGotoAtomsSnapshot.ts
@@ -25,7 +25,9 @@ export function useGotoAtomsSnapshot(scope?: Scope) {
     (values: Iterable<readonly [Atom<unknown>, unknown]> | AtomsSnapshot) => {
       if (isIterable(values)) {
         if (__DEV__) {
-          console.warn('snapshot as iterable is no longer supported. use an object instead.')
+          console.warn(
+            'snapshot as iterable is no longer supported. use an object instead.'
+          )
         }
         store[RESTORE_ATOMS](values)
         return

--- a/tests/devtools/useAtomsSnapshot.test.tsx
+++ b/tests/devtools/useAtomsSnapshot.test.tsx
@@ -26,7 +26,7 @@ it('[DEV-ONLY] should register newly added atoms', async () => {
   }
 
   const RegisteredAtomsCount = () => {
-    const [atoms] = useAtomsSnapshot()
+    const atoms = useAtomsSnapshot().values
 
     return <p>atom count: {atoms.size}</p>
   }
@@ -56,7 +56,7 @@ it('[DEV-ONLY] should let you access atoms and their state', async () => {
   }
 
   const SimpleDevtools = () => {
-    const [atoms] = useAtomsSnapshot()
+    const atoms = useAtomsSnapshot().values
 
     return (
       <div>
@@ -91,7 +91,7 @@ it('[DEV-ONLY] should contain initial values', async () => {
   }
 
   const SimpleDevtools = () => {
-    const [atoms] = useAtomsSnapshot()
+    const atoms = useAtomsSnapshot().values
 
     return (
       <div>
@@ -143,7 +143,7 @@ it('[DEV-ONLY] conditional dependencies + updating state should call devtools.se
   }
 
   const SimpleDevtools = () => {
-    const [, dependents] = useAtomsSnapshot()
+    const { dependents } = useAtomsSnapshot()
 
     const obj: Record<string, string[]> = {}
 

--- a/tests/devtools/useGoToAtomsSnapshot.test.tsx
+++ b/tests/devtools/useGoToAtomsSnapshot.test.tsx
@@ -20,7 +20,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should modify atoms snapshot', async () => {
   }
 
   const UpdateSnapshot = () => {
-    const snapshot = useAtomsSnapshot()
+    const [snapshot] = useAtomsSnapshot()
     const goToSnapshot = useGotoAtomsSnapshot()
     return (
       <button
@@ -65,7 +65,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with derived atoms', async () =>
   }
 
   const UpdateSnapshot = () => {
-    const snapshot = useAtomsSnapshot()
+    const [snapshot] = useAtomsSnapshot()
     const goToSnapshot = useGotoAtomsSnapshot()
     return (
       <button
@@ -116,7 +116,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with async derived atoms', async
   }
 
   const UpdateSnapshot = () => {
-    const snapshot = useAtomsSnapshot()
+    const [snapshot] = useAtomsSnapshot()
     const goToSnapshot = useGotoAtomsSnapshot()
     return (
       <button
@@ -170,7 +170,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with original snapshot', async (
   }
 
   const UpdateSnapshot = () => {
-    const snapshot = useAtomsSnapshot()
+    const [snapshot] = useAtomsSnapshot()
     const snapshotRef = useRef<Map<Atom<unknown>, unknown>>()
     useEffect(() => {
       if (snapshot.size && !snapshotRef.current) {
@@ -226,7 +226,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should respect atom scope', async () => {
   }
 
   const UpdateSnapshot = () => {
-    const snapshot = useAtomsSnapshot(scope)
+    const [snapshot] = useAtomsSnapshot(scope)
     const goToSnapshot = useGotoAtomsSnapshot(scope)
     return (
       <button

--- a/tests/devtools/useGoToAtomsSnapshot.test.tsx
+++ b/tests/devtools/useGoToAtomsSnapshot.test.tsx
@@ -25,10 +25,10 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should modify atoms snapshot', async () => {
     return (
       <button
         onClick={() => {
-          const newSnapshot = new Map(snapshot)
-          newSnapshot.set(petAtom, 'dog')
-          newSnapshot.set(colorAtom, 'green')
-          goToSnapshot(newSnapshot)
+          const newSnapshot = { ...snapshot, values: new Map(snapshot.values) }
+          newSnapshot.values.set(petAtom, 'dog')
+          newSnapshot.values.set(colorAtom, 'green')
+          goToSnapshot(newSnapshot.values) // `values` for testing backward compatibility
         }}>
         click
       </button>
@@ -65,13 +65,13 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with derived atoms', async () =>
   }
 
   const UpdateSnapshot = () => {
-    const [snapshot] = useAtomsSnapshot()
+    const snapshot = useAtomsSnapshot()
     const goToSnapshot = useGotoAtomsSnapshot()
     return (
       <button
         onClick={() => {
-          const newSnapshot = new Map(snapshot)
-          newSnapshot.set(priceAtom, 20)
+          const newSnapshot = { ...snapshot, values: new Map(snapshot.values) }
+          newSnapshot.values.set(priceAtom, 20)
           goToSnapshot(newSnapshot)
         }}>
         click
@@ -121,8 +121,8 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with async derived atoms', async
     return (
       <button
         onClick={() => {
-          const newSnapshot = new Map(snapshot)
-          newSnapshot.set(priceAtom, 20)
+          const newSnapshot = { ...snapshot, values: new Map(snapshot.values) }
+          newSnapshot.values.set(priceAtom, 20)
           goToSnapshot(newSnapshot)
         }}>
         click
@@ -173,9 +173,9 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with original snapshot', async (
     const snapshot = useAtomsSnapshot()
     const snapshotRef = useRef<Map<Atom<unknown>, unknown>>()
     useEffect(() => {
-      if (snapshot.size && !snapshotRef.current) {
+      if (snapshot.values.size && !snapshotRef.current) {
         // save first snapshot
-        snapshotRef.current = snapshot
+        snapshotRef.current = snapshot.values
       }
     })
     const goToSnapshot = useGotoAtomsSnapshot()
@@ -185,7 +185,10 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with original snapshot', async (
           if (!snapshotRef.current) {
             throw new Error('snapshot is not ready yet')
           }
-          const newSnapshot = new Map(snapshotRef.current)
+          const newSnapshot = {
+            ...snapshot,
+            values: new Map(snapshotRef.current),
+          }
           goToSnapshot(newSnapshot)
         }}>
         snapshot
@@ -231,8 +234,8 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should respect atom scope', async () => {
     return (
       <button
         onClick={() => {
-          const newSnapshot = new Map(snapshot)
-          newSnapshot.set(petAtom, 'dog')
+          const newSnapshot = { ...snapshot, values: new Map(snapshot.values) }
+          newSnapshot.values.set(petAtom, 'dog')
           goToSnapshot(newSnapshot)
         }}>
         click

--- a/tests/devtools/useGoToAtomsSnapshot.test.tsx
+++ b/tests/devtools/useGoToAtomsSnapshot.test.tsx
@@ -20,7 +20,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should modify atoms snapshot', async () => {
   }
 
   const UpdateSnapshot = () => {
-    const [snapshot] = useAtomsSnapshot()
+    const snapshot = useAtomsSnapshot()
     const goToSnapshot = useGotoAtomsSnapshot()
     return (
       <button
@@ -116,7 +116,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with async derived atoms', async
   }
 
   const UpdateSnapshot = () => {
-    const [snapshot] = useAtomsSnapshot()
+    const snapshot = useAtomsSnapshot()
     const goToSnapshot = useGotoAtomsSnapshot()
     return (
       <button
@@ -170,7 +170,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with original snapshot', async (
   }
 
   const UpdateSnapshot = () => {
-    const [snapshot] = useAtomsSnapshot()
+    const snapshot = useAtomsSnapshot()
     const snapshotRef = useRef<Map<Atom<unknown>, unknown>>()
     useEffect(() => {
       if (snapshot.size && !snapshotRef.current) {
@@ -226,7 +226,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should respect atom scope', async () => {
   }
 
   const UpdateSnapshot = () => {
-    const [snapshot] = useAtomsSnapshot(scope)
+    const snapshot = useAtomsSnapshot(scope)
     const goToSnapshot = useGotoAtomsSnapshot(scope)
     return (
       <button


### PR DESCRIPTION
This issue address this in #911 
> Maybe we should somehow return dependents too. (Provider's useDebugState does it)
