### PR TITLE
refactor(zustand): Removed unnecessary unknown extends

### DIFF
--- a/src/zustand/atomWithStore.ts
+++ b/src/zustand/atomWithStore.ts
@@ -1,8 +1,8 @@
-import type { State, StoreApi } from 'zustand/vanilla'
+import type { StoreApi } from 'zustand/vanilla'
 import { atom } from 'jotai'
 import type { SetStateAction } from 'jotai'
 
-export function atomWithStore<T extends State>(store: StoreApi<T>) {
+export function atomWithStore<T>(store: StoreApi<T>) {
   const baseAtom = atom(store.getState())
   baseAtom.onMount = (setValue) => {
     const callback = () => {


### PR DESCRIPTION
## Related Issues

Fixes #.

## Summary
The unknown part of <T extends unknown> in the atomWithStore function of the jotai/zustand package is unnecessary extends, so I deleted it. The reason is that the State type itself is marked as deprecated first. And since the StoreApi type generics does not extend anything in particular, this Generics T should be fine as is.

## Check List

- [x] `yarn run prettier` for formatting code and docs
