### PR TITLE
docs: warn about usage of `Provider` inside `Suspense`

### DIFF
--- a/docs/basics/async.mdx
+++ b/docs/basics/async.mdx
@@ -12,7 +12,7 @@ Async support is first class in jotai. It fully leverages React Suspense.
 
 To use async atoms, you need to wrap your component tree with `<Suspense>`.
 
-> If you have a `<Provider>`, place **at least one** `<Suspense>` inside said `<Provider>`.
+> If you have a `<Provider>`, place **at least one** `<Suspense>` inside said `<Provider>`; otherwise, it may cause an endless loop while rendering the components.
 
 ```jsx
 const App = () => (

--- a/docs/basics/async.mdx
+++ b/docs/basics/async.mdx
@@ -11,7 +11,8 @@ Async support is first class in jotai. It fully leverages React Suspense.
 ## Suspense
 
 To use async atoms, you need to wrap your component tree with `<Suspense>`.
-If you have `<Provider>`, place at least one `<Suspense>` inside the `<Provider>`.
+
+> If you have a `<Provider>`, place **at least one** `<Suspense>` inside said `<Provider>`.
 
 ```jsx
 const App = () => (


### PR DESCRIPTION
As discussed in #1112, I've made the warning about using a `Provider` inside a `Suspense` a bit more noticeable.

Initially, I wanted to create a section with a heading and the paragraph, but I think the yellow box (blockquote) inside the "Suspense" paragraph makes more sense.

Do you think this is okay? For example, should I write what could happen if the `Provider` contains no `Suspense`?