### PR TITLE
docs: typo in some files

### DIFF
--- a/docs/api/babel.mdx
+++ b/docs/api/babel.mdx
@@ -10,7 +10,7 @@ Jotai is based on object references and not keys (like Recoil). This means there
 
 However, this can quickly become cumbersome to add a `debugLabel` to every atom.
 
-This `babel` plugin adds a `debugLabel` to every atom, based on its identifer.
+This `babel` plugin adds a `debugLabel` to every atom, based on its identifier.
 
 The plugin transforms this code:
 

--- a/docs/api/utils.mdx
+++ b/docs/api/utils.mdx
@@ -42,7 +42,7 @@ This is an overview of the atom creators/hooks utilities that can be found under
 
 9. [atomWithReducer](../utils/atom-with-reducer.mdx)
 
-   This is a function to create an atom with an embeded reducer function to update the value.
+   This is a function to create an atom with an embedded reducer function to update the value.
 
 10. [atomWithDefault](../utils/atom-with-default.mdx)
 

--- a/docs/guides/async.mdx
+++ b/docs/guides/async.mdx
@@ -6,7 +6,7 @@ nav: 1.03
 
 Using async atoms, you gain access to real-world data while still managing them directly from your atoms and with incredible ease.
 
-We can seperate them in two main categories:
+We can separate them in two main categories:
 
 - Async read atoms: async request is started instantly as soon as you try to get its value, you could relate to them as "smart getters"
 - Async write atoms: async request is started at a specific moment, you could relate to them as "actions"

--- a/docs/guides/core-internals.mdx
+++ b/docs/guides/core-internals.mdx
@@ -142,7 +142,7 @@ const getAtomState = (atom) => {
 
 // If atom is primitive, we return it's value.
 // If atom is derived, we read the parent atom's value
-// and add current atom to parent's the dependent set (recursivly).
+// and add current atom to parent's the dependent set (recursively).
 const readAtom = (atom) => {
   const atomState = getAtomState(atom)
   const get = (a) => {
@@ -158,7 +158,7 @@ const readAtom = (atom) => {
   return value
 }
 
-// if atomState is modified, we need to notify all the dependent atoms (recursivly)
+// if atomState is modified, we need to notify all the dependent atoms (recursively)
 // now run callbacks for all the components that are dependent on this atom
 const notify = (atom) => {
   const atomState = getAtomState(atom)
@@ -179,7 +179,7 @@ const writeAtom = (atom, value) => {
   }
 
   // if 'a' is the same as atom, update the value, notify that atom and return
-  // else calls writeAtom for 'a' (recursivly)
+  // else calls writeAtom for 'a' (recursively)
   const set = (a, v) => {
     if (a === atom) {
       atomState.value = v

--- a/docs/guides/debugging.mdx
+++ b/docs/guides/debugging.mdx
@@ -103,7 +103,7 @@ This would set the `countAtoms`'s value to `5`.
 
 We'd recommend this hook if you want to keep track of all of your atoms in one place. It means every action on every atom that is placed in the bottom of this hook (in the React tree) will be catched by the Redux Dev Tools.
 
-Every feature of `useAtomDevtools` is supported in this hook, but there's an extra feature, which includes giving more information about atoms dependants like:
+Every feature of `useAtomDevtools` is supported in this hook, but there's an extra feature, which includes giving more information about atoms dependents like:
 
 ```json
 {

--- a/docs/guides/testing.mdx
+++ b/docs/guides/testing.mdx
@@ -54,7 +54,7 @@ test('should increment counter', () => {
 ## Injected Values
 
 You may want to inject arbitrary values to your atom before starting some tests.
-Maybe the counter should be limmited to 100. Let's see how to test that it doesn't increase after reaching 100.
+Maybe the counter should be limited to 100. Let's see how to test that it doesn't increase after reaching 100.
 In order to do that, simply use a [Provider](..api/core#provider), and export your atom to be filled-in.
 
 ```tsx

--- a/docs/integrations/query.mdx
+++ b/docs/integrations/query.mdx
@@ -94,7 +94,7 @@ const UserData = () => {
 
 ### SSR support
 
-Both atoms can be used within the context of a server side rendered app, such as a next.js app or gastby app. You can [use both options](https://react-query.tanstack.com/guides/ssr) that React Query supports for use within SSR apps, [hydration](https://react-query.tanstack.com/guides/ssr#using-hydration) or [`initialData`](https://react-query.tanstack.com/guides/ssr#using-initialdata).
+Both atoms can be used within the context of a server side rendered app, such as a next.js app or Gatsby app. You can [use both options](https://react-query.tanstack.com/guides/ssr) that React Query supports for use within SSR apps, [hydration](https://react-query.tanstack.com/guides/ssr#using-hydration) or [`initialData`](https://react-query.tanstack.com/guides/ssr#using-initialdata).
 
 ### Examples
 

--- a/docs/utils/atom-with-storage.mdx
+++ b/docs/utils/atom-with-storage.mdx
@@ -32,7 +32,7 @@ The `atomWithStorage` function creates an atom with a value persisted in `localS
 
 **storage** (optional): an object with:
 
-- `getItem` and `setItem` methods for storing/retreiving persisted state; defaults to using `localStorage` for storage/retreival and `JSON.stringify()`/`JSON.parse()` for serialization/deserialization.
+- `getItem` and `setItem` methods for storing/retrieving persisted state; defaults to using `localStorage` for storage/retrieval and `JSON.stringify()`/`JSON.parse()` for serialization/deserialization.
 - Optionally, the storage has a `subscribe` property, which can be used to synchronize storage. The default `localStorage` handles `storage` events for cross-tab synchronization.
 - Optionally, the storage has a `delayInit` (`boolean`) property, which can be used to tell jotai whether to use Suspense
   - `delayInit: true` will not suspend when first reading the value of your atom


### PR DESCRIPTION
1) Fixed typo "embeded" to "embedded"
2) Fixed typo "identifer" to "identifier".
3) Fixed typo "limmited" to "limited".
4) Fixed typo "dependants" to "dependents".
5) Fixed typo "recursivly" to "recursively".
6) Fixed typo "seperate" to "separate".
7) Fixed typo "gastby" to "Gatsby".
8) Fixed typo "retreiving" to "retrieving".
9) Fixed typo "retreival" to "retrieval".