### PR TITLE
fix(xstate): Allow restarting a machine in a global atom

### DIFF
--- a/src/xstate.ts
+++ b/src/xstate.ts
@@ -1,1 +1,1 @@
-export { atomWithMachine } from './xstate/atomWithMachine'
+export { atomWithMachine, RESTART } from './xstate/atomWithMachine'

--- a/src/xstate/atomWithMachine.ts
+++ b/src/xstate/atomWithMachine.ts
@@ -160,6 +160,10 @@ export function atomWithMachine<
       if (event === RESET) {
         service.stop()
         set(cachedMachineAtom, null)
+        set(machineAtom, null)
+        set(machineStateAtom, () => {
+          return
+        })
         service.start()
       } else {
         service.send(event)

--- a/src/xstate/atomWithMachine.ts
+++ b/src/xstate/atomWithMachine.ts
@@ -130,6 +130,7 @@ export function atomWithMachine<
       })
       service.start()
       registerCleanup(() => {
+        const { service } = get(machineAtom)
         service.stop()
       })
     }
@@ -166,8 +167,11 @@ export function atomWithMachine<
         service.stop()
         set(cachedMachineAtom, null)
         set(machineAtom, null)
-        set(machineStateAtom, () => void 0)
-        service.start()
+        const { service: newService } = get(machineAtom)
+        newService.onTransition((nextState: any) => {
+          set(cachedMachineStateAtom, nextState)
+        })
+        newService.start()
       } else {
         service.send(event)
       }

--- a/tests/xstate/atomWithMachine.test.tsx
+++ b/tests/xstate/atomWithMachine.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import { createMachine } from 'xstate'
 import { useAtom } from 'jotai'
+import { RESET } from 'jotai/utils'
 import { atomWithMachine } from 'jotai/xstate'
 import { getTestProvider } from '../testUtils'
 
@@ -10,12 +11,16 @@ it('toggle machine', async () => {
   const toggleMachine = createMachine({
     id: 'toggle',
     initial: 'inactive',
+    on: { DISABLE: '.final' },
     states: {
       inactive: {
         on: { TOGGLE: 'active' },
       },
       active: {
         on: { TOGGLE: 'inactive' },
+      },
+      final: {
+        type: 'final',
       },
     },
   })
@@ -26,11 +31,23 @@ it('toggle machine', async () => {
     const [state, send] = useAtom(toggleMachineAtom)
 
     return (
-      <button onClick={() => send('TOGGLE')}>
-        {state.value === 'inactive'
-          ? 'Click to activate'
-          : 'Active! Click to deactivate'}
-      </button>
+      <>
+        <button
+          onClick={() => send('TOGGLE')}
+          disabled={state.value === 'final'}>
+          {state.value === 'inactive'
+            ? 'Click to activate'
+            : state.value === 'active'
+            ? 'Active! Click to deactivate'
+            : 'Not actionable'}
+        </button>
+        <button
+          onClick={() => {
+            send(state.value === 'final' ? RESET : 'DISABLE')
+          }}>
+          {state.value === 'final' ? 'Restart machine' : 'Go to final state'}
+        </button>
+      </>
     )
   }
 
@@ -47,4 +64,10 @@ it('toggle machine', async () => {
 
   fireEvent.click(getByText('Active! Click to deactivate'))
   await findByText('Click to activate')
+
+  fireEvent.click(getByText('Go to final state'))
+  await findByText('Not actionable')
+
+  fireEvent.click(getByText('Restart machine'))
+  await waitFor(() => expect(findByText('Click to activate')).toBeDefined())
 })

--- a/tests/xstate/atomWithMachine.test.tsx
+++ b/tests/xstate/atomWithMachine.test.tsx
@@ -1,8 +1,7 @@
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { createMachine } from 'xstate'
+import { assign, createMachine } from 'xstate'
 import { useAtom } from 'jotai'
-import { RESET } from 'jotai/utils'
-import { atomWithMachine } from 'jotai/xstate'
+import { RESTART, atomWithMachine } from 'jotai/xstate'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
@@ -11,16 +10,12 @@ it('toggle machine', async () => {
   const toggleMachine = createMachine({
     id: 'toggle',
     initial: 'inactive',
-    on: { DISABLE: '.final' },
     states: {
       inactive: {
         on: { TOGGLE: 'active' },
       },
       active: {
         on: { TOGGLE: 'inactive' },
-      },
-      final: {
-        type: 'final',
       },
     },
   })
@@ -31,23 +26,11 @@ it('toggle machine', async () => {
     const [state, send] = useAtom(toggleMachineAtom)
 
     return (
-      <>
-        <button
-          onClick={() => send('TOGGLE')}
-          disabled={state.value === 'final'}>
-          {state.value === 'inactive'
-            ? 'Click to activate'
-            : state.value === 'active'
-            ? 'Active! Click to deactivate'
-            : 'Not actionable'}
-        </button>
-        <button
-          onClick={() => {
-            send(state.value === 'final' ? RESET : 'DISABLE')
-          }}>
-          {state.value === 'final' ? 'Restart machine' : 'Go to final state'}
-        </button>
-      </>
+      <button onClick={() => send('TOGGLE')}>
+        {state.value === 'inactive'
+          ? 'Click to activate'
+          : 'Active! Click to deactivate'}
+      </button>
     )
   }
 
@@ -64,10 +47,93 @@ it('toggle machine', async () => {
 
   fireEvent.click(getByText('Active! Click to deactivate'))
   await findByText('Click to activate')
+})
+
+it('restartable machine', async () => {
+  const toggleMachine = createMachine(
+    {
+      id: 'toggle',
+      initial: 'inactive',
+      context: { counter: 0 },
+      // schema: { context: {} as { counter: number } },
+      on: { DISABLE: '.final' },
+      states: {
+        inactive: {
+          on: { PRESS: 'active' },
+        },
+        active: {
+          on: {
+            PRESS: {
+              actions: 'increment',
+            },
+          },
+        },
+        final: {
+          type: 'final',
+        },
+      },
+    },
+    {
+      actions: {
+        increment: assign({
+          counter: (prev) => prev.counter + 1,
+        }),
+      },
+    }
+  )
+
+  const toggleMachineAtom = atomWithMachine(() => toggleMachine)
+
+  const Toggler = () => {
+    const [state, send] = useAtom(toggleMachineAtom)
+
+    return (
+      <>
+        <button
+          onClick={() => send('PRESS')}
+          disabled={state.value === 'final'}>
+          {state.value === 'inactive'
+            ? 'Click to activate'
+            : state.value === 'active'
+            ? 'Increment'
+            : 'Not actionable'}
+        </button>
+        <div>Count: {state.context.counter}</div>
+        <button
+          onClick={() => {
+            send(state.value === 'final' ? RESTART : 'DISABLE')
+          }}>
+          {state.value === 'final' ? 'Restart machine' : 'Go to final state'}
+        </button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Toggler />
+    </Provider>
+  )
+
+  await findByText('Click to activate')
+  await findByText('Count: 0')
+
+  fireEvent.click(getByText('Click to activate'))
+  await findByText('Increment')
+  await findByText('Count: 0')
+
+  fireEvent.click(getByText('Increment'))
+  await findByText('Count: 1')
+
+  fireEvent.click(getByText('Increment'))
+  await findByText('Count: 2')
 
   fireEvent.click(getByText('Go to final state'))
   await findByText('Not actionable')
 
   fireEvent.click(getByText('Restart machine'))
-  await waitFor(() => expect(findByText('Click to activate')).toBeDefined())
+  await waitFor(() => {
+    expect(findByText('Click to activate')).toBeDefined()
+    expect(findByText('Count: 0')).toBeDefined()
+  })
 })


### PR DESCRIPTION
The XState machine can be started with a default state and a custom passed state. This PR handles only the default one (as is the atom - doesn't handle hydration).

It is done by sending a jotai `RESET` in `send`:
```ts
import { RESET } from 'jotai/utils'
// ...

const [current, send] = useAtom(myMachineAtom);

// example usage of resetting machine by leaving a route in react-navigation:
  useFocusEffect(
    useCallback(
      () =>
        navigation.addListener('beforeRemove', () => {
          send(RESET);
        }),
      [navigation, send],
    ),
  );

```
Typescript will not complain as `typeof RESET` is added to the types of events that `send` my accept