### PR TITLE
fix(docs): added info about infinite loop on useAtom

### DIFF
--- a/docs/basics/primitives.mdx
+++ b/docs/basics/primitives.mdx
@@ -71,6 +71,7 @@ const Component = ({ value }) => {
 }
 ```
 
+
 ## useAtom
 
 The `useAtom` hook is to read an atom value in the state.
@@ -94,6 +95,16 @@ const [value, updateValue] = useAtom(anAtom)
 The `updateValue` takes just one argument, which will be passed
 to the third argument of the write function of the atom.
 The behavior depends on how the write function is implemented.
+
+**Note:** as mentioned in the *atom* section, you have to take care of handling the reference of your atom, otherwise it may enter an infinite loop
+```typescript
+const safeAtom = atom(0)
+const Component = () => {
+  const [value] = useAtom(atom(0)) // Will cause an infinite loop
+  const [safeValue] = useAtom(safeAtmo) // is fine
+  const [alsoSafeValue] = useAtom(React.useMemo(0, [])) // is also fine
+}
+```
 
 ## Provider
 

--- a/docs/basics/primitives.mdx
+++ b/docs/basics/primitives.mdx
@@ -98,11 +98,11 @@ The behavior depends on how the write function is implemented.
 
 **Note:** as mentioned in the *atom* section, you have to take care of handling the reference of your atom, otherwise it may enter an infinite loop
 ```typescript
-const safeAtom = atom(0)
+const stableAtom = atom(0)
 const Component = () => {
-  const [value] = useAtom(atom(0)) // Will cause an infinite loop
-  const [safeValue] = useAtom(safeAtmo) // is fine
-  const [alsoSafeValue] = useAtom(React.useMemo(0, [])) // is also fine
+  const [atomValue] = useAtom(atom(0)) // Will cause an infinite loop
+  const [atomValue] = useAtom(stableAtom) // is fine
+  const [derivedAtomValue] = useMemo(() => atom((get) => get(stableAtom) * 2), []) // is also fine
 }
 ```
 

--- a/docs/utils/select-atom.mdx
+++ b/docs/utils/select-atom.mdx
@@ -53,6 +53,33 @@ const nameAtom = selectAtom(personAtom, (person) => person.name)
 const birthAtom = selectAtom(personAtom, (person) => person.birth, deepEquals)
 ```
 
+## Hold stable references
+
+As always, to prevent an infinite loop when using `useAtom` in render cycle, you must provide `useAtom` a stable reference of your atoms.
+For `selectAtom`, we need **both** the base atom and the selector to be stable.
+
+```typescript
+const [value] = useAtom(selectAtom(atom(0), (val) => val)) // So this will cause an infinite loop
+```
+
+You have multiple options in order to satisfy these constraints:
+
+```typescript
+const baseAtom = atom(0) // Stable
+const selector = (v) => v // Stable
+const Component = () => {
+  // Solution 1: Memoize the whole resulting atom with "useMemo"
+  const [value] = useAtom(useMemo(() => selectAtom(baseAtom, (v) => v), []))
+
+  // Solution 2: Memoize the inline callback with "useCallback"
+  const [value] = useAtom(selectAtom(baseAtom, useCallback((v) => v, [])))
+
+  // Solution 3: All constraints are already satisfied
+  const [value] = useAtom(selectAtom(baseAtom, selector))
+}
+
+```
+
 ## CodeSandbox
 
 <CodeSandbox id="8czek" />


### PR DESCRIPTION
@dai-shi I know you wanted to talk about `selectAtom` at this point, but I'm not sure why it's related, as it will still cause an infinite loop if used directly in the `useAtom`

I tested this:

```typescript
const [value] = useAtom(selectAtom(atom(0), (val) => val))
```

On the first render it does okay, but as soon as there is another render triggered by something else, this will cause an infinite loop.
I may be missing something about this selectAtom, for me it was just a fancy tool for redux lovers :p