### PR TITLE
docs: typo in debugging.mdx

### DIFF
--- a/docs/guides/debugging.mdx
+++ b/docs/guides/debugging.mdx
@@ -103,7 +103,7 @@ This would set the `countAtoms`'s value to `5`.
 
 We'd recommend this hook if you want to keep track of all of your atoms in one place. It means every action on every atom that is placed in the bottom of this hook (in the React tree) will be catched by the Redux Dev Tools.
 
-Every feature of `useAtomDevtools` is supported in this hook, but there's an extra feature, which includes giving more information about atoms dependants like:
+Every feature of `useAtomDevtools` is supported in this hook, but there's an extra feature, which includes giving more information about atoms dependents like:
 
 ```json
 {


### PR DESCRIPTION
Fixed typo "dependants" to "dependents".