### PR TITLE
fix(query): create QueryObserver with initial options

### DIFF
--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -166,7 +166,9 @@ export function atomWithQuery<
           unsubscribe = null
           return observer.refetch({ cancelRefetch: true }).then(listener)
         }
-        return observer.refetch({ cancelRefetch: true })
+        return observer.refetch({ cancelRefetch: true }).then((result) => {
+          setResult?.(result)
+        })
       }
       if (unsubscribe) {
         clearTimeout(timer)

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -164,8 +164,7 @@ export function atomWithQuery<
         if (options.enabled !== false) {
           if (!setResult && unsubscribe) {
             unsubscribe()
-            unsubscribe = null
-            observer.refetch({ cancelRefetch: true }).then(listener)
+            unsubscribe = observer.subscribe(listener)
           } else {
             observer.refetch({ cancelRefetch: true }).then((result) => {
               setResult?.(result)
@@ -197,7 +196,7 @@ export function atomWithQuery<
     resultAtom.onMount = (update) => {
       setResult = update
       if (unsubscribe) {
-        clearTimeout(timer as Timeout)
+        clearTimeout(timer)
       } else {
         startQuery()
       }

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -61,11 +61,7 @@ export function atomWithQuery<
     >
   >,
   getQueryClient?: GetQueryClient
-): WritableAtom<
-  TData | TQueryData | undefined,
-  AtomWithQueryAction,
-  void | Promise<void>
->
+): WritableAtom<TData | undefined, AtomWithQueryAction>
 
 export function atomWithQuery<
   TQueryFnData,
@@ -78,7 +74,7 @@ export function atomWithQuery<
     AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>
   >,
   getQueryClient?: GetQueryClient
-): WritableAtom<TData, AtomWithQueryAction, Promise<void>>
+): WritableAtom<TData, AtomWithQueryAction>
 
 export function atomWithQuery<
   TQueryFnData,
@@ -154,7 +150,6 @@ export function atomWithQuery<
       }
       if (options.enabled !== false) {
         unsubscribe = observer.subscribe(listener)
-        listener(observer.getCurrentResult())
       }
       if (!setResult) {
         // not mounted yet
@@ -200,7 +195,7 @@ export function atomWithQuery<
       switch (action.type) {
         case 'refetch': {
           set(resultAtom, makePending())
-          return startQuery(true)
+          startQuery(true)
         }
       }
     }

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -99,11 +99,11 @@ export function atomWithQuery<
   >
   type Result = QueryObserverResult<TData, TError>
 
-  const observerMap = new WeakMap<
+  const observerCache = new WeakMap<
     QueryClient,
     QueryObserver<TQueryFnData, TError, TData, TQueryData, TQueryKey>
   >()
-  const getObserver = (
+  const createObserver = (
     queryClient: QueryClient,
     options: QueryObserverOptions<
       TQueryFnData,
@@ -113,7 +113,7 @@ export function atomWithQuery<
       TQueryKey
     >
   ) => {
-    let observer = observerMap.get(queryClient)
+    let observer = observerCache.get(queryClient)
     if (!observer) {
       observer = new QueryObserver<
         TQueryFnData,
@@ -122,7 +122,7 @@ export function atomWithQuery<
         TQueryData,
         TQueryKey
       >(queryClient, options)
-      observerMap.set(queryClient, observer)
+      observerCache.set(queryClient, observer)
     }
     return observer
   }
@@ -140,7 +140,7 @@ export function atomWithQuery<
       const options =
         typeof createQuery === 'function' ? createQuery(get) : createQuery
       const queryClient = getQueryClient(get)
-      const observer = getObserver(queryClient, options)
+      const observer = createObserver(queryClient, options)
       observer.destroy()
       observer.setOptions(options)
       const initialResult = observer.getCurrentResult()
@@ -200,7 +200,7 @@ export function atomWithQuery<
         return
       }
       const queryClient = getQueryClient(get)
-      const observer = getObserver(queryClient, options)
+      const observer = createObserver(queryClient, options)
       switch (action.type) {
         case 'refetch': {
           set(resultAtom, new Promise<never>(() => {})) // infinite pending

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -141,16 +141,9 @@ export function atomWithQuery<
     let unsubscribe: (() => void) | null = null
     let timer: Timeout | undefined
     const startQuery = (refetch?: boolean) => {
-      if (refetch) {
+      if (refetch && setResult) {
         if (options.enabled !== false) {
-          if (!setResult && unsubscribe) {
-            unsubscribe()
-            unsubscribe = observer.subscribe(listener)
-          } else {
-            observer.refetch({ cancelRefetch: true }).then((result) => {
-              setResult?.(result)
-            })
-          }
+          observer.refetch({ cancelRefetch: true }).then(setResult)
         }
         return
       }

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -96,41 +96,11 @@ export function atomWithQuery<
 
   const previousDataCache = new WeakMap<QueryClient, TData>()
 
-  const observerCache = new WeakMap<
-    QueryClient,
-    QueryObserver<TQueryFnData, TError, TData, TQueryData, TQueryKey>
-  >()
-  const createObserver = (
-    queryClient: QueryClient,
-    options: QueryObserverOptions<
-      TQueryFnData,
-      TError,
-      TData,
-      TQueryData,
-      TQueryKey
-    >
-  ) => {
-    let observer = observerCache.get(queryClient)
-    if (!observer) {
-      observer = new QueryObserver<
-        TQueryFnData,
-        TError,
-        TData,
-        TQueryData,
-        TQueryKey
-      >(queryClient, options)
-      // observerCache.set(queryClient, observer)
-    }
-    return observer
-  }
-
   const queryDataAtom = atom((get) => {
+    const queryClient = getQueryClient(get)
     const options =
       typeof createQuery === 'function' ? createQuery(get) : createQuery
-    const queryClient = getQueryClient(get)
-    const observer = createObserver(queryClient, options)
-    observer.destroy()
-    observer.setOptions(options)
+    const observer = new QueryObserver(queryClient, options)
     const initialResult = observer.getCurrentResult()
     if (
       initialResult.data === undefined &&

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -161,14 +161,18 @@ export function atomWithQuery<
     let timer: Timeout | undefined
     const startQuery = (refetch?: boolean) => {
       if (refetch) {
-        if (!setResult && unsubscribe) {
-          unsubscribe()
-          unsubscribe = null
-          return observer.refetch({ cancelRefetch: true }).then(listener)
+        if (options.enabled !== false) {
+          if (!setResult && unsubscribe) {
+            unsubscribe()
+            unsubscribe = null
+            observer.refetch({ cancelRefetch: true }).then(listener)
+          } else {
+            observer.refetch({ cancelRefetch: true }).then((result) => {
+              setResult?.(result)
+            })
+          }
         }
-        return observer.refetch({ cancelRefetch: true }).then((result) => {
-          setResult?.(result)
-        })
+        return
       }
       if (unsubscribe) {
         clearTimeout(timer)
@@ -203,7 +207,7 @@ export function atomWithQuery<
         }
       }
     }
-    return { options, resultAtom, makePending, startQuery }
+    return { resultAtom, makePending, startQuery }
   })
 
   const queryAtom = atom(
@@ -216,11 +220,7 @@ export function atomWithQuery<
       return result.data
     },
     (get, set, action: AtomWithQueryAction) => {
-      const { options, resultAtom, makePending, startQuery } =
-        get(queryDataAtom)
-      if (options.enabled === false) {
-        return
-      }
+      const { resultAtom, makePending, startQuery } = get(queryDataAtom)
       switch (action.type) {
         case 'refetch': {
           set(resultAtom, makePending())

--- a/src/query/atomWithQuery.ts
+++ b/src/query/atomWithQuery.ts
@@ -177,9 +177,11 @@ export function atomWithQuery<
       if (unsubscribe) {
         clearTimeout(timer)
         unsubscribe()
+        unsubscribe = null
       }
       if (options.enabled !== false) {
         unsubscribe = observer.subscribe(listener)
+        listener(observer.getCurrentResult())
       }
       if (!setResult) {
         // not mounted yet
@@ -194,9 +196,10 @@ export function atomWithQuery<
     startQuery()
     resultAtom.onMount = (update) => {
       setResult = update
-      if (options.enabled !== false && !unsubscribe) {
-        unsubscribe = observer.subscribe(listener)
-        listener(observer.getCurrentResult())
+      if (unsubscribe) {
+        clearTimeout(timer as Timeout)
+      } else {
+        startQuery()
       }
       return () => {
         setResult = null

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -748,14 +748,10 @@ it('query expected QueryCache test', async () => {
         response: { count },
       },
     ] = useAtom(countAtom)
-    const cachedQueries = useSyncExternalStore(
-      queryClient.getQueryCache().subscribe,
-      () => queryClient.getQueryCache().getAll()
-    )
+
     return (
       <>
         <div>count: {count}</div>
-        <div>queries in cache: {cachedQueries.length}</div>
       </>
     )
   }
@@ -772,5 +768,5 @@ it('query expected QueryCache test', async () => {
 
   await findByText('loading')
   await findByText('count: 0')
-  await findByText('queries in cache: 1')
+  expect(queryClient.getQueryCache().getAll().length).toBe(1)
 })

--- a/tests/query/atomWithQuery.test.tsx
+++ b/tests/query/atomWithQuery.test.tsx
@@ -1,11 +1,4 @@
-import {
-  Component,
-  StrictMode,
-  Suspense,
-  useContext,
-  useState,
-  useSyncExternalStore,
-} from 'react'
+import { Component, StrictMode, Suspense, useContext, useState } from 'react'
 import type { ReactNode } from 'react'
 import { QueryClient } from '@tanstack/query-core'
 import { fireEvent, render } from '@testing-library/react'


### PR DESCRIPTION
## Related Issues

Fixes #1416 

## Summary

- Create an observer just once for each `options`.
- Add a hack for `keepPreviousData`.
- Refactor to be similar to `jotai/urql` impl.
  - `write` function no longer returns a promise.

## Check List

- [x] `yarn run prettier` for formatting code and docs
