### PR TITLE
refactor: prefer interface to type alias

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,7 +46,6 @@
     ],
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/no-empty-function": "off",
-    "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
     "jest/consistent-test-it": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,6 +48,7 @@
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
     "jest/consistent-test-it": [
       "error",
       { "fn": "it", "withinDescribe": "it" }

--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -1,6 +1,6 @@
 type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
 
-type Getter = {
+interface Getter {
   <Value>(atom: Atom<Value | Promise<Value>>): Value
   <Value>(atom: Atom<Promise<Value>>): Value
   <Value>(atom: Atom<Value>): Awaited<Value>
@@ -19,7 +19,7 @@ type WriteGetter = Getter & {
     | Awaited<Value>
 }
 
-type Setter = {
+interface Setter {
   <Value, Result extends void | Promise<void>>(
     atom: WritableAtom<Value, undefined, Result>
   ): Result
@@ -37,7 +37,7 @@ type Write<Update, Result extends void | Promise<void>> = (
   update: Update
 ) => Result
 
-type WithInitialValue<Value> = {
+interface WithInitialValue<Value> {
   init: Value
 }
 
@@ -59,17 +59,17 @@ type OnMount<Update, Result extends void | Promise<void>> = <
   setAtom: S
 ) => OnUnmount | void
 
-export type Atom<Value> = {
+export interface Atom<Value> {
   toString: () => string
   debugLabel?: string
   read: Read<Value>
 }
 
-export type WritableAtom<
+export interface WritableAtom<
   Value,
   Update,
   Result extends void | Promise<void> = void
-> = Atom<Value> & {
+> extends Atom<Value> {
   write: Write<Update, Result>
   onMount?: OnMount<Update, Result>
 }

--- a/src/core/contexts.ts
+++ b/src/core/contexts.ts
@@ -6,7 +6,7 @@ import type { Store } from './store'
 
 type VersionedWrite = (write: (version?: object) => void) => void
 
-export type ScopeContainer = {
+export interface ScopeContainer {
   s: Store
   w?: VersionedWrite
 }

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -61,7 +61,7 @@ export type AtomState<Value = AnyAtomValue> = {
  * While a new version is being built, we read atom previous state from the
  * previous version.
  */
-export type VersionObject = {
+export interface VersionObject {
   /**
    * "p"arent version.
    *
@@ -84,7 +84,7 @@ type Dependents = Set<AnyAtom>
  *
  * The mounted state of an atom is freed once it is no longer mounted.
  */
-type Mounted = {
+interface Mounted {
   /** The list of subscriber functions. */
   l: Listeners
   /** Atoms that depend on *this* atom. Used to fan out invalidation. */

--- a/src/devtools/types.ts
+++ b/src/devtools/types.ts
@@ -1,7 +1,7 @@
 import type {} from '@redux-devtools/extension'
 
 // FIXME https://github.com/reduxjs/redux-devtools/issues/1097
-export type Message = {
+export interface Message {
   type: string
   payload?: any
   state?: any

--- a/src/devtools/useAtomsDebugValue.ts
+++ b/src/devtools/useAtomsDebugValue.ts
@@ -35,7 +35,7 @@ const stateToPrintable = ([store, atoms]: [Store, Atom<unknown>[]]) =>
     })
   )
 
-type Options = {
+interface Options {
   scope?: Scope
   enabled?: boolean
 }

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -20,24 +20,29 @@ export type AtomWithInfiniteQueryAction<TQueryFnData> =
   | { type: 'fetchNextPage' }
   | { type: 'fetchPreviousPage' }
 
-export type AtomWithInfiniteQueryOptions<
+export interface AtomWithInfiniteQueryOptions<
   TQueryFnData,
   TError,
   TData,
   TQueryData
-> = InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryData> & {
+> extends InfiniteQueryObserverOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryData
+  > {
   queryKey: QueryKey
 }
 
-export type AtomWithInfiniteQueryOptionsWithEnabled<
+export interface AtomWithInfiniteQueryOptionsWithEnabled<
   TQueryFnData,
   TError,
   TData,
   TQueryData
-> = Omit<
-  AtomWithInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryData>,
-  'enabled'
-> & {
+> extends Omit<
+    AtomWithInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryData>,
+    'enabled'
+  > {
   enabled: boolean
 }
 

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -10,20 +10,24 @@ import type { PrimitiveAtom, WritableAtom } from 'jotai'
 import { queryClientAtom } from './queryClientAtom'
 import type { CreateQueryOptions, GetQueryClient } from './types'
 
-export type AtomWithQueryAction = { type: 'refetch' }
-export type AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData> =
-  QueryObserverOptions<TQueryFnData, TError, TData, TQueryData> & {
-    queryKey: QueryKey
-  }
-export type AtomWithQueryOptionsWithEnabled<
+export interface AtomWithQueryAction {
+  type: 'refetch'
+}
+
+export interface AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>
+  extends QueryObserverOptions<TQueryFnData, TError, TData, TQueryData> {
+  queryKey: QueryKey
+}
+
+export interface AtomWithQueryOptionsWithEnabled<
   TQueryFnData,
   TError,
   TData,
   TQueryData
-> = Omit<
-  AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>,
-  'enabled'
-> & {
+> extends Omit<
+    AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData>,
+    'enabled'
+  > {
   enabled: boolean
 }
 

--- a/src/urql/atomWithMutation.ts
+++ b/src/urql/atomWithMutation.ts
@@ -8,7 +8,7 @@ import { atom } from 'jotai'
 import type { Getter } from 'jotai'
 import { clientAtom } from './clientAtom'
 
-type MutationAction<Data, Variables extends object> = {
+interface MutationAction<Data, Variables extends object> {
   variables?: Variables
   context?: Partial<OperationContext>
   callback?: (result: OperationResult<Data, Variables>) => void

--- a/src/urql/atomWithQuery.ts
+++ b/src/urql/atomWithQuery.ts
@@ -11,7 +11,7 @@ import { atom } from 'jotai'
 import type { Getter, PrimitiveAtom, WritableAtom } from 'jotai'
 import { clientAtom } from './clientAtom'
 
-type AtomWithQueryAction = {
+interface AtomWithQueryAction {
   type: 'reexecute'
   opts?: Partial<OperationContext>
 }
@@ -28,7 +28,7 @@ const isOperationResultWithData = <Data, Variables>(
 ): result is OperationResultWithData<Data, Variables> =>
   'data' in result && !result.error
 
-type QueryArgs<Data, Variables extends object> = {
+interface QueryArgs<Data, Variables extends object> {
   query: TypedDocumentNode<Data, Variables> | string
   variables?: Variables
   requestPolicy?: RequestPolicy

--- a/src/urql/atomWithSubscription.ts
+++ b/src/urql/atomWithSubscription.ts
@@ -20,7 +20,7 @@ const isOperationResultWithData = <Data, Variables>(
   result: OperationResult<Data, Variables>
 ): result is OperationResultWithData<Data, Variables> => 'data' in result
 
-type SubscriptionArgs<Data, Variables extends object> = {
+interface SubscriptionArgs<Data, Variables extends object> {
   query: TypedDocumentNode<Data, Variables> | string
   variables?: Variables
   context?: Partial<OperationContext>

--- a/src/utils/atomFamily.ts
+++ b/src/utils/atomFamily.ts
@@ -2,7 +2,7 @@ import type { Atom } from 'jotai'
 
 type ShouldRemove<Param> = (createdAt: number, param: Param) => boolean
 
-type AtomFamily<Param, AtomType> = {
+interface AtomFamily<Param, AtomType> {
   (param: Param): AtomType
   remove(param: Param): void
   setShouldRemove(shouldRemove: ShouldRemove<Param> | null): void

--- a/src/utils/atomWithObservable.ts
+++ b/src/utils/atomWithObservable.ts
@@ -7,17 +7,17 @@ declare global {
   }
 }
 
-type Subscription = {
+interface Subscription {
   unsubscribe: () => void
 }
 
-type Observer<T> = {
+interface Observer<T> {
   next: (value: T) => void
   error: (error: unknown) => void
   complete: () => void
 }
 
-type ObservableLike<T> = {
+interface ObservableLike<T> {
   subscribe(observer: Observer<T>): Subscription
   subscribe(
     next: (value: T) => void,
@@ -31,7 +31,7 @@ type SubjectLike<T> = ObservableLike<T> & Observer<T>
 
 type InitialValueFunction<T> = () => T | undefined
 
-type AtomWithObservableOptions<TData> = {
+interface AtomWithObservableOptions<TData> {
   initialValue?: TData | InitialValueFunction<TData>
 }
 

--- a/src/utils/atomWithStorage.ts
+++ b/src/utils/atomWithStorage.ts
@@ -4,7 +4,7 @@ import { RESET } from './constants'
 
 type Unsubscribe = () => void
 
-type AsyncStorage<Value> = {
+interface AsyncStorage<Value> {
   getItem: (key: string) => Promise<Value>
   setItem: (key: string, newValue: Value) => Promise<void>
   removeItem: (key: string) => Promise<void>
@@ -12,7 +12,7 @@ type AsyncStorage<Value> = {
   subscribe?: (key: string, callback: (value: Value) => void) => Unsubscribe
 }
 
-type SyncStorage<Value> = {
+interface SyncStorage<Value> {
   getItem: (key: string) => Value
   setItem: (key: string, newValue: Value) => void
   removeItem: (key: string) => void
@@ -20,13 +20,13 @@ type SyncStorage<Value> = {
   subscribe?: (key: string, callback: (value: Value) => void) => Unsubscribe
 }
 
-type AsyncStringStorage = {
+interface AsyncStringStorage {
   getItem: (key: string) => Promise<string | null>
   setItem: (key: string, newValue: string) => Promise<void>
   removeItem: (key: string) => Promise<void>
 }
 
-type SyncStringStorage = {
+interface SyncStringStorage {
   getItem: (key: string) => string | null
   setItem: (key: string, newValue: string) => void
   removeItem: (key: string) => void

--- a/src/utils/splitAtom.ts
+++ b/src/utils/splitAtom.ts
@@ -54,7 +54,7 @@ export function splitAtom<Item, Key>(
   return memoizeAtom(
     () => {
       type ItemAtom = PrimitiveAtom<Item> | Atom<Item>
-      type Mapping = {
+      interface Mapping {
         atomList: ItemAtom[]
         keyList: Key[]
       }

--- a/src/valtio/atomWithProxy.ts
+++ b/src/valtio/atomWithProxy.ts
@@ -32,7 +32,7 @@ const applyChanges = <T extends object>(proxyObject: T, prev: T, next: T) => {
   })
 }
 
-type Options = {
+interface Options {
   sync?: boolean
 }
 

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -226,7 +226,10 @@ it('only re-renders if value has changed', async () => {
   const count2Atom = atom(0)
   const productAtom = atom((get) => get(count1Atom) * get(count2Atom))
 
-  type Props = { countAtom: typeof count1Atom; name: string }
+  interface Props {
+    countAtom: typeof count1Atom
+    name: string
+  }
   const Counter = ({ countAtom, name }: Props) => {
     const [count, setCount] = useAtom(countAtom)
     return (

--- a/tests/items.test.tsx
+++ b/tests/items.test.tsx
@@ -6,7 +6,7 @@ import { getTestProvider } from './testUtils'
 const Provider = getTestProvider()
 
 it('remove an item, then add another', async () => {
-  type Item = {
+  interface Item {
     text: string
     checked: boolean
   }
@@ -93,7 +93,7 @@ it('remove an item, then add another', async () => {
 })
 
 it('add an item with filtered list', async () => {
-  type Item = {
+  interface Item {
     text: string
     checked: boolean
   }

--- a/tests/utils/splitAtom.test.tsx
+++ b/tests/utils/splitAtom.test.tsx
@@ -7,7 +7,10 @@ import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
 
-type TodoItem = { task: string; checked?: boolean }
+interface TodoItem {
+  task: string
+  checked?: boolean
+}
 
 const useCommitCount = () => {
   const commitCountRef = useRef(1)
@@ -495,7 +498,7 @@ it('no error with cached atoms (fix 510)', async () => {
     return prevAtoms.current
   }
 
-  type NumItemProps = {
+  interface NumItemProps {
     atom: Atom<number>
   }
 


### PR DESCRIPTION
I didn't prefer interfaces because of the overload capability.

But, this isn't nice at all: https://tsplay.dev/mq132m

<img width="768" alt="image" src="https://user-images.githubusercontent.com/490574/174033961-7928b17c-b4ae-45ff-930e-8ab5ba04cc91.png">

So, changing my mind...

close #1233