### PR TITLE
fix(urql): atomWithQuery: improve isOperationResultWithData to avoid `undefined` in case of error

### DIFF
--- a/src/urql/atomWithQuery.ts
+++ b/src/urql/atomWithQuery.ts
@@ -18,11 +18,14 @@ type AtomWithQueryAction = {
 type OperationResultWithData<Data, Variables> = OperationResult<
   Data,
   Variables
->
+> & {
+  data: Data
+}
 
 const isOperationResultWithData = <Data, Variables>(
   result: OperationResult<Data, Variables>
-): result is OperationResultWithData<Data, Variables> => 'data' in result
+): result is OperationResultWithData<Data, Variables> =>
+  'data' in result && !result.error
 
 type QueryArgs<Data, Variables extends object> = {
   query: TypedDocumentNode<Data, Variables> | string

--- a/src/urql/atomWithQuery.ts
+++ b/src/urql/atomWithQuery.ts
@@ -18,9 +18,7 @@ type AtomWithQueryAction = {
 type OperationResultWithData<Data, Variables> = OperationResult<
   Data,
   Variables
-> & {
-  data: Data
-}
+>
 
 const isOperationResultWithData = <Data, Variables>(
   result: OperationResult<Data, Variables>


### PR DESCRIPTION
Despite the runtime check (`isOperationResultWithData`), there is a key `data` in the result, but the value is `undefined` in case of error. Let's retain optional `data` definition from `urql` `OperationResult`

![Screenshot_20220429_001040](https://user-images.githubusercontent.com/829569/165847184-f48580b2-869a-4683-a0d2-7a5ba546ac8c.png)
