### PR TITLE
docs: typo in async.mdx

### DIFF
--- a/docs/guides/async.mdx
+++ b/docs/guides/async.mdx
@@ -6,7 +6,7 @@ nav: 1.03
 
 Using async atoms, you gain access to real-world data while still managing them directly from your atoms and with incredible ease.
 
-We can seperate them in two main categories:
+We can separate them in two main categories:
 
 - Async read atoms: async request is started instantly as soon as you try to get its value, you could relate to them as "smart getters"
 - Async write atoms: async request is started at a specific moment, you could relate to them as "actions"


### PR DESCRIPTION
Fixed typo "seperate" to "separate".