### PR TITLE
refactor(devtools): use useAtomsSnapshot in useAtomsDevtools

### DIFF
--- a/src/devtools/useAtomsDevtools.ts
+++ b/src/devtools/useAtomsDevtools.ts
@@ -1,13 +1,7 @@
-import { useCallback, useContext, useEffect, useRef, useState } from 'react'
+import { useContext, useEffect, useRef } from 'react'
 import { SECRET_INTERNAL_getScopeContext as getScopeContext } from 'jotai'
 import type { Atom, Scope } from '../core/atom'
-import {
-  DEV_GET_ATOM_STATE,
-  DEV_GET_MOUNTED,
-  DEV_GET_MOUNTED_ATOMS,
-  DEV_SUBSCRIBE_STATE,
-  RESTORE_ATOMS,
-} from '../core/store'
+import { DEV_SUBSCRIBE_STATE } from '../core/store'
 import { Message } from './types'
 import { useAtomsSnapshot } from './useAtomsSnapshot'
 import { useGotoAtomsSnapshot } from './useGotoAtomsSnapshot'
@@ -20,24 +14,6 @@ type AtomsSnapshot = Readonly<{
   values: AtomsValues
   dependents: AtomsDependents
 }>
-
-const isEqualAtomsValues = (left: AtomsValues, right: AtomsValues) =>
-  left.size === right.size &&
-  Array.from(left).every(([left, v]) => Object.is(right.get(left), v))
-
-const isEqualAtomsDependents = (
-  left: AtomsDependents,
-  right: AtomsDependents
-) =>
-  left.size === right.size &&
-  Array.from(left).every(([a, dLeft]) => {
-    const dRight = right.get(a)
-    return (
-      dRight &&
-      dLeft.size === dRight.size &&
-      Array.from(dLeft).every((d) => dRight.has(d))
-    )
-  })
 
 const atomToPrintable = (atom: AnyAtom) =>
   atom.debugLabel ? `${atom}:${atom.debugLabel}` : `${atom}`
@@ -79,7 +55,7 @@ export function useAtomsDevtools(
   }
   const { enabled, scope } = options || {}
   const ScopeContext = getScopeContext(scope)
-  const { s: store, w: versionedWrite } = useContext(ScopeContext)
+  const { s: store } = useContext(ScopeContext)
 
   let extension: typeof window['__REDUX_DEVTOOLS_EXTENSION__'] | false
 

--- a/src/devtools/useAtomsDevtools.ts
+++ b/src/devtools/useAtomsDevtools.ts
@@ -67,10 +67,6 @@ export function useAtomsDevtools(
     }
   }
 
-  if (!__DEV__ && enabled) {
-    return
-  }
-
   const atomsSnapshot = useAtomsSnapshot(scope)
   const goToSnapshot = useGotoAtomsSnapshot(scope)
 

--- a/src/devtools/useAtomsDevtools.ts
+++ b/src/devtools/useAtomsDevtools.ts
@@ -1,7 +1,5 @@
-import { useContext, useEffect, useRef } from 'react'
-import { SECRET_INTERNAL_getScopeContext as getScopeContext } from 'jotai'
+import { useEffect, useRef } from 'react'
 import type { Atom, Scope } from '../core/atom'
-import { DEV_SUBSCRIBE_STATE } from '../core/store'
 import { Message } from './types'
 import { useAtomsSnapshot } from './useAtomsSnapshot'
 import { useGotoAtomsSnapshot } from './useGotoAtomsSnapshot'
@@ -54,8 +52,6 @@ export function useAtomsDevtools(
     options = { scope: options }
   }
   const { enabled, scope } = options || {}
-  const ScopeContext = getScopeContext(scope)
-  const { s: store } = useContext(ScopeContext)
 
   let extension: typeof window['__REDUX_DEVTOOLS_EXTENSION__'] | false
 
@@ -69,10 +65,6 @@ export function useAtomsDevtools(
     if (__DEV__ && enabled) {
       console.warn('Please install/enable Redux devtools extension')
     }
-  }
-
-  if (extension && !store[DEV_SUBSCRIBE_STATE]) {
-    throw new Error('useAtomsDevtools can only be used in dev mode.')
   }
 
   if (!__DEV__ && enabled) {

--- a/src/devtools/useAtomsDevtools.ts
+++ b/src/devtools/useAtomsDevtools.ts
@@ -67,6 +67,7 @@ export function useAtomsDevtools(
     }
   }
 
+  // This an exception, we don't usually use utils in themselves!
   const atomsSnapshot = useAtomsSnapshot(scope)
   const goToSnapshot = useGotoAtomsSnapshot(scope)
 


### PR DESCRIPTION
Resolves #1356 

Since we have so common code between useAtomsDevtools and useAtomsSnapshot, we try to use the latter in the former. 

Note: This an exception, we don't usually use utils in themselves !