### PR TITLE
docs(fast refresh): introduce dx issue

### DIFF
--- a/docs/guides/fast-refresh.mdx
+++ b/docs/guides/fast-refresh.mdx
@@ -5,11 +5,11 @@ nav: 3.12
 ---
 
 In order to deliver the best Developer Experience (DX), we're working on being compatible with Fast Refresh from the ground up.
+Currently, by default, editing a file will result in resetting the state of all the declared atoms inside it.
 
-### Developer experience issue
+### Splitting workaround
 
-Currently, editing a file will result in resetting the state of all the declared atoms inside it.
-In order to best avoid resetting, you can split your atoms in seperate files. This way, the state is reset according to more granular file updates.
+In order to best avoid resetting, you could split your atoms in seperate files. This way, the state is reset according to more granular file updates.
 
 ```ts
 // file: atoms/atom1.ts
@@ -30,9 +30,9 @@ import { atom2 } from './atoms/atom2'
 // Other files can be refreshed and don't reset the state
 ```
 
-However, please note that in some edge-cases, atoms will still reset even if you didn't edit the file containing its declaration, and it will be hard to predict and understand why. If you're in doubt, reload
+However, please note that in some edge-cases, atoms will still reset even if you didn't edit the file containing its declaration, and it will be hard to predict and understand why. If you're in doubt, reload.
 
-### Our solution
+### Drop-in solution
 
 In order to prevent the reset of your atoms when you update a file, we setup a babel plugin that fixes the issue.
 Just plug it in your babel configuration file and restart your hot-reload server. See [Babel documentation](../api/babel.mdx) for more info.


### PR DESCRIPTION
Following-up to [issue #1025](https://github.com/pmndrs/jotai/issues/1025)

Quick reminder: goal is to have some kind of "official statement" of the status with Fast Refresh:

- current workaround: as long as you don't modify a file that contains the atom declaration, it will not reset the state
- our feeling: DX not the best, forcing to split atoms to avoid state reset, but we are aware/working on it
- can be very hard to understand why it got reset in some situations
- we're very much open to support/contribution on this
- (edit) can fix instantly with babel plugin!