### PR TITLE
Add missing `queryClientAtom` import to the `React Query` guide

### DIFF
--- a/docs/integrations/query.mdx
+++ b/docs/integrations/query.mdx
@@ -117,7 +117,7 @@ import {
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query'
-import { atomWithQuery } from 'jotai/query'
+import { atomWithQuery, queryClientAtom } from 'jotai/query'
 
 const queryClient = new QueryClient()
 export const App = () => {


### PR DESCRIPTION
## Summary

While reading the documentation on getting started with React Query, I noticed that import was missing.

## Check List

- [ ] `yarn run prettier` for formatting code and docs

^ didn't run, as the change is md related.