### PR TITLE
refactor(utils): atomWithObservable

### DIFF
--- a/src/utils/atomWithObservable.ts
+++ b/src/utils/atomWithObservable.ts
@@ -1,6 +1,9 @@
 import { atom } from 'jotai'
 import type { Atom, Getter, WritableAtom } from 'jotai'
 
+type Timeout = ReturnType<typeof setTimeout>
+type AnyError = unknown
+
 declare global {
   interface SymbolConstructor {
     readonly observable: symbol
@@ -13,7 +16,7 @@ type Subscription = {
 
 type Observer<T> = {
   next: (value: T) => void
-  error: (error: unknown) => void
+  error: (error: AnyError) => void
   complete: () => void
 }
 
@@ -21,7 +24,7 @@ type ObservableLike<T> = {
   subscribe(observer: Observer<T>): Subscription
   subscribe(
     next: (value: T) => void,
-    error?: (error: unknown) => void,
+    error?: (error: AnyError) => void,
     complete?: () => void
   ): Subscription
   [Symbol.observable]?: () => ObservableLike<T> | undefined
@@ -29,25 +32,24 @@ type ObservableLike<T> = {
 
 type SubjectLike<T> = ObservableLike<T> & Observer<T>
 
-type InitialValueFunction<T> = () => T | undefined
-
-type AtomWithObservableOptions<TData> = {
-  initialValue?: TData | InitialValueFunction<TData>
+type Options<Data> = {
+  initialValue?: Data | (() => Data)
+  timeout?: number
 }
 
-export function atomWithObservable<TData>(
-  createObservable: (get: Getter) => SubjectLike<TData>,
-  options?: AtomWithObservableOptions<TData>
-): WritableAtom<TData, TData>
+export function atomWithObservable<Data>(
+  createObservable: (get: Getter) => SubjectLike<Data>,
+  options?: Options<Data>
+): WritableAtom<Data, Data>
 
-export function atomWithObservable<TData>(
-  createObservable: (get: Getter) => ObservableLike<TData>,
-  options?: AtomWithObservableOptions<TData>
-): Atom<TData>
+export function atomWithObservable<Data>(
+  createObservable: (get: Getter) => ObservableLike<Data>,
+  options?: Options<Data>
+): Atom<Data>
 
-export function atomWithObservable<TData>(
-  createObservable: (get: Getter) => ObservableLike<TData> | SubjectLike<TData>,
-  options?: AtomWithObservableOptions<TData>
+export function atomWithObservable<Data>(
+  createObservable: (get: Getter) => ObservableLike<Data> | SubjectLike<Data>,
+  options?: Options<Data>
 ) {
   const observableResultAtom = atom((get) => {
     let observable = createObservable(get)
@@ -56,113 +58,98 @@ export function atomWithObservable<TData>(
       observable = itself
     }
 
-    // To differentiate beetwen no value was emitted and `undefined` was emitted,
-    // this symbol is used
-    const EMPTY = Symbol()
+    type Result = { d: Data } | { e: AnyError }
+    let resolve: ((result: Result) => void) | null = null
+    const makePending = () =>
+      new Promise<Result>((r) => {
+        resolve = r
+      })
+    const initialResult: Result | Promise<Result> =
+      options && 'initialValue' in options
+        ? {
+            d:
+              typeof options.initialValue === 'function'
+                ? (options.initialValue as () => Data)()
+                : (options.initialValue as Data),
+          }
+        : makePending()
 
-    let resolveEmittedInitialValue:
-      | ((data: TData | Promise<TData>) => void)
-      | null = null
-    let initialEmittedValue: Promise<TData> | TData | undefined =
-      options?.initialValue === undefined
-        ? new Promise((resolve) => {
-            resolveEmittedInitialValue = resolve
-          })
-        : undefined
-    let initialValueWasEmitted = false
-
-    let emittedValueBeforeMount: TData | Promise<TData> | typeof EMPTY = EMPTY
-    let isSync = true
-    let setData: (data: TData | Promise<TData>) => void = (data) => {
-      // First we set the initial value (if not other initialValue was provided)
-      // All the following data is saved in a variable so it doesn't get lost before the mount
-      if (options?.initialValue === undefined && !initialValueWasEmitted) {
-        if (isSync) {
-          initialEmittedValue = data
-        }
-        resolveEmittedInitialValue?.(data)
-        initialValueWasEmitted = true
-        resolveEmittedInitialValue = null
-      } else {
-        emittedValueBeforeMount = data
-      }
-    }
-
-    const dataListener = (data: TData) => {
-      setData(data)
-    }
-
-    const errorListener = (error: unknown) => {
-      setData(Promise.reject<TData>(error))
+    let setResult: ((result: Result) => void) | null = null
+    let lastResult: Result | undefined
+    const listener = (result: Result) => {
+      lastResult = result
+      resolve?.(result)
+      setResult?.(result)
     }
 
     let subscription: Subscription | null = null
-    let initialValue:
-      | TData
-      | Promise<TData>
-      | InitialValueFunction<TData>
-      | undefined
-    if (options?.initialValue !== undefined) {
-      initialValue = getInitialValue(options)
-    } else {
-      // FIXME
-      // There is the potential for memory leaks in this implementation.
-      //
-      // If the observable doesn't emit an initial value before the component that uses the atom gets destroyed,
-      // the onMount function never gets called and therefore the subscription never gets cleaned up.
-      //
-      // Unfortunately, currently there is no good way to prevent this issue (as of 2022-05-23).
-      // Timeouts may lead to an endless loading state, if the subscription get's cleaned up too quickly.
-      //
-      // Discussion: https://github.com/pmndrs/jotai/pull/1170
-      subscription = observable.subscribe(dataListener, errorListener)
-      initialValue = initialEmittedValue
-    }
-    isSync = false
-
-    const dataAtom = atom(initialValue)
-    dataAtom.onMount = (update) => {
-      setData = update
-      if (emittedValueBeforeMount !== EMPTY) {
-        update(emittedValueBeforeMount)
+    let timer: Timeout | undefined
+    const isNotMounted = () => !setResult
+    const start = () => {
+      if (subscription) {
+        clearTimeout(timer)
+        subscription.unsubscribe()
       }
-      if (!subscription) {
-        subscription = observable.subscribe(dataListener, errorListener)
+      subscription = observable.subscribe(
+        (d) => listener({ d }),
+        (e) => listener({ e })
+      )
+      if (isNotMounted() && options?.timeout) {
+        timer = setTimeout(() => {
+          if (subscription) {
+            subscription.unsubscribe()
+            subscription = null
+          }
+        }, options.timeout)
+      }
+    }
+    start()
+
+    const resultAtom = atom(lastResult || initialResult)
+    resultAtom.onMount = (update) => {
+      setResult = update
+      if (lastResult) {
+        update(lastResult)
+      }
+      if (subscription) {
+        clearTimeout(timer)
+      } else {
+        start()
       }
       return () => {
-        subscription?.unsubscribe()
-        subscription = null
+        setResult = null
+        if (subscription) {
+          subscription.unsubscribe()
+          subscription = null
+        }
       }
     }
-
-    return { dataAtom, observable }
+    return [resultAtom, observable, makePending, start, isNotMounted] as const
   })
+
   const observableAtom = atom(
     (get) => {
-      const { dataAtom } = get(observableResultAtom)
-
-      return get(dataAtom)
+      const [resultAtom] = get(observableResultAtom)
+      const result = get(resultAtom)
+      if ('e' in result) {
+        throw result.e
+      }
+      return result.d
     },
-    (get, set, data: TData) => {
-      const { dataAtom, observable } = get(observableResultAtom)
+    (get, set, data: Data) => {
+      const [resultAtom, observable, makePending, start, isNotMounted] =
+        get(observableResultAtom)
       if ('next' in observable) {
-        // FIXME one-time subscription is only necessary if not mounted yet
-        let subscription: Subscription | null = null
-        const callback = (data: TData) => {
-          set(dataAtom, data)
-          subscription?.unsubscribe()
+        if (isNotMounted()) {
+          set(resultAtom, makePending())
+          start()
         }
-        subscription = observable.subscribe(callback)
         observable.next(data)
       } else {
         throw new Error('observable is not subject')
       }
     }
   )
-  return observableAtom
-}
 
-function getInitialValue<TData>(options: AtomWithObservableOptions<TData>) {
-  const initialValue = options.initialValue
-  return initialValue instanceof Function ? initialValue() : initialValue
+  return observableAtom
 }

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -1,12 +1,25 @@
-import { Component, StrictMode, Suspense, useState } from 'react'
+import { Component, StrictMode, Suspense, useContext, useState } from 'react'
 import type { ReactElement, ReactNode } from 'react'
 import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import { BehaviorSubject, Observable, Subject, delay, of } from 'rxjs'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { atomWithObservable } from 'jotai/utils'
+import {
+  atom,
+  SECRET_INTERNAL_getScopeContext as getScopeContext,
+  useAtom,
+  useAtomValue,
+  useSetAtom,
+} from 'jotai'
+import { RESET, atomWithObservable } from 'jotai/utils'
 import { getTestProvider } from '../testUtils'
 
 const Provider = getTestProvider()
+
+// This is only used to pass tests with unstable_enableVersionedWrite
+const useRetryFromError = (scope?: symbol | string | number) => {
+  const ScopeContext = getScopeContext(scope)
+  const { r: retryFromError } = useContext(ScopeContext)
+  return retryFromError || ((fn) => fn())
+}
 
 class ErrorBoundary extends Component<
   { children: ReactNode },
@@ -526,4 +539,200 @@ it("don't omit values emitted between init and mount", async () => {
 
   fireEvent.click(getByText('button'))
   await findByText('count: 9')
+})
+
+describe('error handling', () => {
+  class ErrorBoundary extends Component<
+    { message?: string; retry?: () => void; children: ReactNode },
+    { hasError: boolean }
+  > {
+    constructor(props: { message?: string; children: ReactNode }) {
+      super(props)
+      this.state = { hasError: false }
+    }
+    static getDerivedStateFromError() {
+      return { hasError: true }
+    }
+    render() {
+      return this.state.hasError ? (
+        <div>
+          {this.props.message || 'errored'}
+          {this.props.retry && (
+            <button
+              onClick={() => {
+                this.props.retry?.()
+                this.setState({ hasError: false })
+              }}>
+              retry
+            </button>
+          )}
+        </div>
+      ) : (
+        this.props.children
+      )
+    }
+  }
+
+  it('can catch error in error boundary', async () => {
+    const subject = new Subject<number>()
+    const countAtom = atomWithObservable(() => subject)
+
+    const Counter = () => {
+      const [count] = useAtom(countAtom)
+      return (
+        <>
+          <div>count: {count}</div>
+        </>
+      )
+    }
+
+    const { findByText } = render(
+      <StrictMode>
+        <Provider>
+          <ErrorBoundary>
+            <Suspense fallback="loading">
+              <Counter />
+            </Suspense>
+          </ErrorBoundary>
+        </Provider>
+      </StrictMode>
+    )
+
+    await findByText('loading')
+    act(() => subject.error(new Error('Test Error')))
+    await findByText('errored')
+  })
+
+  it('can recover from error', async () => {
+    const subject = new Subject<number>()
+    const countAtom = atomWithObservable(() => subject)
+
+    const Counter = () => {
+      const [count, dispatch] = useAtom(countAtom)
+      const refetch = () => dispatch(RESET)
+      return (
+        <>
+          <div>count: {count}</div>
+          <button onClick={refetch}>refetch</button>
+        </>
+      )
+    }
+
+    const App = () => {
+      const dispatch = useSetAtom(countAtom)
+      const retryFromError = useRetryFromError()
+      const retry = () => {
+        retryFromError(() => {
+          dispatch(RESET)
+        })
+      }
+      return (
+        <ErrorBoundary retry={retry}>
+          <Suspense fallback="loading">
+            <Counter />
+          </Suspense>
+        </ErrorBoundary>
+      )
+    }
+
+    const { findByText, getByText } = render(
+      <StrictMode>
+        <Provider>
+          <App />
+        </Provider>
+      </StrictMode>
+    )
+
+    await findByText('loading')
+    act(() => subject.error(new Error('Test Error')))
+    await findByText('errored')
+
+    await new Promise((r) => setTimeout(r, 100))
+    fireEvent.click(getByText('retry'))
+    await findByText('loading')
+    act(() => subject.next(1))
+    await findByText('count: 1')
+
+    await new Promise((r) => setTimeout(r, 100))
+    fireEvent.click(getByText('retry'))
+    await findByText('loading')
+    act(() => subject.error(new Error('Test Error')))
+    await findByText('errored')
+
+    await new Promise((r) => setTimeout(r, 100))
+    fireEvent.click(getByText('retry'))
+    await findByText('loading')
+    act(() => subject.next(1))
+    await findByText('count: 3')
+  })
+
+  it('can recover from error with dependency', async () => {
+    const baseAtom = atom(0)
+    const countAtom = atomWithObservable((get) => {
+      const base = get(baseAtom)
+      if (base % 2 === 0) {
+        const subject = new Subject<number>()
+        setTimeout(() => {
+          subject.error(new Error('Test Error'))
+        }, 100)
+        return subject
+      }
+      const observable = of(base).pipe(delay(500))
+      return observable
+    })
+
+    const Counter = () => {
+      const [count] = useAtom(countAtom)
+      const setBase = useSetAtom(baseAtom)
+      return (
+        <>
+          <div>count: {count}</div>
+          <button onClick={() => setBase((v) => v + 1)}>next</button>
+        </>
+      )
+    }
+
+    const App = () => {
+      const setBase = useSetAtom(baseAtom)
+      const retryFromError = useRetryFromError()
+      const retry = () => {
+        retryFromError(() => {
+          setBase((c) => c + 1)
+        })
+      }
+      return (
+        <ErrorBoundary retry={retry}>
+          <Suspense fallback="loading">
+            <Counter />
+          </Suspense>
+        </ErrorBoundary>
+      )
+    }
+
+    const { findByText, getByText } = render(
+      <StrictMode>
+        <Provider>
+          <App />
+        </Provider>
+      </StrictMode>
+    )
+
+    await findByText('loading')
+    await findByText('errored')
+
+    await new Promise((r) => setTimeout(r, 100))
+    fireEvent.click(getByText('retry'))
+    await findByText('loading')
+    await findByText('count: 1')
+
+    await new Promise((r) => setTimeout(r, 100))
+    fireEvent.click(getByText('next'))
+    await findByText('loading')
+    await findByText('errored')
+
+    await new Promise((r) => setTimeout(r, 100))
+    fireEvent.click(getByText('retry'))
+    await findByText('loading')
+    await findByText('count: 3')
+  })
 })

--- a/tests/utils/atomWithObservable.test.tsx
+++ b/tests/utils/atomWithObservable.test.tsx
@@ -120,11 +120,9 @@ it('writable count state without initial value', async () => {
     <StrictMode>
       <Provider>
         <Suspense fallback="loading">
-          <Suspense fallback="loading">
-            <CounterValue />
-          </Suspense>
-          <CounterButton />
+          <CounterValue />
         </Suspense>
+        <CounterButton />
       </Provider>
     </StrictMode>
   )
@@ -533,8 +531,10 @@ it("don't omit values emitted between init and mount", async () => {
   )
 
   await findByText('loading')
-  act(() => subject.next(1))
-  act(() => subject.next(2))
+  act(() => {
+    subject.next(1)
+    subject.next(2)
+  })
   await findByText('count: 2')
 
   fireEvent.click(getByText('button'))


### PR DESCRIPTION
close #1404 

error handling was already supported, so what this PR does are:
- add more tests with error handling.
- better error handling code eliminating Promise.reject().
- refactor the entire code with our recent experience with jotai/query and jotai/urql.
- options type is slightly changed to avoid confusion.