### PR TITLE
docs(markdowns): clean-up

### DIFF
--- a/docs/advanced-recipes/atom-creators.mdx
+++ b/docs/advanced-recipes/atom-creators.mdx
@@ -30,7 +30,7 @@ The setter function can have an optional argument to force a particular state, s
 
 Here is how it's used.
 
-```ts
+```js
 import { atomWithToggle } from 'XXX'
 
 // will have an initial value set to true
@@ -39,7 +39,7 @@ const isActiveAtom = atomWithToggle(true)
 
 And in a component:
 
-```tsx
+```jsx
 const Toggle = () => {
   const [isActive, toggle] = useAtom(isActiveAtom)
 
@@ -85,7 +85,7 @@ export function atomWithToggleAndStorage(
 
 And how it's used:
 
-```ts
+```js
 import { atomWithToggleAndStorage } from 'XXX'
 
 // will have an initial value set to false & get stored in localStorage under the key "isActive"
@@ -134,7 +134,7 @@ const styleAtom = atomWithCompare<CSSProperties>(
 
 In a component:
 
-```ts
+```jsx
 const StylePreview = () => {
   const [styles, setStyles] = useAtom(styleAtom)
 
@@ -184,7 +184,7 @@ export function atomWithRefresh<T>(fn: (get: Getter) => T) {
 
 Here's how you'd use it to implement an refresh-able source of data:
 
-```ts
+```js
 import { atomWithRefresh } from 'XXX'
 
 const postsAtom = atomWithRefresh((get) =>
@@ -194,14 +194,14 @@ const postsAtom = atomWithRefresh((get) =>
 
 In a component:
 
-```ts
+```jsx
 const PostsList = () => {
   const [posts, refreshPosts] = useAtom(postsAtom)
 
   return (
     <div>
       <ul>
-        {posts.map((post: any) => (
+        {posts.map((post) => (
           <li key={post.id}>{post.title}</li>
         ))}
       </ul>
@@ -269,7 +269,7 @@ export function atomWithListeners<Value>(initialValue: Value) {
 
 In a component:
 
-```ts
+```jsx
 const [countAtom, useCountListener] = atomWithListeners(0)
 
 function EvenCounter() {

--- a/docs/advanced-recipes/custom-useatom-hooks.mdx
+++ b/docs/advanced-recipes/custom-useatom-hooks.mdx
@@ -9,7 +9,7 @@ This page shows the ways of creating different utility functions. Utility functi
 
 ### useSelectAtom
 
-```ts
+```js
 import { useAtomValue } from 'jotai'
 import { selectAtom } from 'jotai/utils'
 
@@ -29,7 +29,7 @@ Please note that in this case `keyFn` must be stable, either define outside rend
 
 ### useFreezeAtom
 
-```ts
+```js
 import { useAtom } from 'jotai'
 import { freezeAtom } from 'jotai/utils'
 
@@ -40,7 +40,7 @@ export function useFreezeAtom(anAtom) {
 
 ### useSplitAtom
 
-```ts
+```js
 import { useAtom } from 'jotai'
 import { splitAtom } from 'jotai/utils'
 
@@ -53,7 +53,7 @@ export function useSplitAtom(anAtom) {
 
 ### useFocusAtom
 
-```ts
+```js
 import { useAtom } from 'jotai'
 import { focusAtom } from 'jotai/optics'
 

--- a/docs/advanced-recipes/large-objects.mdx
+++ b/docs/advanced-recipes/large-objects.mdx
@@ -9,7 +9,7 @@ Sometimes we have nested data we need to store in atoms, and we may need to chan
 
 Consider this example:
 
-```jsx
+```js
 const initialData = {
   people: [
     {
@@ -45,7 +45,7 @@ const initialData = {
 
 We use this utility to focus an atom and create an atom from a specific part of the data. For example we may need to consume the people property of the above data, Here's how we do it:
 
-```jsx
+```js
 import { atom } from 'jotai'
 import { focusAtom } from 'jotai/optics'
 
@@ -64,7 +64,7 @@ If we change the `film` property of the above data example, the `peopleAtom` won
 
 We use this utility for atoms that return arrays as their values. For example, the `peopleAtom` we made above returns the people property array, so we can return an atom for each item of that array. If the array atom is writable, `splitAtom` returned atoms are going to be writable, if the array atom is read-only, the returned atoms will be read-only too.
 
-```jsx
+```js
 import { splitAtom } from 'jotai/utils'
 
 const peopleAtomsAtom = splitAtom(peopleAtom)
@@ -93,7 +93,7 @@ This utility is like `focusAtom`, but we use it when we have a read-only atom to
 
 Assume we want to consume the info data, and its data is always unchangeable. We can make a read-only atom from it and select that created atom.
 
-```jsx
+```js
 // first we create a read-only atom based on initialData.info
 const readOnlyInfoAtom = atom((get) => get(dataAtom).info)
 ```
@@ -104,7 +104,7 @@ Then we use it in our component:
 import { atom, useAtom } from 'jotai'
 import { selectAtom, splitAtom } from 'jotai/utils'
 
-const Tags: React.FC = () => {
+const Tags = () => {
   const tagsAtom = selectAtom(readOnlyInfoAtom, (s) => s.tags)
   const tagsAtomsAtom = splitAtom(tagsAtom)
   const [tagAtoms] = useAtom(tagsAtomsAtom)

--- a/docs/api/babel.mdx
+++ b/docs/api/babel.mdx
@@ -14,27 +14,27 @@ This `babel` plugin adds a `debugLabel` to every atom, based on its identifer.
 
 The plugin transforms this code:
 
-```ts
+```js
 export const countAtom = atom(0)
 ```
 
 Into:
 
-```ts
+```js
 export const countAtom = atom(0)
 countAtom.debugLabel = 'countAtom'
 ```
 
 Default exports are also handled, based on the file naming:
 
-```ts
+```js
 // countAtom.ts
 export default atom(0)
 ```
 
 Which transform into:
 
-```ts
+```js
 // countAtom.ts
 const countAtom = atom(0)
 countAtom.debugLabel = 'countAtom'

--- a/docs/api/core.mdx
+++ b/docs/api/core.mdx
@@ -13,7 +13,7 @@ nav: 2.01
 
 Use `atom` to create an atom config. An atom config is an immutable object. The atom config doesn't hold an atom value. The atom value is stored in a Provider state.
 
-```tsx
+```ts
 // primitive atom
 function atom<Value>(initialValue: Value): PrimitiveAtom<Value>
 
@@ -37,7 +37,7 @@ function atom<Value, Update>(
 - `read`: a function that's called on every re-render. The signature of `read` is `(get) => Value | Promise<Value>`, and `get` is a function that takes an atom config and returns its value stored in Provider as described below. Dependency is tracked, so if `get` is used for an atom at least once, the `read` will be reevaluated whenever the atom value is changed.
 - `write`: a function mostly used for mutating atom's values, for a better description; it gets called whenever we call the second value of the returned pair of `useAtom`, the `useAtom()[1]`. The default value of this function in the primitive atom will change the value of that atom. The signature of `write` is `(get, set, update) => void | Promise<void>`. `get` is similar to the one described above, but it doesn't track the dependency. `set` is a function that takes an atom config and a new value which then updates the atom value in Provider. `update` is an arbitrary value that we receive from the updating function returned by `useAtom` described below.
 
-```tsx
+```js
 const primitiveAtom = atom(initialValue)
 const derivedAtomWithRead = atom(read)
 const derivedAtomWithReadWrite = atom(read, write)
@@ -58,7 +58,7 @@ The created atom config can have an optional property `onMount`. `onMount` is a 
 
 The `onMount` function is called when the atom is first used in a provider, and `onUnmount` is called when it’s no longer used. In some edge cases, an atom can be unmounted and then mounted immediately.
 
-```tsx
+```js
 const anAtom = atom(1)
 anAtom.onMount = (setAtom) => {
   console.log('atom is mounted in provider')
@@ -69,7 +69,7 @@ anAtom.onMount = (setAtom) => {
 
 Calling `setAtom` function will invoke the atom’s `write`. Customizing `write` allows changing the behavior.
 
-```tsx
+```js
 const countAtom = atom(1)
 const derivedAtom = atom(
   (get) => get(countAtom),

--- a/docs/api/devtools.mdx
+++ b/docs/api/devtools.mdx
@@ -125,7 +125,7 @@ As a limitation for this API, we need to put `useAtomsDevtools` in a component w
 
 ### Example
 
-```tsx
+```jsx
 const countAtom = atom(0);
 const doubleCountAtom = atom((get) => get(countAtom) * 2);
 
@@ -136,7 +136,7 @@ function Counter() {
   ...
 }
 
-const AtomsDevtools = ({ children }: { children: ReactElement }) => {
+const AtomsDevtools = ({ children }) => {
   useAtomsDevtools('demo')
   return children
 }
@@ -169,7 +169,7 @@ Be careful using this hook because it will cause the component to re-render for 
 
 ### Example
 
-```tsx
+```jsx
 import { Provider } from 'jotai'
 import { useAtomsSnapshot } from 'jotai/devtools'
 
@@ -212,14 +212,14 @@ This hook is primarily meant for debugging and devtools use cases.
 
 ### Example
 
-```tsx
+```jsx
 import { Provider } from 'jotai'
 import { useAtomsSnapshot, useGotoAtomsSnapshot } from 'jotai/devtools'
 
 const petAtom = atom('cat')
 const colorAtom = atom('blue')
 
-const UpdateSnapshot: React.FC = () => {
+const UpdateSnapshot = () => {
   const snapshot = useAtomsSnapshot()
   const goToSnapshot = useGotoAtomsSnapshot()
   return (

--- a/docs/basics/primitives.mdx
+++ b/docs/basics/primitives.mdx
@@ -64,7 +64,7 @@ It will invoke the write function of the target atom.
 They can be created dynamically too.
 To create an atom in render function, `useMemo` or `useRef` is required to get a stable reference. If in doubt about using `useMemo` or `useRef` for memoization, use `useMemo`.
 
-```jsx
+```js
 const Component = ({ value }) => {
   const valueAtom = useMemo(() => atom({ value }), [value])
   // ...
@@ -97,7 +97,7 @@ The behavior depends on how the write function is implemented.
 
 **Note:** as mentioned in the _atom_ section, you have to take care of handling the reference of your atom, otherwise it may enter an infinite loop
 
-```ts
+```js
 const stableAtom = atom(0)
 const Component = () => {
   const [atomValue] = useAtom(atom(0)) // This will cause an infinite loop

--- a/docs/guides/async.mdx
+++ b/docs/guides/async.mdx
@@ -51,7 +51,7 @@ const anotherAtom = atom((get) => get(asyncAtom) / 2)
 
 ```js
 const asyncAtom = atom(async (get) => ...)
-const writeAtom = atom(null, (get, set, payload: any) => {
+const writeAtom = atom(null, (get, set, payload) => {
   get(asyncAtom) // This throws an error if "asyncAtom" is still in pending state
 })
 ```
@@ -78,7 +78,7 @@ const Root = () => {
 
 Async write atoms are another kind of async atom. When the `write` function of atom returns a promise.
 
-```jsx
+```js
 const countAtom = atom(1)
 const asyncIncrementAtom = atom(null, async (get, set) => {
   // await something
@@ -97,15 +97,13 @@ const Component = () => {
 
 An interesting pattern that can be achieved with Jotai are is switching from async to sync to trigger suspending when wanted.
 
-```jsx
+```js
 const request = async () => fetch('https://...').then((res) => res.json())
 const baseAtom = atom(0)
 const Component = () => {
   const [value, setValue] = useAtom(baseAtom)
   React.useEffect(() => {
-    setTimeout(() => {
-      setValue(request()) // Will suspend until request resolves
-    }, 2000)
+    setValue(request()) // Will suspend until request resolves
   }, [])
 }
 ```
@@ -114,7 +112,7 @@ const Component = () => {
 
 Sometimes you may want to suspend until an unpredetermined moment (or never).
 
-```jsx
+```js
 const baseAtom = atom(new Promise(() => {})) // Will be suspend until set otherwise
 ```
 

--- a/docs/guides/atoms-in-atom.mdx
+++ b/docs/guides/atoms-in-atom.mdx
@@ -71,7 +71,7 @@ const Component = () => {
 
 It's possible to create a derived atom.
 
-```jsx
+```js
 const derivedNameAtom = atom((get) => {
   const nameAtom = get(showingNameAtom)
   return get(nameAtom)
@@ -124,7 +124,7 @@ It is important to note that `anAtom.toString()` returns a unique id, which can 
 
 ### Hint for TypeScript users
 
-```tsx
+```jsx
 <Counter countAtom={countAtom} key={`${countAtom}`} />
 ```
 

--- a/docs/guides/debugging.mdx
+++ b/docs/guides/debugging.mdx
@@ -65,8 +65,8 @@ to inspect atoms, with many features like Time-travelling and value dispatching.
 
 If you have a specific atom in mind that you may want to debug, `useAtomDevtools` can be a good option.
 
-```ts
-const  countAtom = atom(0)
+```js
+const countAtom = atom(0)
 // setting countAtom.debugLabel is recommended if we have more atoms
 
 function Counter() {

--- a/docs/guides/persistence.mdx
+++ b/docs/guides/persistence.mdx
@@ -108,7 +108,7 @@ const Preloader = () => {
 }
 ```
 
-```js
+```jsx
 const Root = () => {
   return (
     <Suspense fallback={<Text>Hydrating...<Text>}>
@@ -126,7 +126,7 @@ const Root = () => {
 const storage = { ...createJSONStorage(() => AsyncStorage), delayInit: true }
 const userId = atomWithStorage('user-id-key', null, storage)
 const userInfo = atom({})
-const fetchUserInfo = atom(null, async (get, set, payload: any) => {
+const fetchUserInfo = atom(null, async (get, set, payload) => {
   let id = get(userId)
   if (id === null) {
     // We make sure to preload if no value has yet been loaded

--- a/docs/guides/persistence.mdx
+++ b/docs/guides/persistence.mdx
@@ -164,7 +164,7 @@ const serializeAtom = atom<
   }
 })
 
-const Persist: React.FC = () => {
+const Persist = () => {
   const [, dispatch] = useAtom(serializeAtom)
   const save = () => {
     dispatch({
@@ -225,7 +225,7 @@ const serializeAtom = atom<
   }
 })
 
-const Persist: React.FC = () => {
+const Persist = () => {
   const [, dispatch] = useAtom(serializeAtom)
   const save = () => {
     dispatch({

--- a/docs/guides/resettable.mdx
+++ b/docs/guides/resettable.mdx
@@ -64,7 +64,7 @@ const centsAtom = atom(
     set(dollarsAtom, newValue === RESET ? newValue : newValue / 100)
 )
 
-const ResetExample: React.FC = () => {
+const ResetExample = () => {
   const [dollars] = useAtom(dollarsAtom)
   const setCents = useUpdateAtom(centsAtom)
   const resetCents = useResetAtom(centsAtom)

--- a/docs/guides/testing.mdx
+++ b/docs/guides/testing.mdx
@@ -15,7 +15,7 @@ Here's an example using [React testing library](https://github.com/testing-libra
 
 `Counter.tsx`:
 
-```tsx
+```jsx
 import { atom, useAtom } from 'jotai'
 
 const countAtom = atom(0)
@@ -31,9 +31,9 @@ export function Counter() {
 }
 ```
 
-`Counter.test.tsx`:
+`Counter.test.ts`:
 
-```tsx
+```jsx
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { Counter } from './Counter'
@@ -60,7 +60,7 @@ Here's an example below:
 
 `countAtom.ts`:
 
-```tsx
+```ts
 import { useAtom } from 'jotai'
 import { atomWithReducer } from 'jotai/utils'
 
@@ -79,7 +79,7 @@ export const countAtom = atomWithReducer(0, reducer)
 
 `countAtom.test.ts`:
 
-```tsx
+```ts
 import { renderHook, act } from '@testing-library/react-hooks'
 import { useAtom } from 'jotai'
 import { countAtom } from './countAtom'

--- a/docs/guides/typescript.mdx
+++ b/docs/guides/typescript.mdx
@@ -17,7 +17,7 @@ Jotai relies heavily on type inferences and requires `strictNullChecks` to be en
 
 ### Primitive atoms are basically type inferred
 
-```ts
+```js
 const numAtom = atom(0) // primitive number atom
 const strAtom = atom('') // primitive string atom
 ```
@@ -43,7 +43,7 @@ const readWriteAtom = atom<string, number>(
 
 ### useAtom is typed based on atom types
 
-```ts
+```js
 const [num, setNum] = useAtom(primitiveNumAtom)
 const [num] = useAtom(readOnlyNumAtom)
 const [, setNum] = useAtom(writeOnlyNumAtom)

--- a/docs/guides/vite.mdx
+++ b/docs/guides/vite.mdx
@@ -8,7 +8,7 @@ You can use the plugins from the `jotai/babel` bundle to enhance your developer 
 
 In your `vite.config.ts`:
 
-```ts
+```js
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import jotaiDebugLabel from 'jotai/babel/plugin-debug-label'

--- a/docs/integrations/immer.mdx
+++ b/docs/integrations/immer.mdx
@@ -19,7 +19,7 @@ yarn add immer
 `atomWithImmer` creates a new atom similar to the regular [`atom`](../api/core.mdx#atom) [atom] with a different `writeFunction`. In this bundle, we don't have read-only atoms, because the point of these functions is the immer produce(mutability) function.
 The signature of writeFunction is `(get, set, update: (draft: Draft<Value>) => void) => void`.
 
-```js
+```jsx
 import { useAtom } from 'jotai'
 import { atomWithImmer } from 'jotai/immer'
 
@@ -48,7 +48,7 @@ Check this example with atomWithImmer:
 
 `withImmer` takes an atom and returns a derived atom, same as `atomWithImmer` it has a different `writeFunction`.
 
-```js
+```jsx
 import { useAtom, atom } from 'jotai'
 import { withImmer } from 'jotai/immer'
 

--- a/docs/integrations/optics.mdx
+++ b/docs/integrations/optics.mdx
@@ -21,7 +21,7 @@ and when the derived atom is updated, the derivee is notified of the update, and
 
 See this:
 
-```typescript
+```js
 const baseAtom = atom({ a: 5 }) // PrimitiveAtom<{a: number}>
 const derivedAtom = focusAtom(baseAtom, (optic) => optic.prop('a')) // PrimitiveAtom<number>
 ```

--- a/docs/integrations/query.mdx
+++ b/docs/integrations/query.mdx
@@ -26,7 +26,7 @@ yarn add react-query
 
 > A query is a declarative dependency on an asynchronous source of data that is tied to a unique key. A query can be used with any Promise based method (including GET and POST methods) to fetch data from a server.
 
-```js
+```jsx
 import { useAtom } from 'jotai'
 import { atomWithQuery } from 'jotai/query'
 
@@ -53,7 +53,7 @@ const UserData = () => {
 
 A notable difference between a standard query atom is the additional option `getNextPageParam` and `getPreviousPageParam`, which is what you'll use to instruct the query on how to fetch any additional pages.
 
-```js
+```jsx
 import { useAtom } from 'jotai'
 import { atomWithInfiniteQuery } from 'jotai/query'
 

--- a/docs/integrations/redux.mdx
+++ b/docs/integrations/redux.mdx
@@ -40,7 +40,7 @@ const reducer = (state = initialState, action: { type: 'INC' }) => {
 const store = createStore(reducer)
 const storeAtom = atomWithStore(store)
 
-const Counter: React.FC = () => {
+const Counter = () => {
   const [state, dispatch] = useAtom(storeAtom)
 
   return (

--- a/docs/integrations/redux.mdx
+++ b/docs/integrations/redux.mdx
@@ -25,7 +25,7 @@ yarn add redux
 `atomWithStore` creates a new atom with redux store.
 It's two-way binding and you can change the value from both ends.
 
-```js
+```jsx
 import { useAtom } from 'jotai'
 import { atomWithStore } from 'jotai/redux'
 import { createStore } from 'redux'

--- a/docs/integrations/urql.mdx
+++ b/docs/integrations/urql.mdx
@@ -16,7 +16,7 @@ yarn add @urql/core wonka
 
 `atomWithQuery` creates a new atom with a query. It internally uses [client.query](https://formidable.com/open-source/urql/docs/api/core/#clientquery).
 
-```js
+```jsx
 import { useAtom } from 'jotai'
 import { createClient } from '@urql/core'
 import { atomWithQuery } from 'jotai/urql'
@@ -48,7 +48,7 @@ const UserData = () => {
 
 `atomWithMutation` creates a new atom with a mutation. It internally uses [client.mutation](https://formidable.com/open-source/urql/docs/api/core/#clientmutation).
 
-```js
+```jsx
 import { useAtom } from 'jotai'
 import { createClient } from '@urql/core'
 import { atomWithMutation } from 'jotai/urql'
@@ -78,7 +78,7 @@ TODO
 
 `atomWithSubscription` creates a new atom with a mutation. It internally uses [client.subscription](https://formidable.com/open-source/urql/docs/api/core/#clientsubscription).
 
-```js
+```jsx
 import { useAtom } from 'jotai'
 import { createClient } from '@urql/core'
 import { atomWithSubscription } from 'jotai/urql'

--- a/docs/integrations/valtio.mdx
+++ b/docs/integrations/valtio.mdx
@@ -27,14 +27,14 @@ yarn add valtio
 `atomWithProxy` creates a new atom with valtio proxy.
 It's two-way binding and you can change the value from both ends.
 
-```js
+```jsx
 import { useAtom } from 'jotai'
 import { atomWithProxy } from 'jotai/valtio'
 import { proxy } from 'valtio/vanilla'
 
 const proxyState = proxy({ count: 0 })
 const stateAtom = atomWithProxy(proxyState)
-const Counter: React.FC = () => {
+const Counter = () => {
   const [state, setState] = useAtom(stateAtom)
 
   return (

--- a/docs/integrations/xstate.mdx
+++ b/docs/integrations/xstate.mdx
@@ -28,7 +28,7 @@ It receives a function `getMachine` to create a new machine.
 `getMachine` is invoked at the first use with `get` argument,
 with which you can read other atom values.
 
-```js
+```tsx
 import { useAtom } from 'jotai'
 import { atomWithMachine } from 'jotai/xstate'
 import { assign, createMachine } from 'xstate'
@@ -68,7 +68,7 @@ const editableMachineAtom = atomWithMachine((get) =>
   createEditableMachine(get(defaultTextAtom))
 )
 
-const Toggle: React.FC = () => {
+const Toggle = () => {
   const [state, send] = useAtom(editableMachineAtom)
 
   return (

--- a/docs/integrations/zustand.mdx
+++ b/docs/integrations/zustand.mdx
@@ -27,14 +27,14 @@ yarn add zustand
 `atomWithStore` creates a new atom with zustand store.
 It's two-way binding and you can change the value from both ends.
 
-```js
+```jsx
 import { useAtom } from 'jotai'
 import { atomWithStore } from 'jotai/zustand'
 import create from 'zustand/vanilla'
 
 const store = create(() => ({ count: 0 }))
 const stateAtom = atomWithStore(store)
-const Counter: React.FC = () => {
+const Counter = () => {
   const [state, setState] = useAtom(stateAtom)
 
   return (

--- a/docs/utils/atom-with-default.mdx
+++ b/docs/utils/atom-with-default.mdx
@@ -24,14 +24,14 @@ const count2Atom = atomWithDefault((get) => get(count1Atom) * 2)
 
 You can reset the value of an `atomWithDefault` atom to its original default value.
 
-```js
+```jsx
 import { useAtom } from 'jotai'
 import { atomWithDefault, useResetAtom, RESET } from 'jotai/utils'
 
 const count1Atom = atom(1)
 const count2Atom = atomWithDefault((get) => get(count1Atom) * 2)
 
-const Counter: React.FC = () => {
+const Counter = () => {
   const [count1, setCount1] = useAtom(count1Atom)
   const [count2, setCount2] = useAtom(count2Atom)
   const resetCount2 = useResetAtom(count2Atom)

--- a/docs/utils/atom-with-hash.mdx
+++ b/docs/utils/atom-with-hash.mdx
@@ -40,7 +40,7 @@ This function works only with DOM.
 import { useAtom } from 'jotai'
 import { atomWithHash } from 'jotai/utils'
 const countAtom = atomWithHash('count', 1)
-const Counter: React.FC = () => {
+const Counter = () => {
   const [count, setCount] = useAtom(countAtom)
   return (
     <>

--- a/docs/utils/atom-with-observable.mdx
+++ b/docs/utils/atom-with-observable.mdx
@@ -6,7 +6,7 @@ Ref: https://github.com/pmndrs/jotai/pull/341
 
 ## Usage
 
-```ts
+```jsx
 import { useAtom } from 'jotai'
 import { atomWithObservable } from 'jotai/utils'
 import { interval } from 'rxjs'
@@ -30,7 +30,7 @@ To use this atom, you need to wrap your component with `<Suspense>`. Check out [
 
 `atomWithObservable` takes second optional parameter `{ initialValue }` that allows to specify initial value for the atom. If `initialValue` is provided then `atomWithObservable` will not suspend and will show initial value before receiving first value from observable. `initialValue` can be either a value or a function that returns a value
 
-```ts
+```js
 const counterAtom = atomWithObservable(() => counterSubject, {
   initialValue: 10,
 })

--- a/docs/utils/atom-with-storage.mdx
+++ b/docs/utils/atom-with-storage.mdx
@@ -4,7 +4,7 @@ title: atomWithStorage
 
 Ref: https://github.com/pmndrs/jotai/pull/394
 
-```ts
+```jsx
 import { useAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 
@@ -78,7 +78,7 @@ const TextBox = () => {
 You can use any library that implements `getItem`, `setItem` & `removeItem`.
 Let's say you would use the standard AsyncStorage provided by the community.
 
-```jsx
+```js
 import { atomWithStorage, createJSONStorage } from 'jotai/utils'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 

--- a/docs/utils/freeze-atom.mdx
+++ b/docs/utils/freeze-atom.mdx
@@ -4,7 +4,7 @@ title: freezeAtom
 
 ## Usage
 
-```typescript
+```ts
 freezeAtom(anAtom): AtomType
 ```
 
@@ -20,7 +20,7 @@ You may use `freezeAtom` with all atoms to prevent this situation.
 
 ## Examples
 
-```typescript
+```js
 import { atom } from 'jotai'
 import { freezeAtom } from 'jotai/utils'
 

--- a/docs/utils/reset.mdx
+++ b/docs/utils/reset.mdx
@@ -25,7 +25,7 @@ const centsAtom = atom(
     set(dollarsAtom, newValue === RESET ? newValue : newValue / 100)
 )
 
-const ResetExample: React.FC = () => {
+const ResetExample = () => {
   const setDollars = useUpdateAtom(dollarsAtom)
   const resetCents = useResetAtom(centsAtom)
 

--- a/docs/utils/select-atom.mdx
+++ b/docs/utils/select-atom.mdx
@@ -4,7 +4,7 @@ title: selectAtom
 
 Ref: https://github.com/pmndrs/jotai/issues/36
 
-```js
+```ts
 function selectAtom<Value, Slice>(
   anAtom: Atom<Value>,
   selector: (v: Value) => Slice,
@@ -57,13 +57,13 @@ const birthAtom = selectAtom(personAtom, (person) => person.birth, deepEquals)
 As always, to prevent an infinite loop when using `useAtom` in render cycle, you must provide `useAtom` a stable reference of your atoms.
 For `selectAtom`, we need **both** the base atom and the selector to be stable.
 
-```typescript
+```js
 const [value] = useAtom(selectAtom(atom(0), (val) => val)) // So this will cause an infinite loop
 ```
 
 You have multiple options in order to satisfy these constraints:
 
-```typescript
+```js
 const baseAtom = atom(0) // Stable
 const selector = (v) => v // Stable
 const Component = () => {

--- a/docs/utils/use-atom-callback.mdx
+++ b/docs/utils/use-atom-callback.mdx
@@ -6,7 +6,7 @@ Ref: https://github.com/pmndrs/jotai/issues/60
 
 ## Usage
 
-```js
+```ts
 useAtomCallback(
   callback: (get: Getter, set: Setter, arg: Arg) => Result
 ): (arg: Arg) => Promise<Result>

--- a/docs/utils/use-hydrate-atoms.mdx
+++ b/docs/utils/use-hydrate-atoms.mdx
@@ -6,7 +6,7 @@ Ref: https://github.com/pmndrs/jotai/issues/340
 
 ## Usage
 
-```tsx
+```js
 import { atom, useAtom } from 'jotai'
 import { useHydrateAtoms } from 'jotai/utils'
 
@@ -30,7 +30,7 @@ function useHydrateAtoms(
 
 The hook takes an iterable of tuples containing `[atom, value]` as an argument and optionally scope.
 
-```ts
+```js
 // Usage with an array, specifying a scope
 useHydrateAtoms(
   [
@@ -48,7 +48,7 @@ Atoms can only be hydrated once per scope. Therefore, if the initial value used 
 
 If there's a need to hydrate in multiple scopes, use multiple `useHydrateAtoms` hooks to achieve that.
 
-```ts
+```js
 useHydrateAtoms([
   [countAtom, 42],
   [frameworkAtom, 'Next.js'],

--- a/docs/utils/wait-for-all.mdx
+++ b/docs/utils/wait-for-all.mdx
@@ -4,7 +4,7 @@ title: waitForAll
 
 Sometimes you have multiple async atoms in your components:
 
-```tsx
+```js
 const dogsAtom = atom(async (get) => {
   const response = await fetch('/dogs')
   return await response.json()
@@ -25,7 +25,7 @@ However, this will start fetching one at the time, which is not optimal - It wou
 
 The `waitForAll` utility is a concurrency helper, which allows us to evaluate multiple async atoms:
 
-```tsx
+```js
 const dogsAtom = atom(async (get) => {
   const response = await fetch('/dogs')
   return await response.json()
@@ -45,7 +45,7 @@ const App = () => {
 
 You can also use `waitForAll` inside an atom - It's also possible to name them for readability:
 
-```tsx
+```js
 const dogsAtom = atom(async (get) => {
   const response = await fetch('/dogs')
   return await response.json()


### PR DESCRIPTION
Following-up [this issue](https://github.com/pmndrs/jotai/issues/1041) we decided to clean all markdowns, a lot were incorrect and some were overkill.

Pattern followed to clean:

- when there is a component & the component needs to return jsx
  - if typescript matters in the example : use "tsx"
  - if typescript doesn't really matter: use "jsx"
- when there is no component or the component doesn't need to return jsx
  - if typescript matters in the example: use "ts"
  - if typescript doesn't really matter: use "js"