### PR TITLE
fix: copy built-in awaited type

### DIFF
--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -1,4 +1,10 @@
-type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
+type Awaited<T> =
+    T extends null | undefined ? T : // special case for `null | undefined` when not in `--strictNullChecks` mode
+        T extends object & { then(onfulfilled: infer F): any } ? // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+            F extends ((value: infer V, ...args: any) => any) ? // if the argument to `then` is callable, extracts the first argument
+                Awaited<V> : // recursively unwrap the value
+                never : // the argument to `then` was not callable
+        T; // non-object or non-thenable
 
 interface Getter {
   <Value>(atom: Atom<Value | Promise<Value>>): Value

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -8,7 +8,13 @@ import {
 } from './suspensePromise'
 import type { SuspensePromise } from './suspensePromise'
 
-type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
+type Awaited<T> =
+    T extends null | undefined ? T : // special case for `null | undefined` when not in `--strictNullChecks` mode
+        T extends object & { then(onfulfilled: infer F): any } ? // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+            F extends ((value: infer V, ...args: any) => any) ? // if the argument to `then` is callable, extracts the first argument
+                Awaited<V> : // recursively unwrap the value
+                never : // the argument to `then` was not callable
+        T; // non-object or non-thenable
 
 type AnyAtomValue = unknown
 type AnyAtom = Atom<AnyAtomValue>

--- a/src/core/useAtom.ts
+++ b/src/core/useAtom.ts
@@ -2,7 +2,13 @@ import type { Atom, Scope, SetAtom, WritableAtom } from './atom'
 import { useAtomValue } from './useAtomValue'
 import { useSetAtom } from './useSetAtom'
 
-type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
+type Awaited<T> =
+    T extends null | undefined ? T : // special case for `null | undefined` when not in `--strictNullChecks` mode
+        T extends object & { then(onfulfilled: infer F): any } ? // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+            F extends ((value: infer V, ...args: any) => any) ? // if the argument to `then` is callable, extracts the first argument
+                Awaited<V> : // recursively unwrap the value
+                never : // the argument to `then` was not callable
+        T; // non-object or non-thenable
 
 export function useAtom<Value, Update, Result extends void | Promise<void>>(
   atom: WritableAtom<Value, Update, Result>,

--- a/src/core/useAtomValue.ts
+++ b/src/core/useAtomValue.ts
@@ -11,7 +11,13 @@ import { getScopeContext } from './contexts'
 import { COMMIT_ATOM, READ_ATOM, SUBSCRIBE_ATOM } from './store'
 import type { VersionObject } from './store'
 
-type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
+type Awaited<T> =
+    T extends null | undefined ? T : // special case for `null | undefined` when not in `--strictNullChecks` mode
+        T extends object & { then(onfulfilled: infer F): any } ? // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+            F extends ((value: infer V, ...args: any) => any) ? // if the argument to `then` is callable, extracts the first argument
+                Awaited<V> : // recursively unwrap the value
+                never : // the argument to `then` was not callable
+        T; // non-object or non-thenable
 
 export function useAtomValue<Value>(
   atom: Atom<Value>,

--- a/src/utils/loadable.ts
+++ b/src/utils/loadable.ts
@@ -2,7 +2,13 @@ import { atom } from 'jotai'
 import type { Atom } from 'jotai'
 import { createMemoizeAtom } from './weakCache'
 
-type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
+type Awaited<T> =
+    T extends null | undefined ? T : // special case for `null | undefined` when not in `--strictNullChecks` mode
+        T extends object & { then(onfulfilled: infer F): any } ? // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+            F extends ((value: infer V, ...args: any) => any) ? // if the argument to `then` is callable, extracts the first argument
+                Awaited<V> : // recursively unwrap the value
+                never : // the argument to `then` was not callable
+        T; // non-object or non-thenable
 
 const memoizeAtom = createMemoizeAtom()
 

--- a/src/utils/selectAtom.ts
+++ b/src/utils/selectAtom.ts
@@ -2,7 +2,13 @@ import { atom } from 'jotai'
 import type { Atom } from 'jotai'
 import { createMemoizeAtom } from './weakCache'
 
-type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
+type Awaited<T> =
+    T extends null | undefined ? T : // special case for `null | undefined` when not in `--strictNullChecks` mode
+        T extends object & { then(onfulfilled: infer F): any } ? // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+            F extends ((value: infer V, ...args: any) => any) ? // if the argument to `then` is callable, extracts the first argument
+                Awaited<V> : // recursively unwrap the value
+                never : // the argument to `then` was not callable
+        T; // non-object or non-thenable
 
 const memoizeAtom = createMemoizeAtom()
 

--- a/src/utils/waitForAll.ts
+++ b/src/utils/waitForAll.ts
@@ -5,7 +5,13 @@ import { createMemoizeAtom } from './weakCache'
 const memoizeAtom = createMemoizeAtom()
 const emptyArrayAtom = atom(() => [])
 
-type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
+type Awaited<T> =
+    T extends null | undefined ? T : // special case for `null | undefined` when not in `--strictNullChecks` mode
+        T extends object & { then(onfulfilled: infer F): any } ? // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+            F extends ((value: infer V, ...args: any) => any) ? // if the argument to `then` is callable, extracts the first argument
+                Awaited<V> : // recursively unwrap the value
+                never : // the argument to `then` was not callable
+        T; // non-object or non-thenable
 type ResolveAtom<T> = T extends Atom<infer V> ? V : T
 type AwaitedAtom<T> = Awaited<ResolveAtom<T>>
 


### PR DESCRIPTION
It fixes a bug when trying to use the atom in conjunction with generics. Given the following code:

```typescript
const useX = <$StageName extends string>(params: {
    atom: WritableAtom<$StageName, SetStateAction<$StageName>, void>;
    stages: $StageName[];
  }) => {
    const [currentStage, setCurrentStage] = useAtom(params.atom);
    const stageNames = Object.keys(params.stages) as $StageName[];
    const currentStageNumber = stageNames.indexOf(currentStage) + 1;
}
```

I get the following error:

```
Argument of type 'Awaited<$StageName>' is not assignable to parameter of type '$StageName'.
  'Awaited<$StageName>' is assignable to the constraint of type '$StageName', but '$StageName' could be instantiated with a different subtype of constraint 'string'.
    Type 'unknown' is not assignable to type '$StageName'.
      '$StageName' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.ts(2345)
```

Using the built-in `Awaited` type fixes this issue.