### PR TITLE
breaking(types,urql): update @urql/core v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "@types/react-dom": "^18.0.6",
     "@typescript-eslint/eslint-plugin": "^5.35.1",
     "@typescript-eslint/parser": "^5.35.1",
-    "@urql/core": "2.6.1",
+    "@urql/core": "^3.0.2",
     "benny": "^3.7.1",
     "concurrently": "^7.3.0",
     "downlevel-dts": "^0.10.0",

--- a/src/urql/atomWithMutation.ts
+++ b/src/urql/atomWithMutation.ts
@@ -1,4 +1,5 @@
 import type {
+  AnyVariables,
   Client,
   OperationContext,
   OperationResult,
@@ -8,13 +9,13 @@ import { atom } from 'jotai'
 import type { Getter } from 'jotai'
 import { clientAtom } from './clientAtom'
 
-type MutationAction<Data, Variables extends object> = {
-  variables?: Variables
+type MutationAction<Data, Variables extends AnyVariables> = {
+  variables: Variables
   context?: Partial<OperationContext>
   callback?: (result: OperationResult<Data, Variables>) => void
 }
 
-export function atomWithMutation<Data, Variables extends object>(
+export function atomWithMutation<Data, Variables extends AnyVariables>(
   createQuery: (get: Getter) => TypedDocumentNode<Data, Variables> | string,
   getClient: (get: Getter) => Client = (get) => get(clientAtom)
 ) {

--- a/src/urql/atomWithQuery.ts
+++ b/src/urql/atomWithQuery.ts
@@ -1,4 +1,5 @@
 import type {
+  AnyVariables,
   Client,
   OperationContext,
   OperationResult,
@@ -28,26 +29,26 @@ const isOperationResultWithData = <Data, Variables>(
 ): result is OperationResultWithData<Data, Variables> =>
   'data' in result && !result.error
 
-type QueryArgs<Data, Variables extends object> = {
+type QueryArgs<Data, Variables extends AnyVariables> = {
   query: TypedDocumentNode<Data, Variables> | string
-  variables?: Variables
+  variables: Variables
   requestPolicy?: RequestPolicy
   context?: Partial<OperationContext>
 }
 
-type QueryArgsWithPause<Data, Variables extends object> = QueryArgs<
+type QueryArgsWithPause<Data, Variables extends AnyVariables> = QueryArgs<
   Data,
   Variables
 > & {
   pause: boolean
 }
 
-export function atomWithQuery<Data, Variables extends object>(
+export function atomWithQuery<Data, Variables extends AnyVariables>(
   createQueryArgs: (get: Getter) => QueryArgs<Data, Variables>,
   getClient?: (get: Getter) => Client
 ): WritableAtom<OperationResultWithData<Data, Variables>, AtomWithQueryAction>
 
-export function atomWithQuery<Data, Variables extends object>(
+export function atomWithQuery<Data, Variables extends AnyVariables>(
   createQueryArgs: (get: Getter) => QueryArgsWithPause<Data, Variables>,
   getClient?: (get: Getter) => Client
 ): WritableAtom<
@@ -55,7 +56,7 @@ export function atomWithQuery<Data, Variables extends object>(
   AtomWithQueryAction
 >
 
-export function atomWithQuery<Data, Variables extends object>(
+export function atomWithQuery<Data, Variables extends AnyVariables>(
   createQueryArgs: (get: Getter) => QueryArgs<Data, Variables>,
   getClient: (get: Getter) => Client = (get) => get(clientAtom)
 ) {
@@ -128,7 +129,7 @@ export function atomWithQuery<Data, Variables extends object>(
           client.query(args.query, args.variables, {
             ...(args.requestPolicy && { requestPolicy: args.requestPolicy }),
             ...args.context,
-          }) as any, // FIXME can anyone fix typing without any?
+          }),
           subscribe(listener)
         )
         set(subscriptionAtom, subscription)
@@ -167,7 +168,7 @@ export function atomWithQuery<Data, Variables extends object>(
               ...(args.requestPolicy && { requestPolicy: args.requestPolicy }),
               ...args.context,
               ...action.opts,
-            }) as any, // FIXME can anyone fix typing without any?
+            }),
             subscribe(listener)
           )
           const oldSubscription = get(subscriptionAtom)

--- a/src/urql/atomWithSubscription.ts
+++ b/src/urql/atomWithSubscription.ts
@@ -1,4 +1,5 @@
 import type {
+  AnyVariables,
   Client,
   OperationContext,
   OperationResult,
@@ -21,32 +22,32 @@ const isOperationResultWithData = <Data, Variables>(
   result: OperationResult<Data, Variables>
 ): result is OperationResultWithData<Data, Variables> => 'data' in result
 
-type SubscriptionArgs<Data, Variables extends object> = {
+type SubscriptionArgs<Data, Variables extends AnyVariables> = {
   query: TypedDocumentNode<Data, Variables> | string
-  variables?: Variables
+  variables: Variables
   context?: Partial<OperationContext>
 }
 
 type SubscriptionArgsWithPause<
   Data,
-  Variables extends object
+  Variables extends AnyVariables
 > = SubscriptionArgs<Data, Variables> & {
   pause: boolean
 }
 
-export function atomWithSubscription<Data, Variables extends object>(
+export function atomWithSubscription<Data, Variables extends AnyVariables>(
   createSubscriptionArgs: (get: Getter) => SubscriptionArgs<Data, Variables>,
   getClient?: (get: Getter) => Client
 ): Atom<OperationResultWithData<Data, Variables>>
 
-export function atomWithSubscription<Data, Variables extends object>(
+export function atomWithSubscription<Data, Variables extends AnyVariables>(
   createSubscriptionArgs: (
     get: Getter
   ) => SubscriptionArgsWithPause<Data, Variables>,
   getClient?: (get: Getter) => Client
 ): Atom<OperationResultWithData<Data, Variables> | null>
 
-export function atomWithSubscription<Data, Variables extends object>(
+export function atomWithSubscription<Data, Variables extends AnyVariables>(
   createSubscriptionArgs: (get: Getter) => SubscriptionArgs<Data, Variables>,
   getClient: (get: Getter) => Client = (get) => get(clientAtom)
 ) {

--- a/tests/urql/atomWithMutation.test.tsx
+++ b/tests/urql/atomWithMutation.test.tsx
@@ -23,7 +23,7 @@ it('mutation basic test', async () => {
     () => clientMock
   )
   const mutateAtom = atom(null, (_get, set) => {
-    set(countAtom, {})
+    set(countAtom, { variables: {} })
   })
 
   const Counter = () => {

--- a/tests/urql/atomWithQuery.test.tsx
+++ b/tests/urql/atomWithQuery.test.tsx
@@ -32,6 +32,7 @@ it('query basic test', async () => {
   const countAtom = atomWithQuery<{ count: number }, Record<string, never>>(
     () => ({
       query: '{ count }',
+      variables: {},
     }),
     () => generateContinuousClient()
   )
@@ -118,6 +119,7 @@ it('query change client at runtime', async () => {
   const idAtom = atomWithQuery<{ id: string }, Record<string, never>>(
     () => ({
       query: '{ id }',
+      variables: {},
     }),
     (get) => get(clientAtom)
   )
@@ -169,6 +171,7 @@ it('pause test', async () => {
   const countAtom = atomWithQuery<{ count: number }, Record<string, never>>(
     (get) => ({
       query: '{ count }',
+      variables: {},
       pause: !get(enabledAtom),
     }),
     () => generateContinuousClient()
@@ -209,6 +212,7 @@ it('reexecute test', async () => {
   const countAtom = atomWithQuery<{ count: number }, Record<string, never>>(
     () => ({
       query: '{ count }',
+      variables: {},
     }),
     () => generateContinuousClient()
   )
@@ -250,6 +254,7 @@ it('query null client suspense', async () => {
   const idAtom = atomWithQuery<{ id: string }, Record<string, never>>(
     () => ({
       query: '{ id }',
+      variables: {},
     }),
     (get) => get(clientAtom) as Client
   )

--- a/tests/urql/atomWithSubscription.test.tsx
+++ b/tests/urql/atomWithSubscription.test.tsx
@@ -25,6 +25,7 @@ it('subscription basic test', async () => {
       query: 'subscription Test { count }' as unknown as TypedDocumentNode<{
         count: number
       }>,
+      variables: {},
     }),
     () => clientMock
   )
@@ -60,6 +61,7 @@ it('subscription change client at runtime', async () => {
         id: string
         count: number
       }>,
+      variables: {},
     }),
     (get) => get(clientAtom)
   )
@@ -123,6 +125,7 @@ it('pause test', async () => {
       query: 'subscription Test { count }' as unknown as TypedDocumentNode<{
         count: number
       }>,
+      variables: {},
       pause: !get(enabledAtom),
     }),
     () => clientMock
@@ -168,6 +171,7 @@ it('null client suspense', async () => {
         id: string
         count: number
       }>,
+      variables: {},
     }),
     (get) => get(clientAtom) as Client
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1864,13 +1864,13 @@
     "@typescript-eslint/types" "5.35.1"
     eslint-visitor-keys "^3.3.0"
 
-"@urql/core@2.6.1":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@urql/core/-/core-2.6.1.tgz#c10ee972c5e81df6d7bf1e778ef1b5d30e2906e5"
-  integrity sha512-gYrEHy3tViJhwIhauK6MIf2Qp09QTsgNHZRd0n71rS+hF6gdwjspf1oKljl4m25+272cJF7fPjBUGmjaiEr7Kg==
+"@urql/core@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@urql/core/-/core-3.0.2.tgz#91008bc112000dd42c5260142e4eed7901def6bd"
+  integrity sha512-TRpQOdt1Mtpt/EgPlFCx9Aqc3TbHtzH3yj8pJ9yjSUKT4slRyy+ofMQ8yx50oZzZjAOswF02zBRwnxsZANb35A==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.1"
-    wonka "^4.0.14"
+    wonka "^6.0.0"
 
 abab@^2.0.6:
   version "2.0.6"
@@ -5519,11 +5519,6 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
-
-wonka@^4.0.14:
-  version "4.0.15"
-  resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.15.tgz#9aa42046efa424565ab8f8f451fcca955bf80b89"
-  integrity sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg==
 
 wonka@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
close #1368 

This is a breaking change in `jotai/urql` for TypeScript users.
For JavaScript users, it wouldn't be breaking.
See also: https://github.com/FormidableLabs/urql/pull/2607
