### PR TITLE
refactor(tests): better handling with React 18 behavioral difference

### DIFF
--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -7,7 +7,7 @@ import {
   useState,
 } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import ReactDOM from 'react-dom'
+import ReactDOM, { unstable_batchedUpdates } from 'react-dom'
 import { atom, useAtom } from 'jotai'
 import type { WritableAtom } from 'jotai'
 import { getTestProvider } from './testUtils'
@@ -18,6 +18,14 @@ jest.mock('../src/core/useDebugState.ts')
 
 // FIXME this is a hacky workaround temporarily
 const IS_REACT18 = !!(ReactDOM as any).createRoot
+
+const batchedUpdates = (fn: () => void) => {
+  if (IS_REACT18) {
+    fn()
+  } else {
+    unstable_batchedUpdates(fn)
+  }
+}
 
 const useCommitCount = () => {
   const commitCountRef = useRef(1)
@@ -390,7 +398,9 @@ it('uses atoms with tree dependencies', async () => {
     (get) => get(topAtom),
     async (get, set, update: (prev: number) => number) => {
       await new Promise((r) => setTimeout(r, 100))
-      set(topAtom, update(get(topAtom)))
+      batchedUpdates(() => {
+        set(topAtom, update(get(topAtom)))
+      })
     }
   )
 
@@ -416,18 +426,10 @@ it('uses atoms with tree dependencies', async () => {
   await findByText('commits: 1, count: 0')
 
   fireEvent.click(getByText('button'))
-  if (IS_REACT18) {
-    await findByText('commits: 2, count: 1')
-  } else {
-    await findByText('commits: 3, count: 1')
-  }
+  await findByText('commits: 2, count: 1')
 
   fireEvent.click(getByText('button'))
-  if (IS_REACT18) {
-    await findByText('commits: 3, count: 2')
-  } else {
-    await findByText('commits: 5, count: 2')
-  }
+  await findByText('commits: 3, count: 2')
 })
 
 it('runs update only once in StrictMode', async () => {

--- a/tests/utils/atomFamily.test.tsx
+++ b/tests/utils/atomFamily.test.tsx
@@ -1,6 +1,5 @@
-import { StrictMode, Suspense, useEffect, useRef, useState } from 'react'
+import { StrictMode, Suspense, useEffect, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import ReactDOM from 'react-dom'
 import { atom, useAtom, useSetAtom } from 'jotai'
 import type { SetStateAction, WritableAtom } from 'jotai'
 import { atomFamily } from 'jotai/utils'
@@ -9,17 +8,6 @@ import { getTestProvider } from '../testUtils'
 const Provider = getTestProvider()
 
 jest.mock('../../src/core/useDebugState.ts')
-
-// FIXME this is a hacky workaround temporarily
-const IS_REACT18 = !!(ReactDOM as any).createRoot
-
-const useCommitCount = () => {
-  const commitCountRef = useRef(1)
-  useEffect(() => {
-    commitCountRef.current += 1
-  })
-  return commitCountRef.current
-}
 
 it('new atomFamily impl', async () => {
   const myFamily = atomFamily((param: string) => atom(param))
@@ -240,14 +228,17 @@ it('a derived atom from an async atomFamily (#351)', async () => {
   )
   const derivedAtom = atom((get) => get(getAsyncAtom(get(countAtom))))
 
+  let commitCount = 0
+
   const Counter = () => {
     const setCount = useSetAtom(countAtom)
     const [derived] = useAtom(derivedAtom)
+    useEffect(() => {
+      ++commitCount
+    })
     return (
       <>
-        <div>
-          derived: {derived}, commits: {useCommitCount()}
-        </div>
+        <div>derived: {derived}</div>
         <button onClick={() => setCount((c) => c + 1)}>button</button>
       </>
     )
@@ -264,21 +255,16 @@ it('a derived atom from an async atomFamily (#351)', async () => {
   )
 
   await findByText('loading')
-  await findByText('derived: 11, commits: 1')
+  await findByText('derived: 11')
+  const commitCountAfterMount = commitCount
 
   fireEvent.click(getByText('button'))
   await findByText('loading')
-  if (IS_REACT18) {
-    await findByText('derived: 12, commits: 3')
-  } else {
-    await findByText('derived: 12, commits: 2')
-  }
+  await findByText('derived: 12')
+  expect(commitCount).toBe(commitCountAfterMount + 1)
 
   fireEvent.click(getByText('button'))
   await findByText('loading')
-  if (IS_REACT18) {
-    await findByText('derived: 13, commits: 4')
-  } else {
-    await findByText('derived: 13, commits: 3')
-  }
+  await findByText('derived: 13')
+  expect(commitCount).toBe(commitCountAfterMount + 2)
 })


### PR DESCRIPTION
I can't completely remove `IS_REACT18`, unfortunately. Hope to improve it in the future.