### PR TITLE
Handle ESM imports for @babel/template

### DIFF
--- a/src/babel/plugin-debug-label.ts
+++ b/src/babel/plugin-debug-label.ts
@@ -1,7 +1,9 @@
 import path from 'path'
 import babel, { PluginObj } from '@babel/core'
-import templateBuilder from '@babel/template'
+import _templateBuilder from '@babel/template'
 import { isAtom } from './utils'
+
+const templateBuilder = (_templateBuilder as any).default || _templateBuilder
 
 export default function debugLabelPlugin({
   types: t,

--- a/src/babel/plugin-react-refresh.ts
+++ b/src/babel/plugin-react-refresh.ts
@@ -1,6 +1,8 @@
 import babel, { PluginObj } from '@babel/core'
-import templateBuilder from '@babel/template'
+import _templateBuilder from '@babel/template'
 import { isAtom } from './utils'
+
+const templateBuilder = (_templateBuilder as any).default || _templateBuilder
 
 export default function reactRefreshPlugin({
   types: t,


### PR DESCRIPTION
This PR (hopefully) fixes ESM imports for `@babel/template`, when using `vite`.

Fixes #1251.