### PR TITLE
docs(nextjs): educate provider

### DIFF
--- a/docs/guides/nextjs.mdx
+++ b/docs/guides/nextjs.mdx
@@ -44,6 +44,10 @@ const postData = atom((get) => {
 })
 ```
 
+## Provider
+
+Because of the nature of SSR, your app can have more instances existing in JS memory in the same time. You need to wrap your app inside a `Provider` (view more details [in the Core section](../api/core.mdx)) so that each instance has its own state and will not interfere with previous values from a common Provider (provider-less mode).
+
 ## Examples
 
 ### Clock

--- a/docs/guides/nextjs.mdx
+++ b/docs/guides/nextjs.mdx
@@ -46,7 +46,7 @@ const postData = atom((get) => {
 
 ## Provider
 
-Because of the nature of SSR, your app can have more instances existing in JS memory in the same time. You need to wrap your app inside a `Provider` (view more details [in the Core section](../api/core.mdx)) so that each instance has its own state and will not interfere with previous values from a common Provider (provider-less mode).
+Because of the nature of SSR, your app can have more instances existing in JS memory in the same time. You need to wrap your app inside a `Provider` (view more details [in the Core section](../api/core.mdx)) so that each instance has its own state and will not interfere with previous values from a default store (provider-less mode).
 
 ## Examples
 


### PR DESCRIPTION
Follow-up of [this issue](https://github.com/pmndrs/jotai/issues/1190), where it was unclear that NextJS should use `Provider` while we see no use-case without it.

@dai-shi Please review carefully, I'm not sure what I'm talking about too well