### PR TITLE
fix(utils/atomFamily): handle edge case with shouldRemove and custom equality function

### DIFF
--- a/src/utils/atomFamily.ts
+++ b/src/utils/atomFamily.ts
@@ -36,7 +36,7 @@ export function atomFamily<Param, AtomType extends Atom<unknown>>(
 
     if (item !== undefined) {
       if (shouldRemove?.(item[1], param)) {
-        atoms.delete(param)
+        createAtom.remove(param)
       } else {
         return item[0]
       }

--- a/tests/utils/atomFamily.test.tsx
+++ b/tests/utils/atomFamily.test.tsx
@@ -271,3 +271,25 @@ it('a derived atom from an async atomFamily (#351)', async () => {
   await new Promise((r) => setTimeout(r, 10))
   expect(commitCount).toBe(commitCountAfterMount + 2)
 })
+
+it('setShouldRemove with custom equality function', async () => {
+  const myFamily = atomFamily(
+    (num: { index: number }) => atom(num),
+    (l, r) => l.index === r.index
+  )
+  let firstTime = true
+  myFamily.setShouldRemove(() => {
+    if (firstTime) {
+      firstTime = false
+      return true
+    }
+    return false
+  })
+
+  const family1 = myFamily({ index: 0 })
+  const family2 = myFamily({ index: 0 })
+  const family3 = myFamily({ index: 0 })
+
+  expect(family1).not.toBe(family2)
+  expect(family2).toBe(family3)
+})


### PR DESCRIPTION
`shouldRemove` doesn't remove atoms correctly if `areEqual` is provided.
It's an edge case, but it can happen often if `createdAt` in `shouldRmove` is used and `param` isn't used.