### PR TITLE
fix(types): patch awaited for ts < 4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "typesVersions": {
-    "<4.1": {
+    "<4.5": {
       "esm/*": [
         "ts3.4/*"
       ],
@@ -135,7 +135,7 @@
     "test:dev": "jest --watch --no-coverage",
     "test:coverage:watch": "jest --watch",
     "copy": "shx cp -r dist/src/* dist/esm && shx cp -r dist/src/* dist && shx rm -rf dist/src && shx rm -rf dist/{src,tests} && downlevel-dts dist dist/ts3.4 && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined;\"",
-    "patch-ts3.4": "shx sed -i 's/^declare type Awaited[^;]*;/declare type Awaited<T> = T extends Promise<infer V> ? V : T;/' dist/ts3.4/*.d.ts dist/ts3.4/*/*.d.ts dist/ts3.4/*/*/*.d.ts",
+    "patch-ts3.4": "node -e \"require('shelljs').find('dist/ts3.4/**/*.d.ts').forEach(f=>require('fs').appendFileSync(f,'declare type Awaited<T> = T extends Promise<infer V> ? V : T;'))\"",
     "patch-readme": "shx sed -i 's/.*dark mode.*//' dist/readme.md"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "typesVersions": {
-    "<4.0": {
+    "<4.1": {
       "esm/*": [
         "ts3.4/*"
       ],
@@ -124,7 +124,7 @@
     "build:babel:plugin-debug-label": "rollup -c --config-babel_plugin-debug-label",
     "build:babel:plugin-react-refresh": "rollup -c --config-babel_plugin-react-refresh",
     "build:babel:preset": "rollup -c --config-babel_preset",
-    "postbuild": "yarn copy && yarn patch-readme",
+    "postbuild": "yarn copy && yarn patch-ts3.4 && yarn patch-readme",
     "prettier": "prettier '*.{js,json,md}' '{src,tests,benchmarks,docs}/**/*.{ts,tsx,md,mdx}' --write",
     "prettier:ci": "prettier '*.{js,json,md}' '{src,tests,benchmarks,docs}/**/*.{ts,tsx,md,mdx}' --list-different",
     "eslint": "eslint --fix '*.{js,json}' '{src,tests,benchmarks}/**/*.{ts,tsx}'",
@@ -135,6 +135,7 @@
     "test:dev": "jest --watch --no-coverage",
     "test:coverage:watch": "jest --watch",
     "copy": "shx cp -r dist/src/* dist/esm && shx cp -r dist/src/* dist && shx rm -rf dist/src && shx rm -rf dist/{src,tests} && downlevel-dts dist dist/ts3.4 && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined;\"",
+    "patch-ts3.4": "shx sed -i 's/^declare type Awaited[^;]*;/declare type Awaited<T> = T extends Promise<infer V> ? V : T;/' dist/ts3.4/*.d.ts dist/ts3.4/*/*.d.ts dist/ts3.4/*/*/*.d.ts",
     "patch-readme": "shx sed -i 's/.*dark mode.*//' dist/readme.md"
   },
   "engines": {

--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -1,5 +1,3 @@
-type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
-
 type Getter = {
   <Value>(atom: Atom<Value | Promise<Value>>): Value
   <Value>(atom: Atom<Promise<Value>>): Value

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -8,8 +8,6 @@ import {
 } from './suspensePromise'
 import type { SuspensePromise } from './suspensePromise'
 
-type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
-
 type AnyAtomValue = unknown
 type AnyAtom = Atom<AnyAtomValue>
 type AnyWritableAtom = WritableAtom<AnyAtomValue, unknown, void | Promise<void>>

--- a/src/core/useAtom.ts
+++ b/src/core/useAtom.ts
@@ -2,8 +2,6 @@ import type { Atom, Scope, SetAtom, WritableAtom } from './atom'
 import { useAtomValue } from './useAtomValue'
 import { useSetAtom } from './useSetAtom'
 
-type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
-
 export function useAtom<Value, Update, Result extends void | Promise<void>>(
   atom: WritableAtom<Value, Update, Result>,
   scope?: Scope

--- a/src/core/useAtomValue.ts
+++ b/src/core/useAtomValue.ts
@@ -5,8 +5,6 @@ import { getScopeContext } from './contexts'
 import { COMMIT_ATOM, READ_ATOM, SUBSCRIBE_ATOM } from './store'
 import type { VersionObject } from './store'
 
-type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
-
 export function useAtomValue<Value>(
   atom: Atom<Value>,
   scope?: Scope

--- a/src/utils/loadable.ts
+++ b/src/utils/loadable.ts
@@ -2,8 +2,6 @@ import { atom } from 'jotai'
 import type { Atom } from 'jotai'
 import { createMemoizeAtom } from './weakCache'
 
-type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
-
 const memoizeAtom = createMemoizeAtom()
 
 type Loadable<Value> =

--- a/src/utils/selectAtom.ts
+++ b/src/utils/selectAtom.ts
@@ -2,8 +2,6 @@ import { atom } from 'jotai'
 import type { Atom } from 'jotai'
 import { createMemoizeAtom } from './weakCache'
 
-type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
-
 const memoizeAtom = createMemoizeAtom()
 
 export function selectAtom<Value, Slice>(

--- a/src/utils/waitForAll.ts
+++ b/src/utils/waitForAll.ts
@@ -5,7 +5,6 @@ import { createMemoizeAtom } from './weakCache'
 const memoizeAtom = createMemoizeAtom()
 const emptyArrayAtom = atom(() => [])
 
-type Awaited<T> = T extends Promise<infer V> ? Awaited<V> : T
 type ResolveAtom<T> = T extends Atom<infer V> ? V : T
 type AwaitedAtom<T> = Awaited<ResolveAtom<T>>
 


### PR DESCRIPTION
close #1398

We used have our custom `Awaited`, but it doesn't work with TS < 4.0.
This PR eliminates the custom one, and uses the built-in one available since TS >= 4.5.
For older versions, we patch with a limited (non-recursive) `Awaited` type.