### PR TITLE
docs(primitives): Educate idempotent components

### DIFF
--- a/docs/basics/primitives.mdx
+++ b/docs/basics/primitives.mdx
@@ -112,6 +112,8 @@ const Component = () => {
 }
 ```
 
+**Note**: Remember that a React is responsible for calling your component. This means that your component has to be idempotent, ready to be called multiple times. Sometimes the component will get an extra re-render even if no props/atoms have changed. An extra re-render without a commit is an expected behavior. It is actually the default behavior of useReducer in React 18.
+
 ## Provider
 
 Provider is to provide state for a component sub tree.

--- a/docs/basics/primitives.mdx
+++ b/docs/basics/primitives.mdx
@@ -112,7 +112,7 @@ const Component = () => {
 }
 ```
 
-**Note**: Remember that a React is responsible for calling your component. This means that your component has to be idempotent, ready to be called multiple times. Sometimes the component will get an extra re-render even if no props/atoms have changed. An extra re-render without a commit is an expected behavior. It is actually the default behavior of useReducer in React 18.
+**Note**: Remember that React is responsible for calling your component. Meaning it has to be idempotent, ready to be called multiple times. You will often see an extra re-render even if no props or atoms have changed. An extra re-render without a commit is an expected behavior. It is actually the default behavior of useReducer in React 18.
 
 ## Provider
 


### PR DESCRIPTION
Following-up [this issue](https://github.com/pmndrs/jotai/issues/1175) to clarify in the docs that extra-rerenders even if atoms value didn't change is an expected behaviour