### PR TITLE
fix(utils): avoid catching storage error in atomWithStorage

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,7 @@ export { splitAtom } from './utils/splitAtom'
 export { atomWithDefault } from './utils/atomWithDefault'
 export { waitForAll } from './utils/waitForAll'
 export {
+  NO_STORAGE_VALUE,
   atomWithStorage,
   atomWithHash,
   createJSONStorage,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ export { splitAtom } from './utils/splitAtom'
 export { atomWithDefault } from './utils/atomWithDefault'
 export { waitForAll } from './utils/waitForAll'
 export {
-  NO_STORAGE_VALUE,
+  NO_STORAGE_VALUE as unstable_NO_STORAGE_VALUE,
   atomWithStorage,
   atomWithHash,
   createJSONStorage,

--- a/tests/utils/atomWithStorage.test.tsx
+++ b/tests/utils/atomWithStorage.test.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { useAtom } from 'jotai'
 import {
-  NO_STORAGE_VALUE,
+  unstable_NO_STORAGE_VALUE as NO_STORAGE_VALUE,
   RESET,
   atomWithHash,
   atomWithStorage,

--- a/tests/utils/atomWithStorage.test.tsx
+++ b/tests/utils/atomWithStorage.test.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { useAtom } from 'jotai'
 import {
+  NO_STORAGE_VALUE,
   RESET,
   atomWithHash,
   atomWithStorage,
@@ -18,7 +19,7 @@ describe('atomWithStorage (sync)', () => {
   const dummyStorage = {
     getItem: (key: string) => {
       if (!(key in storageData)) {
-        throw new Error('no value stored')
+        return NO_STORAGE_VALUE
       }
       return storageData[key] as number
     },
@@ -195,7 +196,7 @@ describe('atomWithStorage (async)', () => {
     getItem: async (key: string) => {
       await new Promise((r) => setTimeout(r, 100))
       if (!(key in asyncStorageData)) {
-        throw new Error('no value stored')
+        return NO_STORAGE_VALUE
       }
       return asyncStorageData[key] as number
     },
@@ -310,14 +311,12 @@ describe('atomWithStorage (async)', () => {
   })
 })
 
-describe('atomWithStorage (no storage) (#949)', () => {
-  it('can throw in createJSONStorage', async () => {
+describe('atomWithStorage (without localStorage) (#949)', () => {
+  it('createJSONStorage without localStorage', async () => {
     const countAtom = atomWithStorage(
       'count',
       1,
-      createJSONStorage(() => {
-        throw new Error('no storage')
-      })
+      createJSONStorage(() => undefined as any)
     )
 
     const Counter = () => {


### PR DESCRIPTION
close #1347 

I ended up with introducing a symbol and removing big try-catch completely.
(while I originally thought about throwing a symbol or something, returning a symbol should be cleaner.)

I had to fix a test for #949.
Also, did a tweak for `.subscribe` #1004, to work with non `defaultStorage`. (There was an issue/discussion which I don't remember.)