### PR TITLE
docs: typo in testing.mdx

### DIFF
--- a/docs/guides/testing.mdx
+++ b/docs/guides/testing.mdx
@@ -54,7 +54,7 @@ test('should increment counter', () => {
 ## Injected Values
 
 You may want to inject arbitrary values to your atom before starting some tests.
-Maybe the counter should be limmited to 100. Let's see how to test that it doesn't increase after reaching 100.
+Maybe the counter should be limited to 100. Let's see how to test that it doesn't increase after reaching 100.
 In order to do that, simply use a [Provider](..api/core#provider), and export your atom to be filled-in.
 
 ```tsx


### PR DESCRIPTION
Fixed typo "limmited" to "limited".