### PR TITLE
chore: fix the description in Overriding default atom values

### DIFF
--- a/docs/guides/composing-atoms.mdx
+++ b/docs/guides/composing-atoms.mdx
@@ -61,7 +61,7 @@ export const numberAtom = atom(
 ```
 
 The final `numberAtom` just works like a normal primitive atom like `atom(10)`.
-If you set a number value, it will override the `roundNumberAtom` value,
+If you set a number value, it will override the `overwrittenAtom` value,
 and if you set `null`, it will be the `roundNumberAtom` value.
 
 The reusable implementation is available as `atomWithDefault`


### PR DESCRIPTION
## Related Issues

- none

## Summary

- fix the description in [Overriding default atom values](docs/guides/composing-atoms.mdx)
- By the way, the code below is simpler than the example in this document. Why do we need to check the type of `typeof newValue === 'function'` ?

```ts
const rawNumberAtom = atom(10.1) // can be exported
const roundNumberAtom = atom((get) => Math.round(get(rawNumberAtom)))
const overwrittenAtom = atom<number | null>(null)
export const numberAtom = atom(
  (get) => get(overwrittenAtom) ?? get(roundNumberAtom),
  (_, set, newValue: number | null) => set(overwrittenAtom, newValue)
)
```

## Check List

- [ ] `yarn run prettier` for formatting code and docs
