### PR TITLE
chore(tests): enable StrictMode as much as possible

### DIFF
--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -11,7 +11,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react'
 import { unstable_batchedUpdates } from 'react-dom'
 import { atom, useAtom } from 'jotai'
 import type { PrimitiveAtom, WritableAtom } from 'jotai'
-import { getTestProvider } from './testUtils'
+import { StrictModeUnlessVersionedWrite, getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()
 
@@ -97,9 +97,11 @@ it('uses a primitive atom', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -125,9 +127,11 @@ it('uses a read-only derived atom', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -161,9 +165,11 @@ it('uses a read-write derived atom', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -203,10 +209,12 @@ it('uses a write-only derived atom', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Counter />
-      <Control />
-    </Provider>
+    <>
+      <Provider>
+        <Counter />
+        <Control />
+      </Provider>
+    </>
   )
 
   await waitFor(() => {
@@ -251,11 +259,13 @@ it('only re-renders if value has changed', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Counter countAtom={count1Atom} name="count1" />
-      <Counter countAtom={count2Atom} name="count2" />
-      <Product />
-    </Provider>
+    <>
+      <Provider>
+        <Counter countAtom={count1Atom} name="count1" />
+        <Counter countAtom={count2Atom} name="count2" />
+        <Product />
+      </Provider>
+    </>
   )
 
   await waitFor(() => {
@@ -303,9 +313,11 @@ it('re-renders a time delayed derived atom with the same initial value (#947)', 
   }
 
   const { findByText } = render(
-    <Provider>
-      <App />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <App />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('2')
@@ -333,11 +345,13 @@ it('works with async get', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </>
   )
 
   await findByText('loading')
@@ -374,11 +388,13 @@ it('works with async get without setTimeout', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -418,9 +434,11 @@ it('uses atoms with tree dependencies', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <>
+      <Provider>
+        <Counter />
+      </Provider>
+    </>
   )
 
   await findByText('commits: 1, count: 0')
@@ -493,9 +511,11 @@ it('uses an async write-only atom', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <>
+      <Provider>
+        <Counter />
+      </Provider>
+    </>
   )
 
   await findByText('commits: 1, count: 0')
@@ -524,9 +544,11 @@ it('uses a writable atom without read function', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 1')
@@ -547,9 +569,11 @@ it('can write an atom value on useEffect', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <>
+      <Provider>
+        <Counter />
+      </Provider>
+    </>
   )
 
   await findByText('count: 1')
@@ -581,9 +605,11 @@ it('can write an atom value on useEffect in children', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <>
+      <Provider>
+        <Counter />
+      </Provider>
+    </>
   )
 
   await findByText('count: 2')
@@ -614,9 +640,11 @@ it('only invoke read function on use atom', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <>
+      <Provider>
+        <Counter />
+      </Provider>
+    </>
   )
 
   await findByText('commits: 1, count: 0, readCount: 1, doubled: 0')
@@ -659,9 +687,11 @@ it('uses a read-write derived atom with two primitive atoms', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('countA: 0, countB: 0, sum: 0')
@@ -702,9 +732,11 @@ it('updates a derived atom in useEffect with two primitive atoms', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <>
+      <Provider>
+        <Counter />
+      </Provider>
+    </>
   )
 
   await findByText('countA: 1, countB: 1, sum: 2')
@@ -739,9 +771,11 @@ it('updates two atoms in child useEffect', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <>
+      <Provider>
+        <Counter />
+      </Provider>
+    </>
   )
 
   await waitFor(() => {
@@ -780,9 +814,11 @@ it('set atom right after useEffect (#208)', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 2')
@@ -815,9 +851,11 @@ it('changes atom from parent (#273, #275)', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <App />
-    </Provider>
+    <>
+      <Provider>
+        <App />
+      </Provider>
+    </>
   )
 
   await findByText('commits: 1, id: a')
@@ -855,9 +893,11 @@ it('should be able to use a double derived atom twice and useEffect (#373)', asy
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <App />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <App />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0,0,0')
@@ -916,11 +956,13 @@ it('async chain for multiple sync and async atoms (#443)', async () => {
     )
   }
   const { findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -949,9 +991,11 @@ it('sync re-renders with useState re-renders (#827)', async () => {
     )
   }
   const { findByText, getByText } = render(
-    <Provider>
-      <App />
-    </Provider>
+    <>
+      <Provider>
+        <App />
+      </Provider>
+    </>
   )
 
   await findByText('commits: 1')
@@ -981,9 +1025,11 @@ it('chained derive atom with onMount and useEffect (#897)', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictModeUnlessVersionedWrite>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictModeUnlessVersionedWrite>
   )
 
   await findByText('count: 1')
@@ -1009,9 +1055,11 @@ it('onMount is not called when atom value is accessed from writeGetter in derive
   }
 
   render(
-    <Provider>
-      <App />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <App />
+      </Provider>
+    </StrictMode>
   )
 
   expect(onMount).not.toBeCalled()
@@ -1037,9 +1085,11 @@ it('useAtom returns consistent value with input with changing atoms (#1235)', as
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')

--- a/tests/dependency.test.tsx
+++ b/tests/dependency.test.tsx
@@ -1,7 +1,7 @@
-import { Suspense, useEffect, useRef, useState } from 'react'
+import { StrictMode, Suspense, useEffect, useRef, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { getTestProvider } from './testUtils'
+import { StrictModeUnlessVersionedWrite, getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()
 
@@ -34,9 +34,11 @@ it('works with 2 level dependencies', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <>
+      <Provider>
+        <Counter />
+      </Provider>
+    </>
   )
 
   await findByText('commits: 1, count: 1, doubled: 2, tripled: 6')
@@ -66,11 +68,13 @@ it('works a primitive atom and a dependent async atom', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -125,9 +129,11 @@ it('should keep an atom value even if unmounted', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -188,9 +194,11 @@ it('should keep a dependent atom value even if unmounted', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('derived: 0')
@@ -230,10 +238,12 @@ it('should bail out updating if not changed', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Counter />
-      <DerivedCounter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+        <DerivedCounter />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -285,10 +295,12 @@ it('should bail out updating if not changed, 2 level', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Counter />
-      <DerivedCounter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+        <DerivedCounter />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -334,9 +346,11 @@ it('derived atom to update base atom in callback', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <>
+      <Provider>
+        <Counter />
+      </Provider>
+    </>
   )
 
   await findByText('commits: 1, count: 1, doubled: 2')
@@ -364,9 +378,11 @@ it('can read sync derived atom in write without initializing', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 1')
@@ -415,9 +431,11 @@ it('can remount atoms with dependency (#490)', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -496,9 +514,11 @@ it('can remount atoms with intermediate atom', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -579,9 +599,11 @@ it('can update dependents with useEffect (#512)', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictModeUnlessVersionedWrite>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictModeUnlessVersionedWrite>
   )
 
   await waitFor(() => {
@@ -628,10 +650,12 @@ it('update unmounted atom with intermediate atom', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <DerivedCounter />
-      <Control />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <DerivedCounter />
+        <Control />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('derived: 2')
@@ -673,10 +697,12 @@ it('Should bail for derived sync chains (#877)', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Input />
-      <ForceValue />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Input />
+        <ForceValue />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('My very long data')
@@ -718,12 +744,14 @@ it('Should bail for derived async chains (#877)', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Input />
-        <ForceValue />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Input />
+          <ForceValue />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('My very long data')
@@ -768,9 +796,11 @@ it('update correctly with async updates (#1250)', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <App />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <App />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {

--- a/tests/devtools/useAtomDevtools.test.tsx
+++ b/tests/devtools/useAtomDevtools.test.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react'
+import { StrictMode, Suspense } from 'react'
 import { act, fireEvent, render } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
 import { useAtomDevtools } from 'jotai/devtools'
@@ -46,9 +46,11 @@ it('[DEV-ONLY] connects to the extension by initializing', () => {
     )
   }
   render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   expect(extension.init).toHaveBeenLastCalledWith(0)
@@ -81,9 +83,11 @@ describe('If there is no extension installed...', () => {
     __DEV__ = false
     expect(() => {
       render(
-        <Provider>
-          <Counter />
-        </Provider>
+        <StrictMode>
+          <Provider>
+            <Counter />
+          </Provider>
+        </StrictMode>
       )
     }).not.toThrow()
   })
@@ -111,9 +115,11 @@ describe('If there is no extension installed...', () => {
     console.warn = jest.fn()
 
     render(
-      <Provider>
-        <Counter enabled={true} />
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Counter enabled={true} />
+        </Provider>
+      </StrictMode>
     )
 
     expect(console.warn).not.toHaveBeenLastCalledWith(
@@ -129,9 +135,11 @@ describe('If there is no extension installed...', () => {
     const consoleWarn = jest.spyOn(console, 'warn')
 
     render(
-      <Provider>
-        <Counter />
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Counter />
+        </Provider>
+      </StrictMode>
     )
     expect(consoleWarn).not.toBeCalled()
 
@@ -156,9 +164,11 @@ it('[DEV-ONLY] updating state should call devtools.send', async () => {
 
   extension.send.mockClear()
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   expect(extension.send).toBeCalledTimes(0)
@@ -188,11 +198,13 @@ describe('when it receives an message of type...', () => {
 
     extension.send.mockClear()
     const { getByText, findByText } = render(
-      <Provider>
-        <Suspense fallback={'loading'}>
-          <Counter />
-        </Suspense>
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Suspense fallback={'loading'}>
+            <Counter />
+          </Suspense>
+        </Provider>
+      </StrictMode>
     )
 
     expect(extension.send).toBeCalledTimes(0)
@@ -227,9 +239,11 @@ describe('when it receives an message of type...', () => {
 
       extension.send.mockClear()
       const { getByText, findByText } = render(
-        <Provider>
-          <Counter />
-        </Provider>
+        <StrictMode>
+          <Provider>
+            <Counter />
+          </Provider>
+        </StrictMode>
       )
 
       expect(extension.send).toBeCalledTimes(0)
@@ -265,9 +279,11 @@ describe('when it receives an message of type...', () => {
 
       extension.send.mockClear()
       const { getByText, findByText } = render(
-        <Provider>
-          <Counter />
-        </Provider>
+        <StrictMode>
+          <Provider>
+            <Counter />
+          </Provider>
+        </StrictMode>
       )
 
       const nextLiftedState = {
@@ -307,9 +323,11 @@ describe('when it receives an message of type...', () => {
 
         extension.send.mockClear()
         const { getByText, findByText } = render(
-          <Provider>
-            <Counter />
-          </Provider>
+          <StrictMode>
+            <Provider>
+              <Counter />
+            </Provider>
+          </StrictMode>
         )
 
         expect(extension.send).toBeCalledTimes(0)

--- a/tests/devtools/useAtomsSnapshot.test.tsx
+++ b/tests/devtools/useAtomsSnapshot.test.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { StrictMode, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Provider, atom, useAtom } from 'jotai'
 import { useAtomsSnapshot } from 'jotai/devtools'
@@ -33,10 +33,12 @@ it('[DEV-ONLY] should register newly added atoms', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <DisplayCount />
-      <RegisteredAtomsCount />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <DisplayCount />
+        <RegisteredAtomsCount />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('atom count: 1')
@@ -70,10 +72,12 @@ it('[DEV-ONLY] should let you access atoms and their state', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Displayer />
-      <SimpleDevtools />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Displayer />
+        <SimpleDevtools />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('countAtom: 1')
@@ -106,14 +110,16 @@ it('[DEV-ONLY] should contain initial values', async () => {
   }
 
   const { findByText } = render(
-    <Provider
-      initialValues={[
-        [countAtom, 42],
-        [petAtom, 'dog'],
-      ]}>
-      <Displayer />
-      <SimpleDevtools />
-    </Provider>
+    <StrictMode>
+      <Provider
+        initialValues={[
+          [countAtom, 42],
+          [petAtom, 'dog'],
+        ]}>
+        <Displayer />
+        <SimpleDevtools />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('countAtom: 42')
@@ -158,10 +164,12 @@ it('[DEV-ONLY] conditional dependencies + updating state should call devtools.se
   }
 
   const { getByText } = render(
-    <Provider>
-      <App />
-      <SimpleDevtools />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <App />
+        <SimpleDevtools />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {

--- a/tests/devtools/useGoToAtomsSnapshot.test.tsx
+++ b/tests/devtools/useGoToAtomsSnapshot.test.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useRef } from 'react'
+import { StrictMode, Suspense, useEffect, useRef } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Provider, atom, useAtom } from 'jotai'
 import type { Atom } from 'jotai'
@@ -37,10 +37,12 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should modify atoms snapshot', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <DisplayAtoms />
-      <UpdateSnapshot />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <DisplayAtoms />
+        <UpdateSnapshot />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('cat')
@@ -83,10 +85,12 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with derived atoms', async () =>
   }
 
   const { getByText } = render(
-    <Provider>
-      <DisplayPrice />
-      <UpdateSnapshot />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <DisplayPrice />
+        <UpdateSnapshot />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -136,12 +140,14 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with async derived atoms', async
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <DisplayPrice />
-        <UpdateSnapshot />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <DisplayPrice />
+          <UpdateSnapshot />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -205,10 +211,12 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should work with original snapshot', async (
   }
 
   const { getByText } = render(
-    <Provider>
-      <DisplayPrice />
-      <UpdateSnapshot />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <DisplayPrice />
+        <UpdateSnapshot />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -255,10 +263,12 @@ it('[DEV-ONLY] useGotoAtomsSnapshot should respect atom scope', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <DisplayAtoms />
-      <UpdateSnapshot />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <DisplayAtoms />
+        <UpdateSnapshot />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('cat')

--- a/tests/error.test.tsx
+++ b/tests/error.test.tsx
@@ -1,4 +1,4 @@
-import { Component, Suspense, useEffect, useState } from 'react'
+import { Component, StrictMode, Suspense, useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
@@ -61,11 +61,13 @@ it('can throw an initial error in read function', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <ErrorBoundary>
-        <Counter />
-      </ErrorBoundary>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <ErrorBoundary>
+          <Counter />
+        </ErrorBoundary>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('errored')
@@ -93,11 +95,13 @@ it('can throw an error in read function', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <ErrorBoundary>
-        <Counter />
-      </ErrorBoundary>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <ErrorBoundary>
+          <Counter />
+        </ErrorBoundary>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('no error')
@@ -122,11 +126,13 @@ it('can throw an initial chained error in read function', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <ErrorBoundary>
-        <Counter />
-      </ErrorBoundary>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <ErrorBoundary>
+          <Counter />
+        </ErrorBoundary>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('errored')
@@ -155,11 +161,13 @@ it('can throw a chained error in read function', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <ErrorBoundary>
-        <Counter />
-      </ErrorBoundary>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <ErrorBoundary>
+          <Counter />
+        </ErrorBoundary>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('no error')
@@ -183,13 +191,15 @@ it('can throw an initial error in async read function', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <ErrorBoundary>
-        <Suspense fallback={null}>
-          <Counter />
-        </Suspense>
-      </ErrorBoundary>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <ErrorBoundary>
+          <Suspense fallback={null}>
+            <Counter />
+          </Suspense>
+        </ErrorBoundary>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('errored')
@@ -217,13 +227,15 @@ it('can throw an error in async read function', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <ErrorBoundary>
-        <Suspense fallback={null}>
-          <Counter />
-        </Suspense>
-      </ErrorBoundary>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <ErrorBoundary>
+          <Suspense fallback={null}>
+            <Counter />
+          </Suspense>
+        </ErrorBoundary>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('no error')
@@ -260,9 +272,11 @@ itSkipIfVersionedWrite('can throw an error in write function', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('no error')
@@ -302,11 +316,13 @@ itSkipIfVersionedWrite(
     }
 
     const { getByText, findByText } = render(
-      <Provider>
-        <Suspense fallback={null}>
-          <Counter />
-        </Suspense>
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Suspense fallback={null}>
+            <Counter />
+          </Suspense>
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('no error')
@@ -355,9 +371,11 @@ itSkipIfVersionedWrite(
     }
 
     const { getByText, findByText } = render(
-      <Provider>
-        <Counter />
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Counter />
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('no error')
@@ -390,11 +408,13 @@ itSkipIfVersionedWrite('throws an error while updating in effect', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <ErrorBoundary>
-        <Counter />
-      </ErrorBoundary>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <ErrorBoundary>
+          <Counter />
+        </ErrorBoundary>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('no error')
@@ -437,11 +457,13 @@ describe('throws an error while updating in effect cleanup', () => {
 
   itSkipIfVersionedWrite('[DEV-ONLY] single setCount', async () => {
     const { getByText, findByText } = render(
-      <Provider>
-        <ErrorBoundary>
-          <Main />
-        </ErrorBoundary>
-      </Provider>
+      <>
+        <Provider>
+          <ErrorBoundary>
+            <Main />
+          </ErrorBoundary>
+        </Provider>
+      </>
     )
 
     await findByText('no error')
@@ -459,11 +481,13 @@ describe('throws an error while updating in effect cleanup', () => {
     doubleSetCount = true
 
     const { getByText, findByText } = render(
-      <Provider>
-        <ErrorBoundary>
-          <Main />
-        </ErrorBoundary>
-      </Provider>
+      <>
+        <Provider>
+          <ErrorBoundary>
+            <Main />
+          </ErrorBoundary>
+        </Provider>
+      </>
     )
 
     await findByText('no error')
@@ -508,12 +532,14 @@ describe('error recovery', () => {
     }
 
     const { getByText, findByText } = render(
-      <Provider>
-        <Counter />
-        <ErrorBoundary>
-          <Display />
-        </ErrorBoundary>
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Counter />
+          <ErrorBoundary>
+            <Display />
+          </ErrorBoundary>
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('errored')
@@ -541,14 +567,16 @@ describe('error recovery', () => {
     }
 
     const { getByText, findByText } = render(
-      <Provider>
-        <Counter />
-        <ErrorBoundary>
-          <Suspense fallback={null}>
-            <Display />
-          </Suspense>
-        </ErrorBoundary>
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Counter />
+          <ErrorBoundary>
+            <Suspense fallback={null}>
+              <Display />
+            </Suspense>
+          </ErrorBoundary>
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('errored')

--- a/tests/immer/atomWithImmer.test.tsx
+++ b/tests/immer/atomWithImmer.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { useAtom } from 'jotai'
 import { atomWithImmer } from 'jotai/immer'
@@ -24,9 +25,11 @@ it('atomWithImmer with useAtom', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -53,9 +56,11 @@ it('atomWithImmer with WritableAtom<Value, Value> signature', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')

--- a/tests/immer/useImmerAtom.test.tsx
+++ b/tests/immer/useImmerAtom.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom } from 'jotai'
 import { atomWithImmer, useImmerAtom, withImmer } from 'jotai/immer'
@@ -24,9 +25,11 @@ it('useImmerAtom with regular atom', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -57,9 +60,11 @@ it('useImmerAtom with immer atom', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -91,9 +96,11 @@ it('useImmerAtom with derived immer atom', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')

--- a/tests/immer/withImmer.test.tsx
+++ b/tests/immer/withImmer.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
 import { withImmer } from 'jotai/immer'
@@ -24,9 +25,11 @@ it('withImmer derived atom with useAtom', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -61,9 +64,11 @@ it('withImmer derived atom with useAtom + scope', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider scope={scope}>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider scope={scope}>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0 0')
@@ -90,9 +95,11 @@ it('withImmer derived atom with WritableAtom<Value, Value> signature', async () 
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')

--- a/tests/items.test.tsx
+++ b/tests/items.test.tsx
@@ -1,4 +1,3 @@
-import { StrictMode } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
 import type { PrimitiveAtom } from 'jotai'
@@ -63,11 +62,11 @@ it('remove an item, then add another', async () => {
   }
 
   const { getByText, findByText } = render(
-    <StrictMode>
+    <StrictModeUnlessVersionedWrite>
       <Provider>
         <List />
       </Provider>
-    </StrictMode>
+    </StrictModeUnlessVersionedWrite>
   )
 
   fireEvent.click(getByText('Add'))

--- a/tests/items.test.tsx
+++ b/tests/items.test.tsx
@@ -1,7 +1,8 @@
+import { StrictMode } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
 import type { PrimitiveAtom } from 'jotai'
-import { getTestProvider } from './testUtils'
+import { StrictModeUnlessVersionedWrite, getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()
 
@@ -62,9 +63,11 @@ it('remove an item, then add another', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <List />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <List />
+      </Provider>
+    </StrictMode>
   )
 
   fireEvent.click(getByText('Add'))
@@ -191,9 +194,11 @@ it('add an item with filtered list', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <List />
-    </Provider>
+    <StrictModeUnlessVersionedWrite>
+      <Provider>
+        <List />
+      </Provider>
+    </StrictModeUnlessVersionedWrite>
   )
 
   fireEvent.click(getByText('Checked'))

--- a/tests/onmount.test.tsx
+++ b/tests/onmount.test.tsx
@@ -1,7 +1,7 @@
-import { Suspense, useState } from 'react'
+import { StrictMode, Suspense, useState } from 'react'
 import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
-import { getTestProvider } from './testUtils'
+import { StrictModeUnlessVersionedWrite, getTestProvider } from './testUtils'
 
 const Provider = getTestProvider()
 
@@ -21,9 +21,11 @@ it('one atom, one effect', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <>
+      <Provider>
+        <Counter />
+      </Provider>
+    </>
   )
 
   await findByText('count: 1')
@@ -61,9 +63,11 @@ it('two atoms, one each', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <>
+      <Provider>
+        <Counter />
+      </Provider>
+    </>
   )
 
   await waitFor(() => {
@@ -99,9 +103,11 @@ it('one derived atom, one onMount', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <>
+      <Provider>
+        <Counter />
+      </Provider>
+    </>
   )
 
   await findByText('count: 1')
@@ -135,9 +141,11 @@ it('mount/unmount test', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Display />
-    </Provider>
+    <>
+      <Provider>
+        <Display />
+      </Provider>
+    </>
   )
 
   expect(onMountFn).toBeCalledTimes(1)
@@ -187,9 +195,11 @@ it('one derived atom, one onMount for the derived one, and one for the regular a
   }
 
   const { getByText } = render(
-    <Provider>
-      <Display />
-    </Provider>
+    <>
+      <Provider>
+        <Display />
+      </Provider>
+    </>
   )
   expect(derivedOnMountFn).toBeCalledTimes(1)
   expect(derivedOnUnMountFn).toBeCalledTimes(0)
@@ -264,9 +274,11 @@ it('mount/unMount order', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Display />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Display />
+      </Provider>
+    </StrictMode>
   )
   expect(committed).toEqual([0, 0])
 
@@ -328,11 +340,13 @@ it('mount/unmount test with async atom', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Display />
-      </Suspense>
-    </Provider>
+    <>
+      <Provider>
+        <Suspense fallback="loading">
+          <Display />
+        </Suspense>
+      </Provider>
+    </>
   )
 
   await findByText('loading')
@@ -387,9 +401,11 @@ it('subscription usage test', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Display />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Display />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 10')
@@ -454,9 +470,11 @@ it('subscription in base atom test', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictModeUnlessVersionedWrite>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictModeUnlessVersionedWrite>
   )
 
   await findByText('count: 10')
@@ -508,11 +526,13 @@ it('create atom with onMount in async get', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictModeUnlessVersionedWrite>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictModeUnlessVersionedWrite>
   )
 
   await findByText('count: 10')

--- a/tests/optics/focus-lens.test.tsx
+++ b/tests/optics/focus-lens.test.tsx
@@ -1,5 +1,5 @@
-import { Suspense } from 'react'
-import * as rtl from '@testing-library/react'
+import { StrictMode, Suspense } from 'react'
+import { fireEvent, render } from '@testing-library/react'
 import * as O from 'optics-ts'
 import { atom, useAtom } from 'jotai'
 import type { SetStateAction } from 'jotai'
@@ -27,24 +27,26 @@ it('basic derivation using focus works', async () => {
     )
   }
 
-  const { getByText, findByText } = rtl.render(
-    <Provider>
-      <Counter />
-    </Provider>
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
   await findByText('bigAtom: {"a":0}')
 
-  rtl.fireEvent.click(getByText('incr'))
+  fireEvent.click(getByText('incr'))
   await findByText('count: 1')
   await findByText('bigAtom: {"a":1}')
 
-  rtl.fireEvent.click(getByText('incr'))
+  fireEvent.click(getByText('incr'))
   await findByText('count: 2')
   await findByText('bigAtom: {"a":2}')
 
-  rtl.fireEvent.click(getByText('set zero'))
+  fireEvent.click(getByText('set zero'))
   await findByText('count: 0')
   await findByText('bigAtom: {"a":0}')
 })
@@ -65,16 +67,18 @@ it('focus on an atom works', async () => {
     )
   }
 
-  const { getByText, findByText } = rtl.render(
-    <Provider>
-      <Counter />
-    </Provider>
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
   await findByText('bigAtom: {"a":0}')
 
-  rtl.fireEvent.click(getByText('button'))
+  fireEvent.click(getByText('button'))
   await findByText('count: 1')
   await findByText('bigAtom: {"a":1}')
 })
@@ -104,27 +108,29 @@ it('double-focus on an atom works', async () => {
     )
   }
 
-  const { getByText, findByText } = rtl.render(
-    <Provider>
-      <Counter />
-    </Provider>
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('bigAtom: {"a":{"b":0}}')
   await findByText('atomA: {"b":0}')
   await findByText('atomB: 0')
 
-  rtl.fireEvent.click(getByText('inc bigAtom'))
+  fireEvent.click(getByText('inc bigAtom'))
   await findByText('bigAtom: {"a":{"b":1}}')
   await findByText('atomA: {"b":1}')
   await findByText('atomB: 1')
 
-  rtl.fireEvent.click(getByText('inc atomA'))
+  fireEvent.click(getByText('inc atomA'))
   await findByText('bigAtom: {"a":{"b":3}}')
   await findByText('atomA: {"b":3}')
   await findByText('atomB: 3')
 
-  rtl.fireEvent.click(getByText('inc atomB'))
+  fireEvent.click(getByText('inc atomB'))
   await findByText('bigAtom: {"a":{"b":6}}')
   await findByText('atomA: {"b":6}')
   await findByText('atomB: 6')
@@ -161,29 +167,31 @@ it('focus on async atom works', async () => {
     )
   }
 
-  const { getByText, findByText } = rtl.render(
-    <Provider>
-      <Suspense fallback={<div>Loading...</div>}>
-        <Counter />
-      </Suspense>
-    </Provider>
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Provider>
+        <Suspense fallback={<div>Loading...</div>}>
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('baseAtom: {"count":0}')
   await findByText('asyncAtom: {"count":0}')
   await findByText('count: 0')
 
-  rtl.fireEvent.click(getByText('incr count'))
+  fireEvent.click(getByText('incr count'))
   await findByText('baseAtom: {"count":1}')
   await findByText('asyncAtom: {"count":1}')
   await findByText('count: 1')
 
-  rtl.fireEvent.click(getByText('incr async'))
+  fireEvent.click(getByText('incr async'))
   await findByText('baseAtom: {"count":2}')
   await findByText('asyncAtom: {"count":2}')
   await findByText('count: 2')
 
-  rtl.fireEvent.click(getByText('incr base'))
+  fireEvent.click(getByText('incr base'))
   await findByText('baseAtom: {"count":3}')
   await findByText('asyncAtom: {"count":3}')
   await findByText('count: 3')
@@ -206,16 +214,18 @@ it('basic derivation using focus with scope works', async () => {
     )
   }
 
-  const { getByText, findByText } = rtl.render(
-    <Provider scope={scope}>
-      <Counter />
-    </Provider>
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Provider scope={scope}>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
   await findByText('bigAtom: {"a":0}')
 
-  rtl.fireEvent.click(getByText('incr'))
+  fireEvent.click(getByText('incr'))
   await findByText('count: 1')
   await findByText('bigAtom: {"a":1}')
 })

--- a/tests/optics/focus-prism.test.tsx
+++ b/tests/optics/focus-prism.test.tsx
@@ -1,4 +1,5 @@
-import * as rtl from '@testing-library/react'
+import { StrictMode } from 'react'
+import { fireEvent, render } from '@testing-library/react'
 import * as O from 'optics-ts'
 import { atom, useAtom } from 'jotai'
 import { focusAtom } from 'jotai/optics'
@@ -23,16 +24,18 @@ it('updates prisms', async () => {
     )
   }
 
-  const { getByText, findByText } = rtl.render(
-    <Provider>
-      <Counter />
-    </Provider>
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 5')
   await findByText('bigAtom: {"a":5}')
 
-  rtl.fireEvent.click(getByText('button'))
+  fireEvent.click(getByText('button'))
   await findByText('count: 6')
   await findByText('bigAtom: {"a":6}')
 })
@@ -54,16 +57,18 @@ it('atoms that focus on no values are not updated', async () => {
     )
   }
 
-  const { getByText, findByText } = rtl.render(
-    <Provider>
-      <Counter />
-    </Provider>
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count:')
   await findByText('bigAtom: {}')
 
-  rtl.fireEvent.click(getByText('button'))
+  fireEvent.click(getByText('button'))
   await findByText('count:')
   await findByText('bigAtom: {}')
 })

--- a/tests/optics/focus-traversal.test.tsx
+++ b/tests/optics/focus-traversal.test.tsx
@@ -1,4 +1,5 @@
-import * as rtl from '@testing-library/react'
+import { StrictMode } from 'react'
+import { fireEvent, render } from '@testing-library/react'
 import * as O from 'optics-ts'
 import { atom, useAtom } from 'jotai'
 import { focusAtom } from 'jotai/optics'
@@ -23,16 +24,18 @@ it('updates traversals', async () => {
     )
   }
 
-  const { getByText, findByText } = rtl.render(
-    <Provider>
-      <Counter />
-    </Provider>
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 5,6')
   await findByText('bigAtom: [{"a":5},{},{"a":6}]')
 
-  rtl.fireEvent.click(getByText('button'))
+  fireEvent.click(getByText('button'))
   await findByText('count: 6,7')
   await findByText('bigAtom: [{"a":6},{},{"a":7}]')
 })

--- a/tests/provider.test.tsx
+++ b/tests/provider.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
 import { getTestProvider } from './testUtils'
@@ -21,13 +22,15 @@ it('uses initial values from provider', async () => {
   }
 
   const { getByText } = render(
-    <Provider
-      initialValues={[
-        [countAtom, 0],
-        [petAtom, 'dog'],
-      ]}>
-      <Display />
-    </Provider>
+    <StrictMode>
+      <Provider
+        initialValues={[
+          [countAtom, 0],
+          [petAtom, 'dog'],
+        ]}>
+        <Display />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -53,9 +56,11 @@ it('only uses initial value from provider for specific atom', async () => {
   }
 
   const { getByText } = render(
-    <Provider initialValues={[[petAtom, 'dog']]}>
-      <Display />
-    </Provider>
+    <StrictMode>
+      <Provider initialValues={[[petAtom, 'dog']]}>
+        <Display />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -65,5 +70,9 @@ it('only uses initial value from provider for specific atom', async () => {
 })
 
 it('renders correctly without children', () => {
-  render(<Provider />)
+  render(
+    <StrictMode>
+      <Provider />
+    </StrictMode>
+  )
 })

--- a/tests/query/atomWithInfiniteQuery.test.tsx
+++ b/tests/query/atomWithInfiniteQuery.test.tsx
@@ -1,4 +1,4 @@
-import { Component, Suspense, useCallback, useContext } from 'react'
+import { Component, StrictMode, Suspense, useCallback, useContext } from 'react'
 import type { ReactNode } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import {
@@ -42,11 +42,13 @@ it('infinite query basic test', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -94,11 +96,13 @@ it('infinite query next page test', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </>
   )
 
   await findByText('loading')
@@ -152,11 +156,13 @@ it('infinite query with enabled', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Parent />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Parent />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('not enabled')
@@ -218,11 +224,13 @@ it('infinite query with enabled 2', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Parent />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Parent />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -287,11 +295,13 @@ it('should be able to refetch only specific pages when refetchPages is provided'
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Page />
-      </Suspense>
-    </Provider>
+    <>
+      <Provider>
+        <Suspense fallback="loading">
+          <Page />
+        </Suspense>
+      </Provider>
+    </>
   )
 
   await findByText('loading')
@@ -365,13 +375,15 @@ describe('error handling', () => {
     }
 
     const { findByText } = render(
-      <Provider>
-        <ErrorBoundary>
-          <Suspense fallback="loading">
-            <Counter />
-          </Suspense>
-        </ErrorBoundary>
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <ErrorBoundary>
+            <Suspense fallback="loading">
+              <Counter />
+            </Suspense>
+          </ErrorBoundary>
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('loading')
@@ -424,9 +436,11 @@ describe('error handling', () => {
     }
 
     const { findByText, getByText } = render(
-      <Provider>
-        <App />
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <App />
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('loading')

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -1,4 +1,4 @@
-import { Component, Suspense, useContext, useState } from 'react'
+import { Component, StrictMode, Suspense, useContext, useState } from 'react'
 import type { ReactNode } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import {
@@ -41,11 +41,13 @@ it('query basic test', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -73,11 +75,13 @@ it('query basic test with object instead of function', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -111,11 +115,13 @@ it('query refetch', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -165,12 +171,14 @@ it('query loading', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-      <RefreshButton />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+        <RefreshButton />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -214,11 +222,13 @@ it('query loading 2', async () => {
     )
   }
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -264,12 +274,14 @@ it('query no-loading with keepPreviousData', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-      <RefreshButton />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+        <RefreshButton />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -322,11 +334,13 @@ it('query with enabled', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Parent />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Parent />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('not enabled')
@@ -391,11 +405,13 @@ it('query with enabled 2', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Parent />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Parent />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
   await findByText('loading')
   expect(mockFetch).toHaveBeenCalledTimes(1)
@@ -454,11 +470,13 @@ it('query with enabled (#500)', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Parent />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Parent />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -498,9 +516,11 @@ it('query with initialData test', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <>
+      <Provider>
+        <Counter />
+      </Provider>
+    </>
   )
 
   // NOTE: the atom never suspends
@@ -540,12 +560,14 @@ it('query dependency test', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-      <Controls />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+        <Controls />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -611,13 +633,15 @@ describe('error handling', () => {
     }
 
     const { findByText } = render(
-      <Provider>
-        <ErrorBoundary>
-          <Suspense fallback="loading">
-            <Counter />
-          </Suspense>
-        </ErrorBoundary>
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <ErrorBoundary>
+            <Suspense fallback="loading">
+              <Counter />
+            </Suspense>
+          </ErrorBoundary>
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('loading')
@@ -672,9 +696,11 @@ describe('error handling', () => {
     }
 
     const { findByText, getByText } = render(
-      <Provider>
-        <App />
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <App />
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('loading')

--- a/tests/redux/atomWithStore.test.tsx
+++ b/tests/redux/atomWithStore.test.tsx
@@ -1,5 +1,6 @@
+import { StrictMode } from 'react'
 import { act, fireEvent, render } from '@testing-library/react'
-import { createStore } from 'redux'
+import { legacy_createStore as createStore } from 'redux'
 import { useAtom } from 'jotai'
 import { atomWithStore } from 'jotai/redux'
 import { getTestProvider } from '../testUtils'
@@ -30,9 +31,11 @@ it('count state', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 1')

--- a/tests/scope.test.tsx
+++ b/tests/scope.test.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { StrictMode, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
 import { getTestProvider } from './testUtils'
@@ -21,9 +21,11 @@ it('simple scoped provider with scoped atom', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider scope={scope}>
-      <Display />
-    </Provider>
+    <StrictMode>
+      <Provider scope={scope}>
+        <Display />
+      </Provider>
+    </StrictMode>
   )
   await findByText('count: 0')
   fireEvent.click(getByText('dispatch'))
@@ -56,11 +58,13 @@ it('default provider and atom with scoped provider and scoped atom', async () =>
   }
 
   const { getByText } = render(
-    <Provider>
-      <Provider scope={scope}>
-        <Display />
+    <StrictMode>
+      <Provider>
+        <Provider scope={scope}>
+          <Display />
+        </Provider>
       </Provider>
-    </Provider>
+    </StrictMode>
   )
   await waitFor(() => {
     getByText('count: 0')
@@ -113,7 +117,11 @@ it('keeps scoped atom value when default provider is removed', async () => {
     )
   }
 
-  const { getByText, findByText } = render(<App />)
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <App />
+    </StrictMode>
+  )
   await findByText('scopedCount: 0')
   fireEvent.click(getByText('dispatch'))
   await findByText('scopedCount: 1')
@@ -151,11 +159,13 @@ it('two different scoped providers and scoped atoms', async () => {
   }
 
   const { getByText } = render(
-    <Provider scope={scope}>
-      <Provider scope={secondScope}>
-        <Display />
+    <StrictMode>
+      <Provider scope={scope}>
+        <Provider scope={secondScope}>
+          <Display />
+        </Provider>
       </Provider>
-    </Provider>
+    </StrictMode>
   )
   await waitFor(() => {
     getByText('scopedCount: 0')

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -1,4 +1,4 @@
-import { createElement } from 'react'
+import { Fragment, StrictMode, createElement } from 'react'
 import { Provider } from 'jotai'
 
 export function getTestProvider(requiresProvider?: boolean) {
@@ -27,3 +27,6 @@ export function getTestProvider(requiresProvider?: boolean) {
 
 export const itSkipIfVersionedWrite =
   process.env.PROVIDER_MODE === 'VERSIONED_WRITE' ? it.skip : it
+
+export const StrictModeUnlessVersionedWrite =
+  process.env.PROVIDER_MODE === 'VERSIONED_WRITE' ? Fragment : StrictMode

--- a/tests/transition.test.tsx
+++ b/tests/transition.test.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useTransition } from 'react'
+import { StrictMode, Suspense, useEffect, useTransition } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { getTestProvider } from './testUtils'
@@ -36,11 +36,13 @@ describeWithUseTransition('useTransition', () => {
     }
 
     const { getByText, findByText } = render(
-      <Provider>
-        <Suspense fallback="loading">
-          <Counter />
-        </Suspense>
-      </Provider>
+      <>
+        <Provider>
+          <Suspense fallback="loading">
+            <Counter />
+          </Suspense>
+        </Provider>
+      </>
     )
 
     await findByText('delayed: 0')
@@ -85,11 +87,13 @@ describeWithUseTransition('useTransition', () => {
     }
 
     const { getByText, findByText } = render(
-      <Provider>
-        <Suspense fallback="loading">
-          <Counter />
-        </Suspense>
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Suspense fallback="loading">
+            <Counter />
+          </Suspense>
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('count: 0')

--- a/tests/urql/atomWithMutation.test.tsx
+++ b/tests/urql/atomWithMutation.test.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react'
+import { StrictMode, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import type { Client } from '@urql/core'
 import { delay, fromValue, pipe, take, toPromise } from 'wonka'
@@ -41,12 +41,14 @@ it('mutation basic test', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-      <Controls />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+        <Controls />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')

--- a/tests/urql/atomWithQuery.test.tsx
+++ b/tests/urql/atomWithQuery.test.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react'
+import { StrictMode, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import type { Client } from '@urql/core'
 import { fromValue, interval, map, pipe, take, toPromise } from 'wonka'
@@ -47,11 +47,13 @@ it('query basic test', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -91,12 +93,14 @@ it('query dependency test', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-      <Controls />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+        <Controls />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -144,12 +148,14 @@ it('query change client at runtime', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Identifier />
-      </Suspense>
-      <Controls />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Identifier />
+        </Suspense>
+        <Controls />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -192,12 +198,14 @@ it('pause test', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-      <Controls />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+        <Controls />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: paused')
@@ -228,11 +236,13 @@ it('reexecute test', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -285,12 +295,14 @@ it('query null client suspense', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Identifier />
-      </Suspense>
-      <Controls />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Identifier />
+        </Suspense>
+        <Controls />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('no data')

--- a/tests/urql/atomWithSubscription.test.tsx
+++ b/tests/urql/atomWithSubscription.test.tsx
@@ -1,10 +1,10 @@
-import { Suspense } from 'react'
+import { StrictMode, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import type { Client, TypedDocumentNode } from '@urql/core'
 import { interval, map, pipe } from 'wonka'
 import { atom, useAtom } from 'jotai'
 import { atomWithSubscription } from 'jotai/urql'
-import { getTestProvider } from '../testUtils'
+import { StrictModeUnlessVersionedWrite, getTestProvider } from '../testUtils'
 
 const generateClient = (id = 'default') =>
   ({
@@ -40,11 +40,13 @@ it('subscription basic test', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </>
   )
 
   await findByText('loading')
@@ -92,12 +94,14 @@ it('subscription change client at runtime', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-      <Controls />
-    </Provider>
+    <>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+        <Controls />
+      </Provider>
+    </>
   )
 
   await findByText('loading')
@@ -146,12 +150,14 @@ it('pause test', async () => {
   }
 
   const { getByText, findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-      <Controls />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+        <Controls />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: paused')
@@ -212,12 +218,14 @@ it('null client suspense', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-      <Controls />
-    </Provider>
+    <StrictModeUnlessVersionedWrite>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+        <Controls />
+      </Provider>
+    </StrictModeUnlessVersionedWrite>
   )
 
   await findByText('no data')

--- a/tests/useAtomValue.test.tsx
+++ b/tests/useAtomValue.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom, useAtomValue, useSetAtom } from 'jotai'
 import { getTestProvider } from './testUtils'
@@ -19,9 +20,11 @@ it('useAtomValue basic test', async () => {
     )
   }
   const { findByText, getByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')

--- a/tests/utils/abortableAtom.test.tsx
+++ b/tests/utils/abortableAtom.test.tsx
@@ -1,4 +1,4 @@
-import { Suspense, version as reactVersion, useState } from 'react'
+import { StrictMode, Suspense, version as reactVersion, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtomValue, useSetAtom } from 'jotai'
 import { abortableAtom } from 'jotai/utils'
@@ -39,12 +39,14 @@ describeExceptFor1686('abortable atom test', () => {
     }
 
     const { findByText, getByText } = render(
-      <Provider>
-        <Suspense fallback="loading">
-          <Component />
-          <Controls />
-        </Suspense>
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Suspense fallback="loading">
+            <Component />
+            <Controls />
+          </Suspense>
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('loading')
@@ -90,12 +92,14 @@ describeExceptFor1686('abortable atom test', () => {
     }
 
     const { findByText, getByText } = render(
-      <Provider>
-        <Suspense fallback="loading">
-          <Component />
-          <Controls />
-        </Suspense>
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Suspense fallback="loading">
+            <Component />
+            <Controls />
+          </Suspense>
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('loading')
@@ -142,11 +146,13 @@ describeExceptFor1686('abortable atom test', () => {
     }
 
     const { findByText, getByText } = render(
-      <Provider>
-        <Suspense fallback="loading">
-          <Parent />
-        </Suspense>
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Suspense fallback="loading">
+            <Parent />
+          </Suspense>
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('loading')
@@ -187,12 +193,14 @@ describeExceptFor1686('abortable atom test', () => {
     }
 
     const { findByText, getByText } = render(
-      <Provider>
-        <Suspense fallback="loading">
-          <Component />
-          <Controls />
-        </Suspense>
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Suspense fallback="loading">
+            <Component />
+            <Controls />
+          </Suspense>
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('loading')

--- a/tests/utils/atomFamily.test.tsx
+++ b/tests/utils/atomFamily.test.tsx
@@ -15,9 +15,11 @@ it('new atomFamily impl', async () => {
     return <div>count: {count}</div>
   }
   const { findByText } = render(
-    <Provider>
-      <Displayer index={'a'} />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Displayer index={'a'} />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: a')
@@ -86,9 +88,11 @@ it('primitive atomFamily initialized with props', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 1')
@@ -163,9 +167,11 @@ it('derived atomFamily functionality as usual', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {

--- a/tests/utils/atomWithDefault.test.tsx
+++ b/tests/utils/atomWithDefault.test.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react'
+import { StrictMode, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
 import { RESET, atomWithDefault } from 'jotai/utils'
@@ -25,9 +25,11 @@ it('simple sync get default', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count1: 1, count2: 2')
@@ -64,11 +66,13 @@ it('simple async get default', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -106,9 +110,11 @@ it('refresh sync atoms to default values', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count1: 1, count2: 2')
@@ -152,11 +158,13 @@ it('refresh async atoms to default values', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -1,4 +1,5 @@
-import { Component, ReactElement, ReactNode, Suspense, useState } from 'react'
+import { Component, StrictMode, Suspense, useState } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import { BehaviorSubject, Observable, Subject, delay, of } from 'rxjs'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
@@ -37,11 +38,13 @@ it('count state', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 1')
@@ -63,11 +66,13 @@ it('writable count state', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 1')
@@ -99,14 +104,16 @@ it('writable count state without initial value', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
+    <StrictMode>
+      <Provider>
         <Suspense fallback="loading">
-          <CounterValue />
+          <Suspense fallback="loading">
+            <CounterValue />
+          </Suspense>
+          <CounterButton />
         </Suspense>
-        <CounterButton />
-      </Suspense>
-    </Provider>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -143,11 +150,13 @@ it('writable count state with delayed value', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -218,11 +227,13 @@ it('cleanup subscription', async () => {
   }
 
   const { findByText, rerender } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -256,13 +267,15 @@ it('resubscribe on remount', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Toggle>
-          <Counter />
-        </Toggle>
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Toggle>
+            <Counter />
+          </Toggle>
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -287,9 +300,11 @@ it("count state with initialValue doesn't suspend", async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 5')
@@ -315,11 +330,13 @@ it('writable count state with initialValue', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 5')
@@ -346,13 +363,15 @@ it('writable count state with error', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <ErrorBoundary>
-        <Suspense fallback="loading">
-          <Counter />
-        </Suspense>
-      </ErrorBoundary>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <ErrorBoundary>
+          <Suspense fallback="loading">
+            <Counter />
+          </Suspense>
+        </ErrorBoundary>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -371,9 +390,11 @@ it('synchronous subscription with initial value', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 1')
@@ -389,9 +410,11 @@ it('synchronous subscription with BehaviorSubject', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 1')
@@ -407,9 +430,11 @@ it('synchronous subscription with already emitted value', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 1')
@@ -427,9 +452,11 @@ it('with falsy initial value', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -446,11 +473,13 @@ it('with initially emitted undefined value', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -481,11 +510,13 @@ it("don't omit values emitted between init and mount", async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Counter />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')

--- a/tests/utils/atomWithReducer.test.tsx
+++ b/tests/utils/atomWithReducer.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { useAtom } from 'jotai'
 import { atomWithReducer } from 'jotai/utils'
@@ -31,9 +32,11 @@ it('atomWithReducer with optional action argument', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -71,9 +74,11 @@ it('atomWithReducer with non-optional action argument', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')

--- a/tests/utils/atomWithStorage.test.tsx
+++ b/tests/utils/atomWithStorage.test.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react'
+import { StrictMode, Suspense } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { useAtom } from 'jotai'
 import {
@@ -59,9 +59,11 @@ describe('atomWithStorage (sync)', () => {
     }
 
     const { findByText, getByText } = render(
-      <Provider>
-        <Counter />
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Counter />
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('count: 10')
@@ -89,9 +91,11 @@ describe('atomWithStorage (sync)', () => {
     }
 
     const { findByText } = render(
-      <Provider>
-        <Counter />
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Counter />
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('count: 9')
@@ -146,9 +150,11 @@ describe('with sync string storage', () => {
     }
 
     const { findByText, getByText } = render(
-      <Provider>
-        <Counter />
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Counter />
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('count: 10')
@@ -179,9 +185,11 @@ describe('with sync string storage', () => {
     }
 
     const { findByText } = render(
-      <Provider>
-        <Counter />
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Counter />
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('noentry: -1')
@@ -225,11 +233,13 @@ describe('atomWithStorage (async)', () => {
     }
 
     const { findByText, getByText } = render(
-      <Provider>
-        <Suspense fallback="loading">
-          <Counter />
-        </Suspense>
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Suspense fallback="loading">
+            <Counter />
+          </Suspense>
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('loading')
@@ -262,11 +272,13 @@ describe('atomWithStorage (async)', () => {
     }
 
     const { findByText, getByText } = render(
-      <Provider>
-        <Suspense fallback="loading">
-          <Counter />
-        </Suspense>
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Suspense fallback="loading">
+            <Counter />
+          </Suspense>
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('loading')
@@ -296,9 +308,11 @@ describe('atomWithStorage (async)', () => {
     }
 
     const { findByText, getByText } = render(
-      <Provider>
-        <Counter />
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Counter />
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('count: 30')
@@ -330,9 +344,11 @@ describe('atomWithStorage (without localStorage) (#949)', () => {
     }
 
     const { findByText } = render(
-      <Provider>
-        <Counter />
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Counter />
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('count: 1')
@@ -391,9 +407,11 @@ describe('atomWithHash', () => {
     }
 
     const { findByText, getByText } = render(
-      <Provider>
-        <Counter />
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Counter />
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('count: 1')
@@ -425,9 +443,11 @@ describe('atomWithHash', () => {
     }
 
     const { findByText, getByText, queryByText } = render(
-      <Provider>
-        <Counter />
-      </Provider>
+      <StrictMode>
+        <Provider>
+          <Counter />
+        </Provider>
+      </StrictMode>
     )
 
     await findByText('visible')

--- a/tests/utils/freezeAtom.test.tsx
+++ b/tests/utils/freezeAtom.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { render } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
 import { freezeAtom, freezeAtomCreator } from 'jotai/utils'
@@ -15,9 +16,11 @@ it('freezeAtom basic test', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Component />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Component />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('isFrozen: true')
@@ -34,9 +37,11 @@ it('freezeAtomCreator basic test', async () => {
   }
 
   const { findByText } = render(
-    <Provider>
-      <Component />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Component />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('isFrozen: true')

--- a/tests/utils/selectAtom.test.tsx
+++ b/tests/utils/selectAtom.test.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useRef } from 'react'
+import { StrictMode, Suspense, useEffect, useRef } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { selectAtom } from 'jotai/utils'
@@ -42,10 +42,12 @@ it('selectAtom works as expected', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-      <Selector />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+        <Selector />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('a: 0')
@@ -87,12 +89,14 @@ it('selectAtom works with async atom', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback={null}>
-        <Parent />
-        <Selector />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback={null}>
+          <Parent />
+          <Selector />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('a: 0')
@@ -142,10 +146,12 @@ it('do not update unless equality function says value has changed', async () => 
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-      <Selector />
-    </Provider>
+    <>
+      <Provider>
+        <Parent />
+        <Selector />
+      </Provider>
+    </>
   )
 
   await findByText('value: {"a":0}')
@@ -209,12 +215,14 @@ it('equality function works even if suspend', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback={null}>
-        <Controls />
-        <Selector />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback={null}>
+          <Controls />
+          <Selector />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('bigValue: {"a":0}')
@@ -258,10 +266,12 @@ it('useSelector with scope', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider scope={scope}>
-      <Parent />
-      <Selector />
-    </Provider>
+    <StrictMode>
+      <Provider scope={scope}>
+        <Parent />
+        <Selector />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('a: 0')

--- a/tests/utils/splitAtom.test.tsx
+++ b/tests/utils/splitAtom.test.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { StrictMode, useEffect, useRef } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom, useSetAtom } from 'jotai'
 import type { Atom, PrimitiveAtom } from 'jotai'
@@ -62,9 +62,11 @@ it('no unnecessary updates when updating atoms', async () => {
   }
 
   const { getByTestId, getByText } = render(
-    <Provider>
-      <TaskList listAtom={todosAtom} />
-    </Provider>
+    <>
+      <Provider>
+        <TaskList listAtom={todosAtom} />
+      </Provider>
+    </>
   )
 
   await waitFor(() => {
@@ -143,9 +145,11 @@ it('removing atoms', async () => {
   }
 
   const { getByTestId, queryByText } = render(
-    <Provider>
-      <TaskList listAtom={todosAtom} />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <TaskList listAtom={todosAtom} />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -241,9 +245,11 @@ it('inserting atoms', async () => {
   }
 
   const { getByTestId, queryByTestId } = render(
-    <Provider>
-      <TaskList listAtom={todosAtom} />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <TaskList listAtom={todosAtom} />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -342,9 +348,11 @@ it('moving atoms', async () => {
   }
 
   const { getByTestId, queryByTestId } = render(
-    <Provider>
-      <TaskList listAtom={todosAtom} />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <TaskList listAtom={todosAtom} />
+      </Provider>
+    </StrictMode>
   )
 
   await waitFor(() => {
@@ -407,9 +415,11 @@ it('read-only array atom', async () => {
   }
 
   const { getByTestId } = render(
-    <Provider>
-      <TaskList listAtom={todosAtom} />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <TaskList listAtom={todosAtom} />
+      </Provider>
+    </StrictMode>
   )
 
   const catBox = getByTestId('get cat food-checkbox') as HTMLInputElement
@@ -457,9 +467,11 @@ it('handles scope', async () => {
   }
 
   const { getByTestId } = render(
-    <Provider scope={scope}>
-      <TaskList listAtom={todosAtom} />
-    </Provider>
+    <StrictMode>
+      <Provider scope={scope}>
+        <TaskList listAtom={todosAtom} />
+      </Provider>
+    </StrictMode>
   )
 
   const catBox = getByTestId('get cat food-checkbox') as HTMLInputElement
@@ -524,10 +536,12 @@ it('no error with cached atoms (fix 510)', async () => {
   }
 
   const { getByText } = render(
-    <Provider>
-      <Filter />
-      <Filtered />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Filter />
+        <Filtered />
+      </Provider>
+    </StrictMode>
   )
 
   fireEvent.click(getByText('button'))
@@ -557,9 +571,11 @@ it('variable sized splitted atom', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <App />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <App />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('numbers: 1,2,3')

--- a/tests/utils/useAtomCallback.test.tsx
+++ b/tests/utils/useAtomCallback.test.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useState } from 'react'
+import { StrictMode, useCallback, useEffect, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
 import { useAtomCallback } from 'jotai/utils'
-import { getTestProvider } from '../testUtils'
+import { StrictModeUnlessVersionedWrite, getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
 
@@ -44,10 +44,12 @@ it('useAtomCallback with get', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Counter />
-      <Monitor />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+        <Monitor />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('atom count: 0')
@@ -96,10 +98,12 @@ it('useAtomCallback with set and update', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Counter />
-      <Monitor />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+        <Monitor />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -131,9 +135,11 @@ it('useAtomCallback with set and update and arg', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <App />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <App />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -164,9 +170,11 @@ it('useAtomCallback with sync atom (#1100)', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictModeUnlessVersionedWrite>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictModeUnlessVersionedWrite>
   )
 
   await findByText('atom count: 0')

--- a/tests/utils/useHydrateAtoms.test.tsx
+++ b/tests/utils/useHydrateAtoms.test.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { StrictMode, useEffect, useRef } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
 import { useHydrateAtoms } from 'jotai/utils'
@@ -21,9 +21,11 @@ it('useHydrateAtoms should only hydrate on first render', async () => {
     )
   }
   const { findByText, getByText, rerender } = render(
-    <Provider>
-      <Counter initialCount={42} />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter initialCount={42} />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 42')
@@ -31,9 +33,11 @@ it('useHydrateAtoms should only hydrate on first render', async () => {
   await findByText('count: 43')
 
   rerender(
-    <Provider>
-      <Counter initialCount={65} />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter initialCount={65} />
+      </Provider>
+    </StrictMode>
   )
   await findByText('count: 43')
 })
@@ -58,9 +62,11 @@ it('useHydrateAtoms should not trigger unnessesary rerenders', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Counter initialCount={42} />
-    </Provider>
+    <>
+      <Provider>
+        <Counter initialCount={42} />
+      </Provider>
+    </>
   )
 
   await findByText('count: 42')
@@ -88,9 +94,11 @@ it('useHydrateAtoms should work with derived atoms', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Counter initialCount={42} />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter initialCount={42} />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 42')
@@ -126,9 +134,11 @@ it('useHydrateAtoms can only restore an atom once', async () => {
     )
   }
   const { findByText, getByText, rerender } = render(
-    <Provider>
-      <Counter initialCount={42} />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter initialCount={42} />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 42')
@@ -136,9 +146,11 @@ it('useHydrateAtoms can only restore an atom once', async () => {
   await findByText('count: 43')
 
   rerender(
-    <Provider>
-      <Counter2 count={65} />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter2 count={65} />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 43')
@@ -172,9 +184,11 @@ it('useHydrateAtoms can only restore an atom once', async () => {
     )
   }
   const { findByText, getByText, rerender } = render(
-    <Provider>
-      <Counter initialCount={42} />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter initialCount={42} />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 42')
@@ -182,9 +196,11 @@ it('useHydrateAtoms can only restore an atom once', async () => {
   await findByText('count: 43')
 
   rerender(
-    <Provider>
-      <Counter2 count={65} />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter2 count={65} />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 43')
@@ -204,9 +220,11 @@ it('useHydrateAtoms should respect onMount', async () => {
     return <div>count: {countValue}</div>
   }
   const { findByText } = render(
-    <Provider>
-      <Counter initialCount={42} />
-    </Provider>
+    <>
+      <Provider>
+        <Counter initialCount={42} />
+      </Provider>
+    </>
   )
 
   await findByText('count: 42')
@@ -242,14 +260,14 @@ it('useHydrateAtoms should let you hydrate an atom once per scope', async () => 
     )
   }
   const { findByText, getByText } = render(
-    <>
+    <StrictMode>
       <Provider>
         <Counter initialCount={42} />
       </Provider>
       <Provider scope={scope}>
         <Counter2 initialCount={65} />
       </Provider>
-    </>
+    </StrictMode>
   )
 
   await findByText('count: 42')

--- a/tests/utils/useReducerAtom.test.tsx
+++ b/tests/utils/useReducerAtom.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom } from 'jotai'
 import { useReducerAtom } from 'jotai/utils'
@@ -20,9 +21,11 @@ it('useReducerAtom with no action argument', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -60,9 +63,11 @@ it('useReducerAtom with optional action argument', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -100,9 +105,11 @@ it('useReducerAtom with non-optional action argument', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')

--- a/tests/utils/useResetAtom.test.tsx
+++ b/tests/utils/useResetAtom.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { atom, useAtom } from 'jotai'
 import {
@@ -29,9 +30,11 @@ it('atomWithReset resets to its first value', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -76,9 +79,11 @@ it('atomWithReset reset based on previous value', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -114,9 +119,11 @@ it('atomWithReset through read-write atom', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -153,9 +160,11 @@ it('useResetAtom with custom atom', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -190,9 +199,11 @@ it('useResetAtom with scope', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider scope={scope}>
-      <Parent />
-    </Provider>
+    <StrictMode>
+      <Provider scope={scope}>
+        <Parent />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')

--- a/tests/valtio/atomWithProxy.test.tsx
+++ b/tests/valtio/atomWithProxy.test.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react'
+import { StrictMode, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { proxy, snapshot } from 'valtio/vanilla'
 import { atom, useAtom } from 'jotai'
@@ -29,9 +29,11 @@ it('count state', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 1')
@@ -69,9 +71,11 @@ it('nested count state', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 0')
@@ -122,11 +126,13 @@ it('state with a promise', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Suspense fallback="loading">
-        <Status />
-      </Suspense>
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Suspense fallback="loading">
+          <Status />
+        </Suspense>
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('loading')
@@ -172,9 +178,11 @@ it('synchronous atomWithProxy and regular atom ', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Elements />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Elements />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('selected element: none')
@@ -198,9 +206,11 @@ it('array.length state', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('array0: 0')

--- a/tests/xstate/atomWithMachine.test.tsx
+++ b/tests/xstate/atomWithMachine.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react'
 import { assign, createMachine } from 'xstate'
 import { useAtom } from 'jotai'
 import { RESTART, atomWithMachine } from 'jotai/xstate'
-import { getTestProvider } from '../testUtils'
+import { StrictModeUnlessVersionedWrite, getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
 
@@ -35,9 +35,11 @@ it('toggle machine', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Toggler />
-    </Provider>
+    <StrictModeUnlessVersionedWrite>
+      <Provider>
+        <Toggler />
+      </Provider>
+    </StrictModeUnlessVersionedWrite>
   )
 
   await findByText('Click to activate')
@@ -110,9 +112,11 @@ it('restartable machine', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Toggler />
-    </Provider>
+    <StrictModeUnlessVersionedWrite>
+      <Provider>
+        <Toggler />
+      </Provider>
+    </StrictModeUnlessVersionedWrite>
   )
 
   await findByText('Click to activate')

--- a/tests/zustand/atomWithStore.test.tsx
+++ b/tests/zustand/atomWithStore.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { act, fireEvent, render } from '@testing-library/react'
 import create from 'zustand/vanilla'
 import { useAtom } from 'jotai'
@@ -28,9 +29,11 @@ it('count state', async () => {
   }
 
   const { findByText, getByText } = render(
-    <Provider>
-      <Counter />
-    </Provider>
+    <StrictMode>
+      <Provider>
+        <Counter />
+      </Provider>
+    </StrictMode>
   )
 
   await findByText('count: 1')


### PR DESCRIPTION
This should be done/merged before #1383.
For `loadable` util, there's a bug so excluded. It should be revisited with #1392.