### PR TITLE
feat(utils): support RESET with update function for atomWithStorage/atomWithHash/atomWithReset

### DIFF
--- a/docs/utils/atom-with-storage.mdx
+++ b/docs/utils/atom-with-storage.mdx
@@ -53,11 +53,7 @@ The suggested workaround for this issue is to only render the content dependent 
 For the case you want to delete an item from storage,
 the atom created with `atomWithStorage` accepts the `RESET` symbol on write.
 
-See the following example for RESET usage:
-
-- The input element exemplifies how you could use a previous value to conditionally trigger a reset based on previous value.
-  - In the example, `text` will be reset to `hello` if previous atom value === 'reset'
-- The button resets text to 'hello' when clicked.
+See the following example for the usage:
 
 ```jsx
 import { useAtom } from 'jotai'
@@ -70,13 +66,32 @@ const TextBox = () => {
 
   return (
     <>
-      <input
-        value={text}
-        onChange={(e) =>
-          setText((prev) => (prev === 'reset' ? RESET : e.target.value))
-        }
-      />
+      <input value={text} onChange={(e) => setText(e.target.value)} />
       <button onClick={() => setText(RESET)}>Reset (to 'hello')</button>
+    </>
+  )
+}
+```
+
+If needed, you can also do conditional resets based on previous value.
+
+This can be particularly useful if you wish to clear keys in localStorage if previous values meet a condition.
+
+Below exemplifies this usage that clears the `visible` key whenever the previous value is `true`.
+
+```jsx
+import { useAtom } from 'jotai'
+import { atomWithStorage, RESET } from 'jotai/utils'
+
+const isVisibleAtom = atomWithStorage('visible', false)
+
+const TextBox = () => {
+  const [isVisible, setIsVisible] = useAtom(isVisibleAtom)
+
+  return (
+    <>
+      { isVisible && <h1>Header is visible!</h1> }
+      <button onClick={() => setIsVisible((prev) => prev ? RESET : true))}>Toggle visible</button>
     </>
   )
 }

--- a/docs/utils/atom-with-storage.mdx
+++ b/docs/utils/atom-with-storage.mdx
@@ -55,8 +55,9 @@ the atom created with `atomWithStorage` accepts the `RESET` symbol on write.
 
 See the following example for RESET usage:
 
-- The button resets text to 'hello'
-- The second input element exemplifies how you could use a previous value to conditionally trigger a reset
+- The input element exemplifies how you could use a previous value to conditionally trigger a reset based on previous value.
+  - In the example, `text` will be reset to `hello` if previous atom value === 'reset'
+- The button resets text to 'hello' when clicked.
 
 ```jsx
 import { useAtom } from 'jotai'
@@ -69,19 +70,13 @@ const TextBox = () => {
 
   return (
     <>
-      <input value={text} onChange={(e) => setText(e.target.value)} />
-      <button onClick={() => setText(RESET)}>Reset (to 'hello')</button>
-
-      {/* 
-        trigger a reset based on the previous value. If input text is reset, we
-        will reset value to 'hello' 
-      */}
       <input
         value={text}
         onChange={(e) =>
           setText((prev) => (prev === 'reset' ? RESET : e.target.value))
         }
       />
+      <button onClick={() => setText(RESET)}>Reset (to 'hello')</button>
     </>
   )
 }

--- a/docs/utils/atom-with-storage.mdx
+++ b/docs/utils/atom-with-storage.mdx
@@ -68,6 +68,12 @@ const TextBox = () => {
     <>
       <input value={text} onChange={(e) => setText(e.target.value)} />
       <button onClick={() => setText(RESET)}>Reset (to 'hello')</button>
+      <button
+        onClick={(e) =>
+          setText((prev) => (prev === 'reset' ? RESET : e.target.value))
+        }>
+        Reset value if input text === reset
+      </button>
     </>
   )
 }

--- a/docs/utils/atom-with-storage.mdx
+++ b/docs/utils/atom-with-storage.mdx
@@ -53,7 +53,10 @@ The suggested workaround for this issue is to only render the content dependent 
 For the case you want to delete an item from storage,
 the atom created with `atomWithStorage` accepts the `RESET` symbol on write.
 
-See the following example for the usage:
+See the following example for RESET usage:
+
+- The button resets text to 'hello'
+- The second input element exemplifies how you could use a previous value to conditionally trigger a reset
 
 ```jsx
 import { useAtom } from 'jotai'
@@ -68,6 +71,11 @@ const TextBox = () => {
     <>
       <input value={text} onChange={(e) => setText(e.target.value)} />
       <button onClick={() => setText(RESET)}>Reset (to 'hello')</button>
+
+      {/* 
+        trigger a reset based on the previous value. If input text is reset, we
+        will reset value to 'hello' 
+      */}
       <input
         value={text}
         onChange={(e) =>

--- a/docs/utils/atom-with-storage.mdx
+++ b/docs/utils/atom-with-storage.mdx
@@ -68,8 +68,8 @@ const TextBox = () => {
     <>
       <input value={text} onChange={(e) => setText(e.target.value)} />
       <button onClick={() => setText(RESET)}>Reset (to 'hello')</button>
-      <button
-        onClick={(e) =>
+      <input value={text}
+        onChange={(e) =>
           setText((prev) => (prev === 'reset' ? RESET : e.target.value))
         }>
         Reset value if input text === reset

--- a/docs/utils/atom-with-storage.mdx
+++ b/docs/utils/atom-with-storage.mdx
@@ -68,12 +68,12 @@ const TextBox = () => {
     <>
       <input value={text} onChange={(e) => setText(e.target.value)} />
       <button onClick={() => setText(RESET)}>Reset (to 'hello')</button>
-      <input value={text}
+      <input
+        value={text}
         onChange={(e) =>
           setText((prev) => (prev === 'reset' ? RESET : e.target.value))
-        }>
-        Reset value if input text === reset
-      </button>
+        }
+      />
     </>
   )
 }

--- a/src/utils/atomWithReset.ts
+++ b/src/utils/atomWithReset.ts
@@ -1,20 +1,26 @@
 import { atom } from 'jotai'
-import type { SetStateAction, WritableAtom } from 'jotai'
+import type { WritableAtom } from 'jotai'
 import { RESET } from './constants'
 
+type SetStateActionWithReset<Value> =
+  | Value
+  | typeof RESET
+  | ((prev: Value) => Value | typeof RESET)
+
 export function atomWithReset<Value>(initialValue: Value) {
-  type Update = SetStateAction<Value> | typeof RESET
+  type Update = SetStateActionWithReset<Value>
   const anAtom = atom<Value, Update>(initialValue, (get, set, update) => {
-    if (update === RESET) {
+    const nextValue =
+      typeof update === 'function'
+        ? (update as (prev: Value) => Value | typeof RESET)(get(anAtom))
+        : update
+
+    if (nextValue === RESET) {
       set(anAtom, initialValue)
-    } else {
-      set(
-        anAtom,
-        typeof update === 'function'
-          ? (update as (prev: Value) => Value)(get(anAtom))
-          : update
-      )
+      return
     }
+
+    set(anAtom, nextValue)
   })
   return anAtom as WritableAtom<Value, Update>
 }

--- a/src/utils/atomWithReset.ts
+++ b/src/utils/atomWithReset.ts
@@ -15,12 +15,7 @@ export function atomWithReset<Value>(initialValue: Value) {
         ? (update as (prev: Value) => Value | typeof RESET)(get(anAtom))
         : update
 
-    if (nextValue === RESET) {
-      set(anAtom, initialValue)
-      return
-    }
-
-    set(anAtom, nextValue)
+    set(anAtom, nextValue === RESET ? initialValue : nextValue)
   })
   return anAtom as WritableAtom<Value, Update>
 }

--- a/src/utils/atomWithStorage.ts
+++ b/src/utils/atomWithStorage.ts
@@ -6,6 +6,7 @@ type Unsubscribe = () => void
 
 type SetStateActionWithReset<Value> =
   | Value
+  | typeof RESET
   | ((prev: Value) => Value | typeof RESET)
 
 export interface AsyncStorage<Value> {
@@ -156,7 +157,7 @@ export function atomWithStorage<Value>(
 
   const anAtom = atom(
     (get) => get(baseAtom),
-    (get, set, update: SetStateActionWithReset<Value> | typeof RESET) => {
+    (get, set, update: SetStateActionWithReset<Value>) => {
       const newValue =
         typeof update === 'function'
           ? (update as (prev: Value) => Value | typeof RESET)(get(baseAtom))

--- a/src/utils/atomWithStorage.ts
+++ b/src/utils/atomWithStorage.ts
@@ -150,18 +150,18 @@ export function atomWithStorage<Value>(
   const anAtom = atom(
     (get) => get(baseAtom),
     (get, set, update: SetStateActionWithReset<Value>) => {
-      const newValue =
+      const nextValue =
         typeof update === 'function'
           ? (update as (prev: Value) => Value | typeof RESET)(get(baseAtom))
           : update
 
-      if (newValue === RESET) {
+      if (nextValue === RESET) {
         set(baseAtom, initialValue)
         return storage.removeItem(key)
       }
 
-      set(baseAtom, newValue)
-      return storage.setItem(key, newValue)
+      set(baseAtom, nextValue)
+      return storage.setItem(key, nextValue)
     }
   )
 

--- a/src/utils/atomWithStorage.ts
+++ b/src/utils/atomWithStorage.ts
@@ -89,32 +89,24 @@ export function atomWithStorage<Value>(
   key: string,
   initialValue: Value,
   storage: AsyncStorage<Value> & { delayInit: true }
-): WritableAtom<
-  Value,
-  SetStateActionWithReset<Value> | typeof RESET,
-  Promise<void>
->
+): WritableAtom<Value, SetStateActionWithReset<Value>, Promise<void>>
 
 export function atomWithStorage<Value>(
   key: string,
   initialValue: Value,
   storage: AsyncStorage<Value>
-): WritableAtom<
-  Promise<Value>,
-  SetStateActionWithReset<Value> | typeof RESET,
-  Promise<void>
->
+): WritableAtom<Promise<Value>, SetStateActionWithReset<Value>, Promise<void>>
 
 export function atomWithStorage<Value>(
   key: string,
   initialValue: Value,
   storage: SyncStorage<Value>
-): WritableAtom<Value, SetStateActionWithReset<Value> | typeof RESET>
+): WritableAtom<Value, SetStateActionWithReset<Value>>
 
 export function atomWithStorage<Value>(
   key: string,
   initialValue: Value
-): WritableAtom<Value, SetStateActionWithReset<Value> | typeof RESET>
+): WritableAtom<Value, SetStateActionWithReset<Value>>
 
 export function atomWithStorage<Value>(
   key: string,
@@ -188,7 +180,7 @@ export function atomWithHash<Value>(
     replaceState?: boolean
     subscribe?: (callback: () => void) => () => void
   }
-): WritableAtom<Value, SetStateActionWithReset<Value> | typeof RESET> {
+): WritableAtom<Value, SetStateActionWithReset<Value>> {
   const serialize = options?.serialize || JSON.stringify
   const deserialize = options?.deserialize || JSON.parse
   const subscribe =

--- a/tests/utils/atomWithStorage.test.tsx
+++ b/tests/utils/atomWithStorage.test.tsx
@@ -137,6 +137,9 @@ describe('with sync string storage', () => {
           <div>count: {count}</div>
           <button onClick={() => setCount((c) => c + 1)}>button</button>
           <button onClick={() => setCount(RESET)}>reset</button>
+          <button onClick={() => setCount((c) => (c === 2 ? RESET : c + 1))}>
+            conditional reset
+          </button>
         </>
       )
     }
@@ -154,6 +157,14 @@ describe('with sync string storage', () => {
     expect(storageData.count).toBe('11')
 
     fireEvent.click(getByText('reset'))
+    await findByText('count: 1')
+    expect(storageData.count).toBeUndefined()
+
+    fireEvent.click(getByText('button'))
+    await findByText('count: 2')
+    expect(storageData.count).toBe('2')
+
+    fireEvent.click(getByText('conditional reset'))
     await findByText('count: 1')
     expect(storageData.count).toBeUndefined()
   })
@@ -361,6 +372,47 @@ describe('atomWithHash', () => {
 
     fireEvent.click(getByText('reset'))
     await findByText('count: 1')
+    expect(window.location.hash).toEqual('')
+  })
+
+  it('returning reset from state dispatcher', async () => {
+    const isVisibleAtom = atomWithHash('isVisible', true)
+
+    const Counter = () => {
+      const [isVisible, setIsVisible] = useAtom(isVisibleAtom)
+      return (
+        <>
+          {isVisible && <div id="visible">visible</div>}
+          <button onClick={() => setIsVisible((prev) => !prev)}>button</button>
+          <button onClick={() => setIsVisible(RESET)}>reset</button>
+        </>
+      )
+    }
+
+    const { findByText, getByText, queryByText } = render(
+      <Provider>
+        <Counter />
+      </Provider>
+    )
+
+    await findByText('visible')
+
+    fireEvent.click(getByText('button'))
+
+    await waitFor(() => {
+      expect(queryByText('visible')).toBeNull()
+    })
+
+    expect(window.location.hash).toEqual('#isVisible=false')
+
+    fireEvent.click(getByText('button'))
+    await findByText('visible')
+    expect(window.location.hash).toEqual('#isVisible=true')
+
+    fireEvent.click(getByText('button'))
+
+    fireEvent.click(getByText('reset'))
+    await findByText('visible')
     expect(window.location.hash).toEqual('')
   })
 })

--- a/tests/utils/useResetAtom.test.tsx
+++ b/tests/utils/useResetAtom.test.tsx
@@ -57,7 +57,7 @@ it('atomWithReset resets to its first value', async () => {
   await findByText('count: 13')
 })
 
-it('atomWithReset with previous value conditional reset', async () => {
+it('atomWithReset reset based on previous value', async () => {
   const countAtom = atomWithReset(0)
 
   const Parent = () => {
@@ -69,7 +69,7 @@ it('atomWithReset with previous value conditional reset', async () => {
           onClick={() =>
             setValue((oldValue) => (oldValue === 3 ? RESET : oldValue + 1))
           }>
-          increment count with ceiling of 3
+          increment till 3, then reset
         </button>
       </>
     )
@@ -83,14 +83,14 @@ it('atomWithReset with previous value conditional reset', async () => {
 
   await findByText('count: 0')
 
-  fireEvent.click(getByText('increment count with ceiling of 3'))
+  fireEvent.click(getByText('increment till 3, then reset'))
   await findByText('count: 1')
-  fireEvent.click(getByText('increment count with ceiling of 3'))
+  fireEvent.click(getByText('increment till 3, then reset'))
   await findByText('count: 2')
-  fireEvent.click(getByText('increment count with ceiling of 3'))
+  fireEvent.click(getByText('increment till 3, then reset'))
   await findByText('count: 3')
 
-  fireEvent.click(getByText('increment count with ceiling of 3'))
+  fireEvent.click(getByText('increment till 3, then reset'))
   await findByText('count: 0')
 })
 

--- a/tests/utils/useResetAtom.test.tsx
+++ b/tests/utils/useResetAtom.test.tsx
@@ -57,6 +57,43 @@ it('atomWithReset resets to its first value', async () => {
   await findByText('count: 13')
 })
 
+it('atomWithReset with previous value conditional reset', async () => {
+  const countAtom = atomWithReset(0)
+
+  const Parent = () => {
+    const [count, setValue] = useAtom(countAtom)
+    return (
+      <>
+        <div>count: {count}</div>
+        <button
+          onClick={() =>
+            setValue((oldValue) => (oldValue === 3 ? RESET : oldValue + 1))
+          }>
+          increment count with ceiling of 3
+        </button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <Provider>
+      <Parent />
+    </Provider>
+  )
+
+  await findByText('count: 0')
+
+  fireEvent.click(getByText('increment count with ceiling of 3'))
+  await findByText('count: 1')
+  fireEvent.click(getByText('increment count with ceiling of 3'))
+  await findByText('count: 2')
+  fireEvent.click(getByText('increment count with ceiling of 3'))
+  await findByText('count: 3')
+
+  fireEvent.click(getByText('increment count with ceiling of 3'))
+  await findByText('count: 0')
+})
+
 it('atomWithReset through read-write atom', async () => {
   const primitiveAtom = atomWithReset(0)
   const countAtom = atom(


### PR DESCRIPTION
## Context
Closes #1335 

## Approach

- Created new type `StorageSetStateAction` which allows for the State setter's function to return `typeof RESET`
- Added conditional check to detect if returned `newValue` is `typeof RESET` after calling callback. If it is, run steps to reset storage

## Other Approaches considered
- Update `SetStateAction` callback union type from `type SetStateAction<Value> = Value | ((prev: Value) => Value)` to `type SetStateAction<Value> = Value | ((prev: Value) => Value) | typeof RESET` but this was cause affect all atom state setters. It seems only `atomWithStorage` / `atomWithHash` would benefit from this type, so I decided to create a type specifically for this util atom. 
    - If possible, maybe we can derive types from `SetStateAction`, but I am relatively new to typescript and do not know of a way to do this
    - An approach I tried with the mindset of reusing `SetStateAction`: https://github.com/austinwoon/jotai/pull/1 
        - There may be no good reason for this as `SetStateAction` signature should be stable, but this ensures if we do change `SetStateAction` signature in the future, `atomWithStorage` will catch lint errors if any.

## Tests
- Added to `atomWithStorage` tests by checking if conditional reset based on previous value works and that storage key clears as expected.
- Added to `atomWithHash` test by checking if element toggles as expected, and that url hash clears as expected