### PR TITLE
fix(urql): remove ad-hoc error handling

### DIFF
--- a/src/urql/atomWithQuery.ts
+++ b/src/urql/atomWithQuery.ts
@@ -97,9 +97,9 @@ export function atomWithQuery<Data, Variables extends object>(
         return
       }
       // TODO error handling
-      if (!isOperationResultWithData(result)) {
-        throw new Error('result does not have data')
-      }
+      // if (!isOperationResultWithData(result)) {
+      //   throw new Error('result does not have data')
+      // }
       if (resolve) {
         resolve(result)
         resolve = null
@@ -161,7 +161,7 @@ export function atomWithQuery<Data, Variables extends object>(
             throw new Error('query is paused')
           }
           const { args, client, subscriptionAtom, listener } = queryResult
-          listener(new Promise<never>(() => {})) // infinite pending
+          listener(new Promise<never>(() => { })) // infinite pending
           const newSubscription = pipe(
             client.query(args.query, args.variables, {
               ...(args.requestPolicy && { requestPolicy: args.requestPolicy }),

--- a/src/urql/atomWithSubscription.ts
+++ b/src/urql/atomWithSubscription.ts
@@ -72,9 +72,9 @@ export function atomWithSubscription<Data, Variables extends object>(
     let isMounted = false
     const listener = (result: OperationResult<Data, Variables>) => {
       // TODO error handling
-      if (!isOperationResultWithData(result)) {
-        throw new Error('result does not have data')
-      }
+      // if (!isOperationResultWithData(result)) {
+      //   throw new Error('result does not have data')
+      // }
       if (resolve) {
         if (!isMounted) {
           subscription?.unsubscribe()


### PR DESCRIPTION
Throwing an error makes it much harder to handle the error in application code. Returning the error instead in the atom value is much more ergonomic.

This also makes the behavior more consistent as some other places simply ignore the error.