### PR TITLE
fix(utils): fix memory leaks and other issues in atomWithObservable

### DIFF
--- a/docs/utils/atom-with-observable.mdx
+++ b/docs/utils/atom-with-observable.mdx
@@ -40,6 +40,18 @@ const counterAtom2 = atomWithObservable(() => counterSubject, {
 })
 ```
 
+## Timeout
+
+To prevent memory leaks, the subscription to the observable is cancelled if no initial value was omitted after ten seconds. 
+You can change this value via the `timeout` option. 
+You can disable the `timeout` by setting the value to `false`.
+
+```ts
+const counterAtomWithOneSecondTimeout = atomWithObservable(() => counterSubject, {timeout: 1000});
+
+const counterAtomWithoutTimeout = atomWithObservable(() => counterSubject, {timeout: false});
+```
+
 ### Codesandbox
 
 <CodeSandbox id="88pnt" />

--- a/docs/utils/atom-with-observable.mdx
+++ b/docs/utils/atom-with-observable.mdx
@@ -40,18 +40,6 @@ const counterAtom2 = atomWithObservable(() => counterSubject, {
 })
 ```
 
-## Timeout
-
-To prevent memory leaks, the subscription to the observable is cancelled if no initial value was omitted after ten seconds. 
-You can change this value via the `timeout` option. 
-You can disable the `timeout` by setting the value to `false`.
-
-```ts
-const counterAtomWithOneSecondTimeout = atomWithObservable(() => counterSubject, {timeout: 1000});
-
-const counterAtomWithoutTimeout = atomWithObservable(() => counterSubject, {timeout: false});
-```
-
 ### Codesandbox
 
 <CodeSandbox id="88pnt" />

--- a/src/utils/atomWithObservable.ts
+++ b/src/utils/atomWithObservable.ts
@@ -105,6 +105,16 @@ export function atomWithObservable<TData>(
     if (options?.initialValue !== undefined) {
       initialValue = getInitialValue(options)
     } else {
+      // FIXME
+      // There is the potential for memory leaks in this implementation.
+      //
+      // If the observable doesn't emit an initial value before the component that uses the atom gets destroyed,
+      // the onMount function never gets called and therefore the subscription never gets cleaned up.
+      //
+      // Unfortunately, currently there is no good way to prevent this issue (as of 2022-05-23).
+      // Timeouts may lead to an endless loading state, if the subscription get's cleaned up too quickly.
+      //
+      // Discussion: https://github.com/pmndrs/jotai/pull/1170
       subscription = observable.subscribe(dataListener, errorListener)
       initialValue = initialEmittedValue
     }

--- a/src/utils/atomWithObservable.ts
+++ b/src/utils/atomWithObservable.ts
@@ -58,8 +58,7 @@ export function atomWithObservable<TData>(
 
     // To differentiate beetwen no value was emitted and `undefined` was emitted,
     // this symbol is used
-    const NotEmitted = Symbol()
-    type NotEmitted = typeof NotEmitted
+    const EMPTY = Symbol()
 
     let resolveEmittedInitialValue:
       | ((data: TData | Promise<TData>) => void)
@@ -72,8 +71,7 @@ export function atomWithObservable<TData>(
         : undefined
     let initialValueWasEmitted = false
 
-    let emittedValueBeforeMount: TData | Promise<TData> | NotEmitted =
-      NotEmitted
+    let emittedValueBeforeMount: TData | Promise<TData> | typeof EMPTY = EMPTY
     let isSync = true
     let setData: (data: TData | Promise<TData>) => void = (data) => {
       // First we set the initial value (if not other initialValue was provided)
@@ -108,14 +106,14 @@ export function atomWithObservable<TData>(
       initialValue = getInitialValue(options)
     } else {
       subscription = observable.subscribe(dataListener, errorListener)
-      isSync = false
       initialValue = initialEmittedValue
     }
+    isSync = false
 
     const dataAtom = atom(initialValue)
     dataAtom.onMount = (update) => {
       setData = update
-      if (emittedValueBeforeMount !== NotEmitted) {
+      if (emittedValueBeforeMount !== EMPTY) {
         update(emittedValueBeforeMount)
       }
       if (!subscription) {

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -243,39 +243,6 @@ it('cleanup subscription', async () => {
   await waitFor(() => expect(activeSubscriptions).toEqual(0))
 })
 
-it('cleanup subscriptions after timeout if initial value never emits', async () => {
-  const subject = new Subject()
-  let subscriptions = 0
-  const observable = new Observable((subscriber) => {
-    subscriptions++
-    subject.subscribe(subscriber)
-    return () => {
-      subscriptions--
-    }
-  })
-  const observableAtom = atomWithObservable(() => observable, { timeout: 500 })
-
-  const Counter = () => {
-    const [state] = useAtom(observableAtom)
-
-    return <>count: {state}</>
-  }
-
-  const { findByText, rerender } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
-  )
-
-  await findByText('loading')
-  expect(subscriptions).toEqual(1)
-
-  rerender(<div />)
-  await waitFor(() => expect(subscriptions).toEqual(0))
-})
-
 it('resubscribe on remount', async () => {
   const subject = new Subject<number>()
   const observableAtom = atomWithObservable(() => subject)

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -1,19 +1,41 @@
-import { ReactElement, Suspense, useState } from 'react'
-import { act, fireEvent, render } from '@testing-library/react'
-import { BehaviorSubject, Observable, ReplaySubject, Subject } from 'rxjs'
-import { useAtom } from 'jotai'
+import { Component, ReactElement, ReactNode, Suspense, useState } from 'react'
+import { act, fireEvent, render, waitFor } from '@testing-library/react'
+import {
+  BehaviorSubject,
+  Observable,
+  ReplaySubject,
+  Subject,
+  delay,
+  of,
+} from 'rxjs'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { atomWithObservable } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
 
+class ErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: string }
+> {
+  state = {
+    error: '',
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error: error.message }
+  }
+
+  render() {
+    if (this.state.error) {
+      return <div>Error: {this.state.error}</div>
+    }
+    return this.props.children
+  }
+}
+
 it('count state', async () => {
-  const observableAtom = atomWithObservable(
-    () =>
-      new Observable<number>((subscriber) => {
-        subscriber.next(1)
-      })
-  )
+  const observableAtom = atomWithObservable(() => of(1))
 
   const Counter = () => {
     const [state] = useAtom(observableAtom)
@@ -33,17 +55,8 @@ it('count state', async () => {
 })
 
 it('writable count state', async () => {
-  const observableAtom = atomWithObservable(() => {
-    const observable = new Observable<number>((subscriber) => {
-      subscriber.next(1)
-    })
-    const subject = new ReplaySubject<number>()
-    // is this usual to delay the subscription?
-    setTimeout(() => {
-      observable.subscribe(subject)
-    }, 100)
-    return subject
-  })
+  const subject = new BehaviorSubject(1)
+  const observableAtom = atomWithObservable(() => subject)
 
   const Counter = () => {
     const [state, dispatch] = useAtom(observableAtom)
@@ -64,11 +77,203 @@ it('writable count state', async () => {
     </Provider>
   )
 
+  await findByText('count: 1')
+
+  act(() => subject.next(2))
+  await findByText('count: 2')
+
+  fireEvent.click(getByText('button'))
+  await findByText('count: 9')
+  expect(subject.value).toBe(9)
+
+  expect(subject)
+})
+
+it('writable count state without initial value', async () => {
+  const subject = new Subject<number>()
+  const observableAtom = atomWithObservable(() => subject)
+
+  const CounterValue = () => {
+    const state = useAtomValue(observableAtom)
+
+    return <>count: {state}</>
+  }
+
+  const CounterButton = () => {
+    const dispatch = useSetAtom(observableAtom)
+
+    return <button onClick={() => dispatch(9)}>button</button>
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Suspense fallback="loading">
+        <Suspense fallback="loading">
+          <CounterValue />
+        </Suspense>
+        <CounterButton />
+      </Suspense>
+    </Provider>
+  )
+
+  await findByText('loading')
+
+  fireEvent.click(getByText('button'))
+  await findByText('count: 9')
+
+  act(() => subject.next(3))
+  await findByText('count: 3')
+})
+
+it('writable count state with delayed value', async () => {
+  const subject = new Subject<number>()
+  const observableAtom = atomWithObservable(() => {
+    const observable = of(1).pipe(delay(500))
+    observable.subscribe((n) => subject.next(n))
+    return subject
+  })
+
+  const Counter = () => {
+    const [state, dispatch] = useAtom(observableAtom)
+
+    return (
+      <>
+        count: {state}
+        <button
+          onClick={() => {
+            dispatch(9)
+          }}>
+          button
+        </button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+    </Provider>
+  )
+
   await findByText('loading')
   await findByText('count: 1')
 
   fireEvent.click(getByText('button'))
   await findByText('count: 9')
+})
+
+it('only subscribe once per atom', async () => {
+  const subject = new Subject()
+  let totalSubscriptions = 0
+  const observable = new Observable((subscriber) => {
+    totalSubscriptions++
+    subject.subscribe(subscriber)
+  })
+  const observableAtom = atomWithObservable(() => observable)
+
+  const Counter = () => {
+    const [state] = useAtom(observableAtom)
+
+    return <>count: {state}</>
+  }
+
+  const { findByText, rerender } = render(
+    <Provider>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+    </Provider>
+  )
+  await findByText('loading')
+  act(() => subject.next(1))
+  await findByText('count: 1')
+
+  rerender(<div />)
+  expect(totalSubscriptions).toEqual(1)
+
+  rerender(
+    <Provider>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+    </Provider>
+  )
+  await findByText('loading')
+  act(() => subject.next(2))
+  await findByText('count: 2')
+
+  expect(totalSubscriptions).toEqual(2)
+})
+
+it('cleanup subscription', async () => {
+  const subject = new Subject()
+  let activeSubscriptions = 0
+  const observable = new Observable((subscriber) => {
+    activeSubscriptions++
+    subject.subscribe(subscriber)
+    return () => {
+      activeSubscriptions--
+    }
+  })
+  const observableAtom = atomWithObservable(() => observable)
+
+  const Counter = () => {
+    const [state] = useAtom(observableAtom)
+
+    return <>count: {state}</>
+  }
+
+  const { findByText, rerender } = render(
+    <Provider>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+    </Provider>
+  )
+
+  await findByText('loading')
+
+  act(() => subject.next(1))
+  await findByText('count: 1')
+
+  expect(activeSubscriptions).toEqual(1)
+  rerender(<div />)
+  await waitFor(() => expect(activeSubscriptions).toEqual(0))
+})
+
+it('cleanup subscriptions after timeout if initial value never emits', async () => {
+  const subject = new Subject()
+  let subscriptions = 0
+  const observable = new Observable((subscriber) => {
+    subscriptions++
+    subject.subscribe(subscriber)
+    return () => {
+      subscriptions--
+    }
+  })
+  const observableAtom = atomWithObservable(() => observable, { timeout: 500 })
+
+  const Counter = () => {
+    const [state] = useAtom(observableAtom)
+
+    return <>count: {state}</>
+  }
+
+  const { findByText, rerender } = render(
+    <Provider>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+    </Provider>
+  )
+
+  await findByText('loading')
+  expect(subscriptions).toEqual(1)
+
+  rerender(<div />)
+  await waitFor(() => expect(subscriptions).toEqual(0))
 })
 
 it('resubscribe on remount', async () => {
@@ -136,20 +341,8 @@ it("count state with initialValue doesn't suspend", async () => {
 })
 
 it('writable count state with initialValue', async () => {
-  const observableAtom = atomWithObservable(
-    () => {
-      const observable = new Observable<number>((subscriber) => {
-        subscriber.next(1)
-      })
-      const subject = new Subject<number>()
-      // is this usual to delay the subscription?
-      setTimeout(() => {
-        observable.subscribe(subject)
-      }, 100)
-      return subject
-    },
-    { initialValue: 5 }
-  )
+  const subject = new Subject<number>()
+  const observableAtom = atomWithObservable(() => subject, { initialValue: 5 })
 
   const Counter = () => {
     const [state, dispatch] = useAtom(observableAtom)
@@ -171,21 +364,46 @@ it('writable count state with initialValue', async () => {
   )
 
   await findByText('count: 5')
-
+  act(() => subject.next(1))
   await findByText('count: 1')
 
   fireEvent.click(getByText('button'))
   await findByText('count: 9')
 })
 
-it('with initial value and synchronous subscription', async () => {
-  const observableAtom = atomWithObservable(
-    () =>
-      new Observable<number>((subscriber) => {
-        subscriber.next(1)
-      }),
-    { initialValue: 5 }
+it('writable count state with error', async () => {
+  const subject = new Subject<number>()
+  const observableAtom = atomWithObservable(() => subject)
+
+  const Counter = () => {
+    const [state, dispatch] = useAtom(observableAtom)
+
+    return (
+      <>
+        count: {state}
+        <button onClick={() => dispatch(9)}>button</button>
+      </>
+    )
+  }
+
+  const { findByText } = render(
+    <Provider>
+      <ErrorBoundary>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </ErrorBoundary>
+    </Provider>
   )
+
+  await findByText('loading')
+
+  act(() => subject.error(new Error('Test Error')))
+  findByText('Error: Test Error')
+})
+
+it('synchronous subscription with initial value', async () => {
+  const observableAtom = atomWithObservable(() => of(1), { initialValue: 5 })
 
   const Counter = () => {
     const [state] = useAtom(observableAtom)
@@ -202,14 +420,70 @@ it('with initial value and synchronous subscription', async () => {
   await findByText('count: 1')
 })
 
-it('behaviour subject', async () => {
-  const subject$ = new BehaviorSubject(1)
-  const observableAtom = atomWithObservable(() => subject$)
+it('synchronous subscription with BehaviorSubject', async () => {
+  const observableAtom = atomWithObservable(() => new BehaviorSubject(1))
 
   const Counter = () => {
     const [state] = useAtom(observableAtom)
 
     return <>count: {state}</>
+  }
+
+  const { findByText } = render(
+    <Provider>
+      <Counter />
+    </Provider>
+  )
+
+  await findByText('count: 1')
+})
+
+it('synchronous subscription with already emitted value', async () => {
+  const observableAtom = atomWithObservable(() => of(1))
+
+  const Counter = () => {
+    const [state] = useAtom(observableAtom)
+
+    return <>count: {state}</>
+  }
+
+  const { findByText } = render(
+    <Provider>
+      <Counter />
+    </Provider>
+  )
+
+  await findByText('count: 1')
+})
+
+it('with falsy initial value', async () => {
+  const observableAtom = atomWithObservable(() => new Subject<number>(), {
+    initialValue: 0,
+  })
+
+  const Counter = () => {
+    const [state] = useAtom(observableAtom)
+
+    return <>count: {state}</>
+  }
+
+  const { findByText } = render(
+    <Provider>
+      <Counter />
+    </Provider>
+  )
+
+  await findByText('count: 0')
+})
+
+it('with initially emitted undefined value', async () => {
+  const subject = new Subject<number | undefined | null>()
+  const observableAtom = atomWithObservable(() => subject)
+
+  const Counter = () => {
+    const [state] = useAtom(observableAtom)
+
+    return <>count: {state === undefined ? '-' : state}</>
   }
 
   const { findByText } = render(
@@ -220,5 +494,46 @@ it('behaviour subject', async () => {
     </Provider>
   )
 
+  await findByText('loading')
+  act(() => subject.next(undefined))
+  await findByText('count: -')
+  act(() => subject.next(1))
   await findByText('count: 1')
+})
+
+it("don't omit values emitted between init and mount", async () => {
+  const subject = new Subject<number>()
+  const observableAtom = atomWithObservable(() => subject)
+
+  const Counter = () => {
+    const [state, dispatch] = useAtom(observableAtom)
+
+    return (
+      <>
+        count: {state}
+        <button
+          onClick={() => {
+            dispatch(9)
+          }}>
+          button
+        </button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+    </Provider>
+  )
+
+  await findByText('loading')
+  act(() => subject.next(1))
+  act(() => subject.next(2))
+  await findByText('count: 2')
+
+  fireEvent.click(getByText('button'))
+  await findByText('count: 9')
 })

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -200,7 +200,6 @@ it('only subscribe once per atom', async () => {
       </Suspense>
     </Provider>
   )
-  await findByText('loading')
   act(() => subject.next(2))
   await findByText('count: 2')
 


### PR DESCRIPTION
@dai-shi As discussed this PR builds on https://github.com/pmndrs/jotai/pull/1157

- I added more tests for some of the edge cases
- I fixed some known and unknown issues that are covered by the new tests

This is the test result with the __current__ implementation:
![image](https://user-images.githubusercontent.com/9933601/168898427-04c6142f-4c64-44af-b1cb-2673e6bb7937.png)

This is the test result __new__ implementation:
![image](https://user-images.githubusercontent.com/9933601/168898782-e7bc7cdc-6adf-4262-a9d5-d0b8a5380dbd.png)

Fixed issues:
- Emitted values between the initialValue and onMount are no longer ignored
- Falsy initial values are no longer ignored (`0`, `false`, `''`, etc.)
- If the observable is an `BehaviourSubject` or already has a value, `Suspense` is no longer required.
- If the observable never emits and no initial value is provided, the subscription is cancelled after 10 seconds.  This value can be configured with the `timeout` option
    - I implemented this solution, based on your recommendation in https://github.com/pmndrs/jotai/pull/1058#discussion_r825990484. Unfortunately I also didn't find a better solution.
    - I choose a timeout of ten seconds as a default, instead of one second, because it is not uncommon for requests, to take more than one second.
    - We might want to log a warning during development if the `timeout` gets applied. This way the user knows that something went wrong and can fix the issue (What are your thoughts on that?)
    - __This is actually a breaking change.__ Because it will break observables that take more than ten seconds to emit their first value without manually setting or disabling the timeout. If this is not okay for you, we can remove the default for now and add it separately in the next major release.

I'm looking forward to your thoughts and feedback!