### PR TITLE
fix(types): use TS interfaces only for public api

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,7 +47,6 @@
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
     "jest/consistent-test-it": [
       "error",
       { "fn": "it", "withinDescribe": "it" }

--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -1,6 +1,6 @@
 type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
 
-interface Getter {
+type Getter = {
   <Value>(atom: Atom<Value | Promise<Value>>): Value
   <Value>(atom: Atom<Promise<Value>>): Value
   <Value>(atom: Atom<Value>): Awaited<Value>
@@ -19,7 +19,7 @@ type WriteGetter = Getter & {
     | Awaited<Value>
 }
 
-interface Setter {
+type Setter = {
   <Value, Result extends void | Promise<void>>(
     atom: WritableAtom<Value, undefined, Result>
   ): Result
@@ -36,6 +36,10 @@ type Write<Update, Result extends void | Promise<void>> = (
   set: Setter,
   update: Update
 ) => Result
+
+type WithInitialValue<Value> = {
+  init: Value
+}
 
 export type Scope = symbol | string | number
 
@@ -70,19 +74,9 @@ export interface WritableAtom<
   onMount?: OnMount<Update, Result>
 }
 
-type WritableAtomWithInitialValue<
-  Value,
-  Update,
-  Result extends void | Promise<void> = void
-> = WritableAtom<Value, Update, Result> & { init: Value }
-
 type SetStateAction<Value> = Value | ((prev: Value) => Value)
 
 export type PrimitiveAtom<Value> = WritableAtom<Value, SetStateAction<Value>>
-
-type PrimitiveAtomWithInitialValue<Value> = PrimitiveAtom<Value> & {
-  init: Value
-}
 
 let keyCount = 0 // global key count for all atoms
 
@@ -102,12 +96,12 @@ export function atom(invalidFunction: (...args: any) => any, write?: any): never
 export function atom<Value, Update, Result extends void | Promise<void> = void>(
   initialValue: Value,
   write: Write<Update, Result>
-): WritableAtomWithInitialValue<Value, Update, Result>
+): WritableAtom<Value, Update, Result> & WithInitialValue<Value>
 
 // primitive atom
 export function atom<Value>(
   initialValue: Value
-): PrimitiveAtomWithInitialValue<Value>
+): PrimitiveAtom<Value> & WithInitialValue<Value>
 
 export function atom<Value, Update, Result extends void | Promise<void>>(
   read: Value | Read<Value>,

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -60,8 +60,10 @@ export type AtomState<Value = AnyAtomValue> = {
  *
  * While a new version is being built, we read atom previous state from the
  * previous version.
+ *
+ * This is an INTERNAL type alias.
  */
-export interface VersionObject {
+export type VersionObject = {
   /**
    * "p"arent version.
    *
@@ -84,7 +86,7 @@ type Dependents = Set<AnyAtom>
  *
  * The mounted state of an atom is freed once it is no longer mounted.
  */
-interface Mounted {
+type Mounted = {
   /** The list of subscriber functions. */
   l: Listeners
   /** Atoms that depend on *this* atom. Used to fan out invalidation. */

--- a/src/devtools/types.ts
+++ b/src/devtools/types.ts
@@ -1,7 +1,8 @@
 import type {} from '@redux-devtools/extension'
 
 // FIXME https://github.com/reduxjs/redux-devtools/issues/1097
-export interface Message {
+// This is an INTERNAL type alias.
+export type Message = {
   type: string
   payload?: any
   state?: any

--- a/src/devtools/useAtomDevtools.ts
+++ b/src/devtools/useAtomDevtools.ts
@@ -4,7 +4,7 @@ import type { Atom, WritableAtom } from 'jotai'
 import type { Scope, SetAtom } from '../core/atom'
 import { Message } from './types'
 
-interface DevtoolOptions {
+type DevtoolOptions = {
   name?: string
   scope?: Scope
   enabled?: boolean

--- a/src/devtools/useAtomsDebugValue.ts
+++ b/src/devtools/useAtomsDebugValue.ts
@@ -35,7 +35,7 @@ const stateToPrintable = ([store, atoms]: [Store, Atom<unknown>[]]) =>
     })
   )
 
-interface Options {
+type Options = {
   scope?: Scope
   enabled?: boolean
 }

--- a/src/devtools/useAtomsDevtools.ts
+++ b/src/devtools/useAtomsDevtools.ts
@@ -55,7 +55,7 @@ const getDevtoolsState = (atomsSnapshot: AtomsSnapshot) => {
   }
 }
 
-interface DevtoolsOptions {
+type DevtoolsOptions = {
   scope?: Scope
   enabled?: boolean
 }

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,11 +1,5 @@
 export { queryClientAtom } from './query/queryClientAtom'
 export { atomWithQuery } from './query/atomWithQuery'
 export { atomWithInfiniteQuery } from './query/atomWithInfiniteQuery'
-export type {
-  AtomWithQueryAction,
-  AtomWithQueryOptions,
-} from './query/atomWithQuery'
-export type {
-  AtomWithInfiniteQueryOptions,
-  AtomWithInfiniteQueryAction,
-} from './query/atomWithInfiniteQuery'
+export type { AtomWithQueryOptions } from './query/atomWithQuery'
+export type { AtomWithInfiniteQueryOptions } from './query/atomWithInfiniteQuery'

--- a/src/query/atomWithInfiniteQuery.ts
+++ b/src/query/atomWithInfiniteQuery.ts
@@ -13,7 +13,7 @@ import type { WritableAtom } from 'jotai'
 import { queryClientAtom } from './queryClientAtom'
 import { CreateQueryOptions, GetQueryClient } from './types'
 
-export type AtomWithInfiniteQueryAction<TQueryFnData> =
+type AtomWithInfiniteQueryAction<TQueryFnData> =
   | ({ type: 'refetch' } & Partial<
       RefetchOptions & RefetchQueryFilters<TQueryFnData>
     >)

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -10,7 +10,7 @@ import type { PrimitiveAtom, WritableAtom } from 'jotai'
 import { queryClientAtom } from './queryClientAtom'
 import type { CreateQueryOptions, GetQueryClient } from './types'
 
-export interface AtomWithQueryAction {
+type AtomWithQueryAction = {
   type: 'refetch'
 }
 

--- a/src/urql/atomWithMutation.ts
+++ b/src/urql/atomWithMutation.ts
@@ -8,7 +8,7 @@ import { atom } from 'jotai'
 import type { Getter } from 'jotai'
 import { clientAtom } from './clientAtom'
 
-interface MutationAction<Data, Variables extends object> {
+type MutationAction<Data, Variables extends object> = {
   variables?: Variables
   context?: Partial<OperationContext>
   callback?: (result: OperationResult<Data, Variables>) => void

--- a/src/urql/atomWithQuery.ts
+++ b/src/urql/atomWithQuery.ts
@@ -11,7 +11,7 @@ import { atom } from 'jotai'
 import type { Getter, PrimitiveAtom, WritableAtom } from 'jotai'
 import { clientAtom } from './clientAtom'
 
-interface AtomWithQueryAction {
+type AtomWithQueryAction = {
   type: 'reexecute'
   opts?: Partial<OperationContext>
 }
@@ -28,7 +28,7 @@ const isOperationResultWithData = <Data, Variables>(
 ): result is OperationResultWithData<Data, Variables> =>
   'data' in result && !result.error
 
-interface QueryArgs<Data, Variables extends object> {
+type QueryArgs<Data, Variables extends object> = {
   query: TypedDocumentNode<Data, Variables> | string
   variables?: Variables
   requestPolicy?: RequestPolicy

--- a/src/urql/atomWithSubscription.ts
+++ b/src/urql/atomWithSubscription.ts
@@ -21,7 +21,7 @@ const isOperationResultWithData = <Data, Variables>(
   result: OperationResult<Data, Variables>
 ): result is OperationResultWithData<Data, Variables> => 'data' in result
 
-interface SubscriptionArgs<Data, Variables extends object> {
+type SubscriptionArgs<Data, Variables extends object> = {
   query: TypedDocumentNode<Data, Variables> | string
   variables?: Variables
   context?: Partial<OperationContext>

--- a/src/utils/atomFamily.ts
+++ b/src/utils/atomFamily.ts
@@ -2,7 +2,7 @@ import type { Atom } from 'jotai'
 
 type ShouldRemove<Param> = (createdAt: number, param: Param) => boolean
 
-interface AtomFamily<Param, AtomType> {
+export interface AtomFamily<Param, AtomType> {
   (param: Param): AtomType
   remove(param: Param): void
   setShouldRemove(shouldRemove: ShouldRemove<Param> | null): void

--- a/src/utils/atomWithObservable.ts
+++ b/src/utils/atomWithObservable.ts
@@ -7,17 +7,17 @@ declare global {
   }
 }
 
-interface Subscription {
+type Subscription = {
   unsubscribe: () => void
 }
 
-interface Observer<T> {
+type Observer<T> = {
   next: (value: T) => void
   error: (error: unknown) => void
   complete: () => void
 }
 
-interface ObservableLike<T> {
+type ObservableLike<T> = {
   subscribe(observer: Observer<T>): Subscription
   subscribe(
     next: (value: T) => void,
@@ -31,7 +31,7 @@ type SubjectLike<T> = ObservableLike<T> & Observer<T>
 
 type InitialValueFunction<T> = () => T | undefined
 
-interface AtomWithObservableOptions<TData> {
+type AtomWithObservableOptions<TData> = {
   initialValue?: TData | InitialValueFunction<TData>
 }
 

--- a/src/utils/atomWithStorage.ts
+++ b/src/utils/atomWithStorage.ts
@@ -4,7 +4,7 @@ import { RESET } from './constants'
 
 type Unsubscribe = () => void
 
-interface AsyncStorage<Value> {
+export interface AsyncStorage<Value> {
   getItem: (key: string) => Promise<Value>
   setItem: (key: string, newValue: Value) => Promise<void>
   removeItem: (key: string) => Promise<void>
@@ -12,7 +12,7 @@ interface AsyncStorage<Value> {
   subscribe?: (key: string, callback: (value: Value) => void) => Unsubscribe
 }
 
-interface SyncStorage<Value> {
+export interface SyncStorage<Value> {
   getItem: (key: string) => Value
   setItem: (key: string, newValue: Value) => void
   removeItem: (key: string) => void
@@ -20,13 +20,13 @@ interface SyncStorage<Value> {
   subscribe?: (key: string, callback: (value: Value) => void) => Unsubscribe
 }
 
-interface AsyncStringStorage {
+export interface AsyncStringStorage {
   getItem: (key: string) => Promise<string | null>
   setItem: (key: string, newValue: string) => Promise<void>
   removeItem: (key: string) => Promise<void>
 }
 
-interface SyncStringStorage {
+export interface SyncStringStorage {
   getItem: (key: string) => string | null
   setItem: (key: string, newValue: string) => void
   removeItem: (key: string) => void

--- a/src/utils/splitAtom.ts
+++ b/src/utils/splitAtom.ts
@@ -54,7 +54,7 @@ export function splitAtom<Item, Key>(
   return memoizeAtom(
     () => {
       type ItemAtom = PrimitiveAtom<Item> | Atom<Item>
-      interface Mapping {
+      type Mapping = {
         atomList: ItemAtom[]
         keyList: Key[]
       }

--- a/src/valtio/atomWithProxy.ts
+++ b/src/valtio/atomWithProxy.ts
@@ -32,7 +32,7 @@ const applyChanges = <T extends object>(proxyObject: T, prev: T, next: T) => {
   })
 }
 
-interface Options {
+type Options = {
   sync?: boolean
 }
 

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -226,10 +226,7 @@ it('only re-renders if value has changed', async () => {
   const count2Atom = atom(0)
   const productAtom = atom((get) => get(count1Atom) * get(count2Atom))
 
-  interface Props {
-    countAtom: typeof count1Atom
-    name: string
-  }
+  type Props = { countAtom: typeof count1Atom; name: string }
   const Counter = ({ countAtom, name }: Props) => {
     const [count, setCount] = useAtom(countAtom)
     return (

--- a/tests/items.test.tsx
+++ b/tests/items.test.tsx
@@ -6,7 +6,7 @@ import { getTestProvider } from './testUtils'
 const Provider = getTestProvider()
 
 it('remove an item, then add another', async () => {
-  interface Item {
+  type Item = {
     text: string
     checked: boolean
   }
@@ -93,7 +93,7 @@ it('remove an item, then add another', async () => {
 })
 
 it('add an item with filtered list', async () => {
-  interface Item {
+  type Item = {
     text: string
     checked: boolean
   }

--- a/tests/utils/loadable.test.tsx
+++ b/tests/utils/loadable.test.tsx
@@ -215,7 +215,7 @@ it('loadable of a derived async atom does not trigger infinite loop (#1114)', as
   await findByText('Data: 5')
 })
 
-interface LoadableComponentProps {
+type LoadableComponentProps = {
   asyncAtom: Atom<Promise<number> | Promise<string> | string | number>
   effectCallback?: (loadableValue: any) => void
 }

--- a/tests/utils/splitAtom.test.tsx
+++ b/tests/utils/splitAtom.test.tsx
@@ -7,10 +7,7 @@ import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
 
-interface TodoItem {
-  task: string
-  checked?: boolean
-}
+type TodoItem = { task: string; checked?: boolean }
 
 const useCommitCount = () => {
   const commitCountRef = useRef(1)
@@ -498,9 +495,7 @@ it('no error with cached atoms (fix 510)', async () => {
     return prevAtoms.current
   }
 
-  interface NumItemProps {
-    atom: Atom<number>
-  }
+  type NumItemProps = { atom: Atom<number> }
 
   const NumItem = ({ atom }: NumItemProps) => {
     const [readOnlyItem] = useAtom(atom)


### PR DESCRIPTION
following https://github.com/pmndrs/zustand/pull/1106

This reverts #1234 to some extent.
Exporting types is revisited. For example, `AtomFamily` is exported now. #1012 
