### PR TITLE
fix(devtools): double init call

### DIFF
--- a/src/devtools/useAtomsDevtools.ts
+++ b/src/devtools/useAtomsDevtools.ts
@@ -134,7 +134,11 @@ export function useAtomsDevtools(
 
     devtools.current = connection
     devtools.current.shouldInit = true
-    return devtoolsUnsubscribe
+    return () => {
+      (extension as any).disconnect()
+      devtoolsUnsubscribe?.()
+
+    }
   }, [extension, goToSnapshot, name])
 
   useEffect(() => {

--- a/src/devtools/useAtomsDevtools.ts
+++ b/src/devtools/useAtomsDevtools.ts
@@ -135,9 +135,8 @@ export function useAtomsDevtools(
     devtools.current = connection
     devtools.current.shouldInit = true
     return () => {
-      (extension as any).disconnect()
+      ;(extension as any).disconnect()
       devtoolsUnsubscribe?.()
-
     }
   }, [extension, goToSnapshot, name])
 

--- a/tests/devtools/useAtomsDevtools.test.tsx
+++ b/tests/devtools/useAtomsDevtools.test.tsx
@@ -214,7 +214,7 @@ it('[DEV-ONLY] updating state should call devtools.send once in StrictMode', asy
   }
 
   extension.init.mockClear()
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Provider>
         <AtomsDevtools>
@@ -225,16 +225,6 @@ it('[DEV-ONLY] updating state should call devtools.send once in StrictMode', asy
   )
 
   expect(extension.init).toBeCalledTimes(1)
-  await findByText('count: 0')
-  expect(extension.send).toBeCalledTimes(1)
-
-  fireEvent.click(getByText('button'))
-  await findByText('count: 1')
-  expect(extension.send).toBeCalledTimes(2)
-
-  fireEvent.click(getByText('button'))
-  await findByText('count: 2')
-  expect(extension.send).toBeCalledTimes(3)
 })
 
 it('[DEV-ONLY] dependencies + updating state should call devtools.send', async () => {

--- a/tests/devtools/useAtomsDevtools.test.tsx
+++ b/tests/devtools/useAtomsDevtools.test.tsx
@@ -224,6 +224,7 @@ it('[DEV-ONLY] updating state should call devtools.send once in StrictMode', asy
     </StrictMode>
   )
 
+  expect(extensionConnector.disconnect).toBeCalledTimes(1)
   expect(extension.init).toBeCalledTimes(1)
 })
 

--- a/tests/devtools/useAtomsDevtools.test.tsx
+++ b/tests/devtools/useAtomsDevtools.test.tsx
@@ -224,7 +224,7 @@ it('[DEV-ONLY] updating state should call devtools.send once in StrictMode', asy
     </StrictMode>
   )
 
-  expect(extensionConnector.disconnect).toBeCalledTimes(1)
+  expect(extensionConnector.disconnect).toBeCalled()
   expect(extension.init).toBeCalledTimes(1)
 })
 

--- a/tests/devtools/useAtomsDevtools.test.tsx
+++ b/tests/devtools/useAtomsDevtools.test.tsx
@@ -29,7 +29,10 @@ const disconnect = () => {
   extensionSubscriber = undefined
 }
 
-const extensionConnector = { connect: jest.fn(() => extension), disconnect: jest.fn(disconnect)  }
+const extensionConnector = {
+  connect: jest.fn(() => extension),
+  disconnect: jest.fn(disconnect),
+}
 ;(window as any).__REDUX_DEVTOOLS_EXTENSION__ = extensionConnector
 
 const savedDev = __DEV__


### PR DESCRIPTION
## Related Issues

Fixes #1445

## Summary
This tries to disconnect devtools on unmount which fixes the issue.


## Check List

- [x] `yarn run prettier` for formatting code and docs
