### PR TITLE
feat(devtools): expose useAtomsDebugValue from jotai/devtools

### DIFF
--- a/docs/api/devtools.mdx
+++ b/docs/api/devtools.mdx
@@ -4,6 +4,56 @@ description: This doc describes `jotai/devtool` bundle.
 nav: 2.03
 ---
 
+## useAtomsDebugValue
+
+`useAtomsDebugValue` is a React hook that will show all atom values in React Devtools.
+
+```ts
+function useAtomsDebugValue(options?: {
+  scope?: Scope
+  enabled?: boolean
+}): void
+```
+
+Internally, it uses `useDebugValue` which is only effective in DEV mode.
+It will catch all atoms that are accessible from the place the hook is located.
+
+### Example
+
+```jsx
+import { useAtomsDebugValue } from 'jotai/devtools'
+
+const textAtom = atom('hello')
+textAtom.debugLabel = 'textAtom'
+
+const lenAtom = atom((get) => get(textAtom).length)
+lenAtom.debugLabel = 'lenAtom'
+
+const TextBox = () => {
+  const [text, setText] = useAtom(textAtom)
+  const [len] = useAtom(lenAtom)
+  return (
+    <span>
+      <input value={text} onChange={(e) => setText(e.target.value)} />({len})
+    </span>
+  )
+}
+
+const DebugAtoms = () => {
+  useAtomsDebugValue()
+  return null
+}
+
+const App = () => (
+  <Provider>
+    <DebugAtoms />
+    <TextBox />
+  </Provider>
+)
+```
+
+<CodeSandbox id="vvp12f" />
+
 ## useAtomDevtools
 
 `useAtomDevtools` is a React hook that manages ReduxDevTools integration for a particular atom.
@@ -11,7 +61,11 @@ nav: 2.03
 ```ts
 function useAtomDevtools<Value>(
   anAtom: WritableAtom<Value, Value>,
-  name?: string
+  options?: {
+    name?: string
+    scope?: Scope
+    enabled?: boolean
+  }
 ): void
 ```
 
@@ -20,7 +74,7 @@ The `useAtomDevtools` hook accepts a generic type parameter (mirroring the type 
 
 ### Example
 
-```typescript
+```ts
 import { useAtomDevtools } from 'jotai/devtools'
 
 // The interface for the type stored in the atom.
@@ -55,7 +109,13 @@ export const useTasksDevtools = () => {
 `useAtomsDevtools` is a catch-all version of `useAtomDevtools` where it shows all atoms in the store instead of showing a specific one.
 
 ```ts
-function useAtomsDevtools(name: string, scope?: Scope): void
+function useAtomsDevtools(
+  name: string,
+  options?: {
+    scope?: Scope
+    enabled?: boolean
+  }
+): void
 ```
 
 It takes a `name` parameter that is needed for naming the Redux devtools instance and a `scope` parameter if the hook is used for a specific scope of atoms.
@@ -65,7 +125,7 @@ As a limitation for this API, we need to put `useAtomsDevtools` in a component w
 
 ### Example
 
-```ts
+```tsx
 const countAtom = atom(0);
 const doubleCountAtom = atom((get) => get(countAtom) * 2);
 
@@ -109,7 +169,7 @@ Be careful using this hook because it will cause the component to re-render for 
 
 ### Example
 
-```ts
+```tsx
 import { Provider } from 'jotai'
 import { useAtomsSnapshot } from 'jotai/devtools'
 
@@ -152,7 +212,7 @@ This hook is primarily meant for debugging and devtools use cases.
 
 ### Example
 
-```ts
+```tsx
 import { Provider } from 'jotai'
 import { useAtomsSnapshot, useGotoAtomsSnapshot } from 'jotai/devtools'
 

--- a/docs/basics/primitives.mdx
+++ b/docs/basics/primitives.mdx
@@ -97,7 +97,7 @@ The behavior depends on how the write function is implemented.
 
 **Note:** as mentioned in the _atom_ section, you have to take care of handling the reference of your atom, otherwise it may enter an infinite loop
 
-```typescript
+```ts
 const stableAtom = atom(0)
 const Component = () => {
   const [atomValue] = useAtom(atom(0)) // Will cause an infinite loop
@@ -121,8 +121,8 @@ it will use the default state. This is so-called provider-less mode.
 Providers are useful for three reasons:
 
 1. To provide a different state for each sub tree.
-2. To contain some debug information.
-3. To accept initial values of atoms.
+2. To accept initial values of atoms.
+3. To clear all atoms by remounting.
 
 ```jsx
 const SubTree = () => (

--- a/docs/guides/debugging.mdx
+++ b/docs/guides/debugging.mdx
@@ -27,17 +27,32 @@ if (process.env.NODE_ENV !== 'production') {
 You can use [React Dev Tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi)
 to inspect Jotai state. To achieve that [useDebugValue](https://reactjs.org/docs/hooks-reference.html#usedebugvalue)
 is used inside custom hooks. Keep in mind that it only works in dev mode
-(`NODE_ENV === 'development'`).
-
-> Provider-less mode does not work with React Dev Tools, So we need to wrap our app with the Jotai `Provider`
-
-### Provider
-
-If you navigate to Jotai `Provider` component in the React Dev Tools, we can see a custom hook "DebugState" which allows you to see all atom states, that is a map of atom config and atom values & dependents.
+(such as `NODE_ENV === 'development'`).
 
 ### useAtom
 
 `useAtom` calls `useDebugValue` for atom values, so if you select the component that consumes jotai atoms in React Dev Tools, you would see "Atom" hooks for each atom that is used in the component along with the value it has right now.
+
+### useAtomsDebugValue
+
+`useAtomsDebugValue` catches all atoms in a component tree under Provider (or an entire tree for Provider-less mode), and `useDebugValue` for all atoms values.
+If you navigate to the component that has `useAtomsDebugValue` in the React Dev Tools, we can see a custom hook "AtomsDebugValue" which allows you to see all atom values and their dependents.
+
+One use case is to put the hook just under the `Provider` component:
+
+```jsx
+const DebugAtoms = () => {
+  useAtomsDebugValue()
+  return null
+}
+
+const Root = () => (
+  <Provider>
+    <DebugAtoms />
+    <App />
+  </Provider>
+)
+```
 
 ## Using Redux DevTools
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -5,7 +5,6 @@ import { createScopeContainer, getScopeContext } from './contexts'
 import type { ScopeContainer } from './contexts'
 import { COMMIT_ATOM, createStoreForExport } from './store'
 import type { VersionObject } from './store'
-import { useDebugState } from './useDebugState'
 
 export const Provider = ({
   children,
@@ -56,12 +55,6 @@ export const Provider = ({
         })
       }
     }
-  }
-
-  // LIMITATION: useDebugState prevents to work versioned write properly
-  if (__DEV__ && !unstable_enableVersionedWrite) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useDebugState(scopeContainerRef.current)
   }
 
   const ScopeContainerContext = getScopeContext(scope)

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,4 +1,4 @@
-export { useDebugState } from './devtools/useDebugState'
+export { useAtomsDebugValue } from './devtools/useAtomsDebugValue'
 export { useAtomDevtools } from './devtools/useAtomDevtools'
 export { useAtomsSnapshot } from './devtools/useAtomsSnapshot'
 export { useGotoAtomsSnapshot } from './devtools/useGotoAtomsSnapshot'

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,3 +1,4 @@
+export { useDebugState } from './devtools/useDebugState'
 export { useAtomDevtools } from './devtools/useAtomDevtools'
 export { useAtomsSnapshot } from './devtools/useAtomsSnapshot'
 export { useGotoAtomsSnapshot } from './devtools/useGotoAtomsSnapshot'

--- a/src/devtools/useAtomsDebugValue.ts
+++ b/src/devtools/useAtomsDebugValue.ts
@@ -42,7 +42,7 @@ type Options = {
 
 // We keep a reference to the atoms,
 // so atoms aren't garbage collected by the WeakMap of mounted atoms
-export const useDebugState = (options?: Options) => {
+export const useAtomsDebugValue = (options?: Options) => {
   const enabled = options?.enabled ?? __DEV__
   const ScopeContext = getScopeContext(options?.scope)
   const { s: store } = useContext(ScopeContext)

--- a/src/devtools/useDebugState.ts
+++ b/src/devtools/useDebugState.ts
@@ -1,13 +1,13 @@
-import { useDebugValue, useEffect, useState } from 'react'
-import type { Atom } from './atom'
-import type { ScopeContainer } from './contexts'
+import { useContext, useDebugValue, useEffect, useState } from 'react'
+import { SECRET_INTERNAL_getScopeContext as getScopeContext } from 'jotai'
+import type { Atom, Scope } from '../core/atom'
 import {
   DEV_GET_ATOM_STATE,
   DEV_GET_MOUNTED,
   DEV_GET_MOUNTED_ATOMS,
   DEV_SUBSCRIBE_STATE,
-} from './store'
-import type { AtomState, Store } from './store'
+} from '../core/store'
+import type { AtomState, Store } from '../core/store'
 
 const atomToPrintable = (atom: Atom<unknown>) =>
   atom.debugLabel || atom.toString()
@@ -35,18 +35,28 @@ const stateToPrintable = ([store, atoms]: [Store, Atom<unknown>[]]) =>
     })
   )
 
-// We keep a reference to the atoms in Provider's registeredAtoms in dev mode,
+type Options = {
+  scope?: Scope
+  enabled?: boolean
+}
+
+// We keep a reference to the atoms,
 // so atoms aren't garbage collected by the WeakMap of mounted atoms
-export const useDebugState = (scopeContainer: ScopeContainer) => {
-  const { s: store } = scopeContainer
+export const useDebugState = (options?: Options) => {
+  const enabled = options?.enabled ?? __DEV__
+  const ScopeContext = getScopeContext(options?.scope)
+  const { s: store } = useContext(ScopeContext)
   const [atoms, setAtoms] = useState<Atom<unknown>[]>([])
   useEffect(() => {
+    if (!enabled) {
+      return
+    }
     const callback = () => {
       setAtoms(Array.from(store[DEV_GET_MOUNTED_ATOMS]?.() || []))
     }
     const unsubscribe = store[DEV_SUBSCRIBE_STATE]?.(callback)
     callback()
     return unsubscribe
-  }, [store])
+  }, [enabled, store])
   useDebugValue([store, atoms], stateToPrintable)
 }

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -6,8 +6,6 @@ import { getTestProvider, itSkipIfVersionedWrite } from './testUtils'
 
 const Provider = getTestProvider()
 
-jest.mock('../src/core/useDebugState.ts')
-
 const useCommitCount = () => {
   const commitCountRef = useRef(1)
   useEffect(() => {

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -14,8 +14,6 @@ import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()
 
-jest.mock('../src/core/useDebugState.ts')
-
 // FIXME this is a hacky workaround temporarily
 const IS_REACT18 = !!(ReactDOM as any).createRoot
 

--- a/tests/dependency.test.tsx
+++ b/tests/dependency.test.tsx
@@ -5,8 +5,6 @@ import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()
 
-jest.mock('../src/core/useDebugState.ts')
-
 const useCommitCount = () => {
   const commitCountRef = useRef(1)
   useEffect(() => {

--- a/tests/transition.test.tsx
+++ b/tests/transition.test.tsx
@@ -5,8 +5,6 @@ import { getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()
 
-jest.mock('../src/core/useDebugState.ts')
-
 const describeWithUseTransition =
   typeof useTransition === 'function' ? describe : describe.skip
 

--- a/tests/utils/atomFamily.test.tsx
+++ b/tests/utils/atomFamily.test.tsx
@@ -8,8 +8,6 @@ import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
 
-jest.mock('../../src/core/useDebugState.ts')
-
 // FIXME this is a hacky workaround temporarily
 const IS_REACT18 = !!(ReactDOM as any).createRoot
 

--- a/tests/utils/waitForAll.test.tsx
+++ b/tests/utils/waitForAll.test.tsx
@@ -7,8 +7,6 @@ import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
 
-jest.mock('../../src/core/useDebugState.ts')
-
 const consoleWarn = console.warn
 const consoleError = console.error
 beforeEach(() => {


### PR DESCRIPTION
close #1180 

- [x] impl
- [x] get feedback on the hook name
- [x] docs
- [x] examples

We plan to release this in a minor version update, even though this is technically breaking change in Provider's behavior in DEV-only environments.

---

## Migration Guide

Previously, if you use `<Provider>`, `useDebugValue` is automatically used in the dev mode and you can never disable it.

```jsx
import { Provider } from 'jotai'

const Root = () => (
  <Provider>
    <App />
  </Provider>
}
```

Now, to get the same behavior, you need to use the `useAtomsDebugValue` explicitly.

```jsx
import { Provider } from 'jotai'
import { useAtomsDebugValue } from 'jotai/devtools'

const DebugAtoms = () => {
  useAtomsDebugValue()
  return null
}

const Root = () => (
  <Provider>
    <DebugAtoms />
    <App />
  </Provider>
}
```