### PR TITLE
docs(utils): fix atomWithHash options

### DIFF
--- a/docs/utils/atom-with-hash.mdx
+++ b/docs/utils/atom-with-hash.mdx
@@ -28,7 +28,7 @@ This function works only with DOM.
 
 **deserialize** (optional): a custom function to deserialize the hash to the atom value. Defaults to `JSON.parse`.
 
-**delayInit** (optional): delay initialization of the atom to when `onMount` is called. See [#739](https://github.com/pmndrs/jotai/issues/739#issuecomment-929260696). Defaults to `true`.
+**delayInit** (optional): delay initialization of the atom to when `onMount` is called. See [#739](https://github.com/pmndrs/jotai/issues/739#issuecomment-929260696). Defaults to `false`.
 
 **replaceState** (optional): when the atom value is changed, replace the current history entry instead of adding a new one. See [#660](https://github.com/pmndrs/jotai/issues/660). Defaults to `false`.
 


### PR DESCRIPTION
It seems like a mistake in #879.