### PR TITLE
fix(utils/atomWithStorage): Prevent createJSONStorage from adding subscribe method when window.addEventListener is not defined

### DIFF
--- a/src/utils/atomWithStorage.ts
+++ b/src/utils/atomWithStorage.ts
@@ -76,7 +76,7 @@ export function createJSONStorage<Value>(
       getStringStorage()?.setItem(key, JSON.stringify(newValue)),
     removeItem: (key) => getStringStorage()?.removeItem(key),
   }
-  if (typeof window !== 'undefined') {
+  if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
     storage.subscribe = (key, callback) => {
       const storageEventCallback = (e: StorageEvent) => {
         if (e.key === key && e.newValue) {

--- a/src/utils/atomWithStorage.ts
+++ b/src/utils/atomWithStorage.ts
@@ -76,7 +76,10 @@ export function createJSONStorage<Value>(
       getStringStorage()?.setItem(key, JSON.stringify(newValue)),
     removeItem: (key) => getStringStorage()?.removeItem(key),
   }
-  if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.addEventListener === 'function'
+  ) {
     storage.subscribe = (key, callback) => {
       const storageEventCallback = (e: StorageEvent) => {
         if (e.key === key && e.newValue) {

--- a/tests/utils/atomWithStorage.test.tsx
+++ b/tests/utils/atomWithStorage.test.tsx
@@ -339,6 +339,42 @@ describe('atomWithStorage (without localStorage) (#949)', () => {
   })
 })
 
+describe('atomWithStorage (in non-browser environment)', () => {
+  const asyncStorageData: Record<string, string> = {
+    count: '10',
+  }
+  const asyncDummyStorage = {
+    getItem: async (key: string) => {
+      await new Promise((r) => setTimeout(r, 100))
+      return asyncStorageData[key] as string
+    },
+    setItem: async (key: string, newValue: string) => {
+      await new Promise((r) => setTimeout(r, 100))
+      asyncStorageData[key] = newValue
+    },
+    removeItem: async (key: string) => {
+      await new Promise((r) => setTimeout(r, 100))
+      delete asyncStorageData[key]
+    },
+  }
+
+  const addEventListener = window.addEventListener
+
+  beforeAll(() => {
+    (window as any).addEventListener = undefined
+  })
+
+  afterAll(() => {
+    window.addEventListener = addEventListener;
+  })
+
+  it('createJSONStorage with undefined window.addEventListener', async () => {
+    const storage = createJSONStorage(() => asyncDummyStorage)
+
+    expect(storage.subscribe).toBeUndefined()
+  })
+})
+
 describe('atomWithHash', () => {
   it('simple count', async () => {
     const countAtom = atomWithHash('count', 1)

--- a/tests/utils/atomWithStorage.test.tsx
+++ b/tests/utils/atomWithStorage.test.tsx
@@ -361,11 +361,11 @@ describe('atomWithStorage (in non-browser environment)', () => {
   const addEventListener = window.addEventListener
 
   beforeAll(() => {
-    (window as any).addEventListener = undefined
+    ;(window as any).addEventListener = undefined
   })
 
   afterAll(() => {
-    window.addEventListener = addEventListener;
+    window.addEventListener = addEventListener
   })
 
   it('createJSONStorage with undefined window.addEventListener', async () => {


### PR DESCRIPTION
## Related Issues

Fixes #1373

## Summary

Added a condition to the if statement that already existed that, in addition to checking whether the global `window` object exists, also checks that `window.addEventListener` exists. Also added a simple test to prevent regression in the future.

I tested this in the project I first discovered the bug using yalc (since React Native doesn't support symlinks), and, other than a weird type issue where the `value` in `[value] = useAtom(atom)` shows as unknown, it doesn't throw an error now. I doubt my one-line change could have actually messed with the typings, but wanted to call it out for you to verify as the expert. 

Note: The beforeAll function in the added test looks a bit odd with the `;` in front but was added by prettier, probably to prevent the parentheses around `(window as any)` from accidentally being used to invoke a function. In order to set `addEventListener` as `undefined`, I had to cast `window` as `any`, which requires those parentheses. Alternatively, I could do something like the following if preferred:

```ts
const windowAny = window as any
windowAny.addEventListener = undefined
```

## Check List

- [x] `yarn run prettier` for formatting code and docs
