### PR TITLE
docs(jotai/query): same query client initialisation

### DIFF
--- a/docs/integrations/query.mdx
+++ b/docs/integrations/query.mdx
@@ -94,15 +94,15 @@ const UserData = () => {
 
 ### Referencing the same instance of Query Client in your project
 
-Perhaps you have some functions in your project that utilises the `useQueryClient()` hook to obtain the `QueryClient` object and call its methods.
+Perhaps you have some custom hooks in your project that utilises the `useQueryClient()` hook to obtain the `QueryClient` object and call its methods.
 
 To ensure that you reference the same `QueryClient` object, be sure to wrap the root of your project in a `<Provider>` and initialise `queryClientAtom` with the same `queryClient` value you provided to `QueryClientProvider`.
 
-Without this step, `useQueryAtom` will reference a seperate `QueryClient` from any queries/mutations that utilise the `useQueryClient()` hook to get the queryClient.
+Without this step, `useQueryAtom` will reference a seperate `QueryClient` from any hooks that utilise the `useQueryClient()` hook to get the queryClient.
 
 #### Example
 
-In the example below, we have a mutation, `useTodoMutation` and a query `todosAtom`.
+In the example below, we have a mutation hook, `useTodoMutation` and a query `todosAtom`.
 
 Although they reference methods same query keys (`'todos'`), should `useTodoMutation` be called and invalidate the query without the `Provider` initialisation step, `todosAtom` will not be prompted to refetch and will continue showing stale data.
 

--- a/docs/integrations/query.mdx
+++ b/docs/integrations/query.mdx
@@ -92,6 +92,59 @@ const UserData = () => {
 }
 ```
 
+### Referencing the same instance of Query Client in your project
+
+Perhaps you have some functions in your project that utilises the `useQueryClient()` hook to obtain the `QueryClient` object and call its methods.
+
+To ensure that you reference the same `QueryClient` object, be sure to wrap the root of your project in a `<Provider>` and initialise `queryClientAtom` with the same `queryClient` value you provided to `QueryClientProvider`.
+
+Without this step, `useQueryAtom` will reference a seperate `QueryClient` from any queries/mutations that utilise the `useQueryClient()` hook to get the queryClient.
+
+#### Example
+
+In the example below, we have a mutation, `useTodoMutation` and a query `todosAtom`.
+
+Although they reference methods same query keys (`'todos'`), should `useTodoMutation` be called and invalidate the query without the `Provider` initialisation step, `todosAtom` will not be prompted to refetch and will continue showing stale data.
+
+```js
+const queryClient = new QueryClient()
+export const App = () => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {/* This Provider initalization step is needed so that we reference the same
+      queryClient in both atomWithQuery and other parts of the app. Without this,
+      our useQueryClient() hook will point to a different QueryClient singleton obj */}
+      <Provider initialValues={[[queryClientAtom, queryClient]]}>
+        <App />
+      </Provider>
+    </QueryClientProvider>
+  )
+}
+
+export const todosAtom = atomWithQuery((get) => {
+  return {
+    queryKey: ['todos'],
+    queryFn: () => fetch('/todos'),
+  }
+})
+
+export const useTodoMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation(
+    async (body: todo) => {
+      await fetch('/todo', { Method: 'POST', Body: body })
+    },
+    {
+      onSuccess: () => {
+        void queryClient.invalidateQueries(['todos'])
+      },
+      onError,
+    }
+  )
+}
+```
+
 ## SSR support
 
 Both atoms can be used within the context of a server side rendered app, such as a next.js app or Gatsby app. You can [use both options](https://react-query.tanstack.com/guides/ssr) that React Query supports for use within SSR apps, [hydration](https://react-query.tanstack.com/guides/ssr#using-hydration) or [`initialData`](https://react-query.tanstack.com/guides/ssr#using-initialdata).

--- a/docs/integrations/query.mdx
+++ b/docs/integrations/query.mdx
@@ -104,16 +104,28 @@ Without this step, `useQueryAtom` will reference a seperate `QueryClient` from a
 
 In the example below, we have a mutation hook, `useTodoMutation` and a query `todosAtom`.
 
-Although they reference methods same query keys (`'todos'`), should `useTodoMutation` be called and invalidate the query without the `Provider` initialisation step, `todosAtom` will not be prompted to refetch and will continue showing stale data.
+We included an initialisation step in our root `<App>` node.
 
-```js
+Although they reference methods same query key (`'todos'`), the `onSuccess` invalidation in `useTodoMutation` will not trigger **if the `Provider` initialisation step was not done.**
+
+This will result in `todosAtom` showing stale data as it was not prompted to refetch.
+
+```jsx
+import {
+  useMutation,
+  useQueryClient,
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query'
+import { atomWithQuery } from 'jotai/query'
+
 const queryClient = new QueryClient()
 export const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       {/* This Provider initalization step is needed so that we reference the same
       queryClient in both atomWithQuery and other parts of the app. Without this,
-      our useQueryClient() hook will point to a different QueryClient singleton obj */}
+      our useQueryClient() hook will return a different QueryClient object */}
       <Provider initialValues={[[queryClientAtom, queryClient]]}>
         <App />
       </Provider>

--- a/docs/integrations/query.mdx
+++ b/docs/integrations/query.mdx
@@ -92,7 +92,7 @@ const UserData = () => {
 }
 ```
 
-### Referencing the same instance of Query Client in your project
+## Referencing the same instance of Query Client in your project
 
 Perhaps you have some custom hooks in your project that utilises the `useQueryClient()` hook to obtain the `QueryClient` object and call its methods.
 
@@ -100,7 +100,7 @@ To ensure that you reference the same `QueryClient` object, be sure to wrap the 
 
 Without this step, `useQueryAtom` will reference a seperate `QueryClient` from any hooks that utilise the `useQueryClient()` hook to get the queryClient.
 
-#### Example
+### Example
 
 In the example below, we have a mutation hook, `useTodoMutation` and a query `todosAtom`.
 


### PR DESCRIPTION
I had a project with existing integrations with `react-query` before importing `jotai` to the project.

Upon using `atomWithQuery` without this initialisation step, I realised that my existing functions which called `queryClient.invalidate(...)` did not result in `atomWithQuery`'s query invalidating. As a result, data was not refetched and the atom had stale data.

After browsing the discussions, I found the answer here https://github.com/pmndrs/jotai/discussions/500#discussioncomment-803421. The cause was because our functions were referencing different instances of `queryClient`

Seeing that this was a discussion thread, and that others might port in jotai into existing projects which already have `react-query` integrated, I thought it might be helpful to add this piece of documentation into the official query integration documentation.

Please let me know if the example and documentation is clear! Thank you.