### PR TITLE
refactor(devtools): silent useAtomsSnapshot/useGotoAtomsSnapshot in prod

### DIFF
--- a/docs/api/devtools.mdx
+++ b/docs/api/devtools.mdx
@@ -154,7 +154,7 @@ export default function App()  {
 
 ## useAtomsSnapshot
 
-⚠️ Note: This hook only works in a `process.env.NODE_ENV !== 'production'` environment.
+⚠️ Note: This hook only works in a `process.env.NODE_ENV !== 'production'` environment. And it returns a static empty value in production.
 
 `useAtomsSnapshot` takes a snapshot of the currently mounted atoms and their state.
 
@@ -197,7 +197,7 @@ const App = () => (
 
 ## useGotoAtomsSnapshot
 
-⚠️ Note: This hook only works in a `process.env.NODE_ENV !== 'production'` environment.
+⚠️ Note: This hook only works in a `process.env.NODE_ENV !== 'production'` environment. And it works like an empty function in the production environment.
 
 `useGotoAtomsSnapshot` will update the current Jotai state to match the passed snapshot.
 

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -46,7 +46,7 @@ export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
   }))
 
   useEffect(() => {
-    if (!__DEV__) return
+    if (!store[DEV_SUBSCRIBE_STATE]) return
 
     let prevValues: AtomsValues = new Map()
     let prevDependents: AtomsDependents = new Map()

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -55,8 +55,8 @@ export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
       const values: AtomsValues = new Map()
       const dependents: AtomsDependents = new Map()
       let hasNewInvalidatedAtoms = false
-      for (const atom of store[DEV_GET_MOUNTED_ATOMS]?.() || []) {
-        const atomState = store[DEV_GET_ATOM_STATE]?.(atom)
+      for (const atom of store[DEV_GET_MOUNTED_ATOMS]() || []) {
+        const atomState = store[DEV_GET_ATOM_STATE](atom)
         if (atomState) {
           if (!atomState.y) {
             if ('p' in atomState) {
@@ -72,7 +72,7 @@ export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
             values.set(atom, atomState.v)
           }
         }
-        const mounted = store[DEV_GET_MOUNTED]?.(atom)
+        const mounted = store[DEV_GET_MOUNTED](atom)
         if (mounted) {
           dependents.set(atom, mounted.t)
         }
@@ -93,7 +93,7 @@ export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
       invalidatedAtoms.clear()
       setAtomsSnapshot({ values, dependents })
     }
-    const unsubscribe = store[DEV_SUBSCRIBE_STATE]?.(callback)
+    const unsubscribe = store[DEV_SUBSCRIBE_STATE](callback)
     callback()
     return unsubscribe
   }, [store])

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -47,6 +47,7 @@ export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
 
   useEffect(() => {
     if (!__DEV__) return
+
     let prevValues: AtomsValues = new Map()
     let prevDependents: AtomsDependents = new Map()
     const invalidatedAtoms = new Set<AnyAtom>()

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -46,6 +46,7 @@ export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
   }))
 
   useEffect(() => {
+    if (!__DEV__) return
     let prevValues: AtomsValues = new Map()
     let prevDependents: AtomsDependents = new Map()
     const invalidatedAtoms = new Set<AnyAtom>()

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -35,12 +35,31 @@ const isEqualAtomsDependents = (
     )
   })
 
-export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
+type Options = {
+  scope?: Scope
+  enabled?: boolean
+}
+
+export function useAtomsSnapshot(options?: Options): AtomsSnapshot
+
+/*
+ * @deprecated Please use object options (DevtoolsOptions)
+ */
+export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot
+
+export function useAtomsSnapshot(options?: Options | Scope): AtomsSnapshot {
+  if (typeof options !== 'undefined' && typeof options !== 'object') {
+    console.warn('DEPRECATED [useAtomsSnapshot] use Options')
+    options = { scope: options }
+  }
+
+  const { enabled, scope } = options || {}
+
   const ScopeContext = getScopeContext(scope)
   const scopeContainer = useContext(ScopeContext)
   const store = scopeContainer.s
 
-  if (!store[DEV_SUBSCRIBE_STATE]) {
+  if (enabled && !store[DEV_SUBSCRIBE_STATE]) {
     throw new Error('useAtomsSnapshot can only be used in dev mode.')
   }
 
@@ -48,6 +67,10 @@ export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
     values: new Map(),
     dependents: new Map(),
   }))
+
+  if (!__DEV__ && enabled) {
+    return atomsSnapshot
+  }
 
   useEffect(() => {
     let prevValues: AtomsValues = new Map()

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -59,10 +59,6 @@ export function useAtomsSnapshot(options?: Options | Scope): AtomsSnapshot {
   const scopeContainer = useContext(ScopeContext)
   const store = scopeContainer.s
 
-  if (enabled && !store[DEV_SUBSCRIBE_STATE]) {
-    throw new Error('useAtomsSnapshot can only be used in dev mode.')
-  }
-
   const [atomsSnapshot, setAtomsSnapshot] = useState<AtomsSnapshot>(() => ({
     values: new Map(),
     dependents: new Map(),

--- a/src/devtools/useAtomsSnapshot.ts
+++ b/src/devtools/useAtomsSnapshot.ts
@@ -35,26 +35,7 @@ const isEqualAtomsDependents = (
     )
   })
 
-type Options = {
-  scope?: Scope
-  enabled?: boolean
-}
-
-export function useAtomsSnapshot(options?: Options): AtomsSnapshot
-
-/*
- * @deprecated Please use object options (DevtoolsOptions)
- */
-export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot
-
-export function useAtomsSnapshot(options?: Options | Scope): AtomsSnapshot {
-  if (typeof options !== 'undefined' && typeof options !== 'object') {
-    console.warn('DEPRECATED [useAtomsSnapshot] use Options')
-    options = { scope: options }
-  }
-
-  const { enabled, scope } = options || {}
-
+export function useAtomsSnapshot(scope?: Scope): AtomsSnapshot {
   const ScopeContext = getScopeContext(scope)
   const scopeContainer = useContext(ScopeContext)
   const store = scopeContainer.s
@@ -63,10 +44,6 @@ export function useAtomsSnapshot(options?: Options | Scope): AtomsSnapshot {
     values: new Map(),
     dependents: new Map(),
   }))
-
-  if (!__DEV__ && enabled) {
-    return atomsSnapshot
-  }
 
   useEffect(() => {
     let prevValues: AtomsValues = new Map()

--- a/src/devtools/useGotoAtomsSnapshot.ts
+++ b/src/devtools/useGotoAtomsSnapshot.ts
@@ -21,12 +21,10 @@ export function useGotoAtomsSnapshot(scope?: Scope) {
   const ScopeContext = getScopeContext(scope)
   const { s: store, w: versionedWrite } = useContext(ScopeContext)
 
-  if (!store[DEV_SUBSCRIBE_STATE]) {
-    throw new Error('useGotoAtomsSnapshot can only be used in dev mode.')
-  }
-
   return useCallback(
     (snapshot: AtomsSnapshot | DeprecatedIterableSnapshot) => {
+      if (!__DEV__) return
+
       const restoreAtoms = (
         values: Iterable<readonly [AnyAtom, AnyAtomValue]>
       ) => {

--- a/src/devtools/useGotoAtomsSnapshot.ts
+++ b/src/devtools/useGotoAtomsSnapshot.ts
@@ -23,7 +23,7 @@ export function useGotoAtomsSnapshot(scope?: Scope) {
 
   return useCallback(
     (snapshot: AtomsSnapshot | DeprecatedIterableSnapshot) => {
-      if (!__DEV__) return
+      if (!store[DEV_SUBSCRIBE_STATE]) return
 
       const restoreAtoms = (
         values: Iterable<readonly [AnyAtom, AnyAtomValue]>

--- a/tests/devtools/useAtomsSnapshot.test.tsx
+++ b/tests/devtools/useAtomsSnapshot.test.tsx
@@ -4,6 +4,7 @@ import { Provider, atom, useAtom } from 'jotai'
 import { useAtomsSnapshot } from 'jotai/devtools'
 
 it('[DEV-ONLY] should register newly added atoms', async () => {
+  __DEV__ = true
   const countAtom = atom(1)
   const petAtom = atom('cat')
 
@@ -44,6 +45,7 @@ it('[DEV-ONLY] should register newly added atoms', async () => {
 })
 
 it('[DEV-ONLY] should let you access atoms and their state', async () => {
+  __DEV__ = true
   const countAtom = atom(1)
   countAtom.debugLabel = 'countAtom'
   const petAtom = atom('cat')
@@ -79,6 +81,7 @@ it('[DEV-ONLY] should let you access atoms and their state', async () => {
 })
 
 it('[DEV-ONLY] should contain initial values', async () => {
+  __DEV__ = true
   const countAtom = atom(1)
   countAtom.debugLabel = 'countAtom'
   const petAtom = atom('cat')

--- a/tests/devtools/useGoToAtomsSnapshot.test.tsx
+++ b/tests/devtools/useGoToAtomsSnapshot.test.tsx
@@ -5,6 +5,7 @@ import type { Atom } from 'jotai'
 import { useAtomsSnapshot, useGotoAtomsSnapshot } from 'jotai/devtools'
 
 it('[DEV-ONLY] useGotoAtomsSnapshot should modify atoms snapshot', async () => {
+  __DEV__ = true
   const petAtom = atom('cat')
   const colorAtom = atom('blue')
 
@@ -51,6 +52,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should modify atoms snapshot', async () => {
 })
 
 it('[DEV-ONLY] useGotoAtomsSnapshot should work with derived atoms', async () => {
+  __DEV__ = true
   const priceAtom = atom(10)
   const taxAtom = atom((get) => get(priceAtom) * 0.2)
 
@@ -100,6 +102,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with derived atoms', async () =>
 })
 
 it('[DEV-ONLY] useGotoAtomsSnapshot should work with async derived atoms', async () => {
+  __DEV__ = true
   const priceAtom = atom(10)
   const taxAtom = atom(async (get) => {
     await new Promise((r) => setTimeout(r, 100))
@@ -156,6 +159,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with async derived atoms', async
 })
 
 it('[DEV-ONLY] useGotoAtomsSnapshot should work with original snapshot', async () => {
+  __DEV__ = true
   const priceAtom = atom(10)
   const taxAtom = atom((get) => get(priceAtom) * 0.2)
 
@@ -226,6 +230,7 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with original snapshot', async (
 })
 
 it('[DEV-ONLY] useGotoAtomsSnapshot should respect atom scope', async () => {
+  __DEV__ = true
   const scope = Symbol()
   const petAtom = atom('cat')
 


### PR DESCRIPTION
This PR tries to follow the footsteps of the useAtomsDevtools for useAtomsSnapshot/useGotoAtomsSnapshot!