### PR TITLE
docs: typo in babel.mdx

### DIFF
--- a/docs/api/babel.mdx
+++ b/docs/api/babel.mdx
@@ -10,7 +10,7 @@ Jotai is based on object references and not keys (like Recoil). This means there
 
 However, this can quickly become cumbersome to add a `debugLabel` to every atom.
 
-This `babel` plugin adds a `debugLabel` to every atom, based on its identifer.
+This `babel` plugin adds a `debugLabel` to every atom, based on its identifier.
 
 The plugin transforms this code:
 


### PR DESCRIPTION
Fixed typo "identifer" to "identifier".