### PR TITLE
chore: fix doc example in loadable api

### DIFF
--- a/docs/utils/loadable.mdx
+++ b/docs/utils/loadable.mdx
@@ -21,7 +21,7 @@ const asyncAtom = atom(async (get) => ...)
 const loadableAtom = loadable(asyncAtom)
 // Does not need to be wrapped by a <Suspense> element
 const Component = () => {
-  const value = useAtom(loadableAtom)
+  const [value] = useAtom(loadableAtom)
   if (value.state === 'hasError') return <Text>{value.error}</Text>
   if (value.state === 'loading') {
     return <Text>Loading...</Text>


### PR DESCRIPTION
## Related Issues

- none

## Summary

- Fixed how variables are assigned when getting an asynchronous response using the loadable API in the sample docs.
- Since the response type is `[Awaited<Value>, never]`, we need to enclose the variable in square brackets. Or is it better to fix it with `useAtomValue`?

## Check List

- [ ] `yarn run prettier` for formatting code and docs
