### PR TITLE
docs: typo in documentation changed 'warp' to 'wrap'

### DIFF
--- a/docs/advanced-recipes/custom-useatom-hooks.mdx
+++ b/docs/advanced-recipes/custom-useatom-hooks.mdx
@@ -73,4 +73,4 @@ useFocusAtom(anAtom) {
 
 <CodeSandbox id="y5wef8" />
 
-Please note that in this case `keyFn` must be stable, either define outside render or warp with `useCallback`.
+Please note that in this case `keyFn` must be stable, either define outside render or wrap with `useCallback`.

--- a/docs/advanced-recipes/custom-useatom-hooks.mdx
+++ b/docs/advanced-recipes/custom-useatom-hooks.mdx
@@ -25,7 +25,7 @@ useSelectAtom(
 )
 ```
 
-Please note that in this case `keyFn` must be stable, either define outside render or warp with `useCallback`.
+Please note that in this case `keyFn` must be stable, either define outside render or wrap with `useCallback`.
 
 ### useFreezeAtom
 


### PR DESCRIPTION
fixed typo 