### PR TITLE
chore(test): test with old typescript versions

### DIFF
--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -56,5 +56,5 @@ jobs:
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          rm -r node_modules/@types/jsdom node_modules/parse5
+          rm -r node_modules/@types/jsdom node_modules/parse5 node_modules/@types/jest/node_modules/jest-diff
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -56,5 +56,5 @@ jobs:
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          rm -fr node_modules/@types/jsdom node_modules/parse5 node_modules/**/node_modules/pretty-format
+          rm -fr node_modules/@types/jsdom node_modules/parse5 node_modules/@types/prettier node_modules/**/node_modules/pretty-format
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -25,8 +25,6 @@ jobs:
           - 3.9.7
           - 3.8.3
           - 3.7.5
-          - 3.6.3
-          - 3.5.1
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -43,8 +43,8 @@ jobs:
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/\"exactOptionalPropertyTypes\": true,//" tsconfig.json
-          sed -i~ "s/\"jotai\": \[\".\/src\/index.ts\"\],/\"jotai\": [\".\/dist\/index.d.ts\"],/" tsconfig.json
-          sed -i~ "s/\"jotai\/\*\": \[\".\/src\/\*.ts\"\]/\"jotai\/*\": [\".\/dist\/*.d.ts\"]/" tsconfig.json
+          sed -i~ "s/\"jotai\": \[\".\/src\/index.ts\"\],/\"jotai\": [\".\/dist\/ts3.4\/index.d.ts\"],/" tsconfig.json
+          sed -i~ "s/\"jotai\/\*\": \[\".\/src\/\*.ts\"\]/\"jotai\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
       - name: Test ${{ matrix.typescript }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -53,9 +53,10 @@ jobs:
           sed -i~ "s/^import type /import /" tests/*.tsx tests/*/*.tsx
           sed -i~ "s/^.* from '\.\/utils\/waitForAll';//" dist/ts3.4/utils.d.ts
           yarn json -I -f package.json -e "this.resolutions['@types/jest']='27.4.1'; this.resolutions['pretty-format']='27.5.1';"
+          yarn add -D @types/jest@27.4.1 pretty-format@27.5.1
           rm -r tests/query tests/urql tests/optics tests/valtio tests/zustand tests/utils/atomWithObservable.* tests/utils/waitForAll.*
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          rm -fr node_modules/@types/jsdom node_modules/parse5 node_modules/@types/prettier
+          rm -r node_modules/@types/jsdom node_modules/parse5 node_modules/@types/prettier
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -38,8 +38,8 @@ jobs:
       - run: yarn build
       - name: Patch for Old TS
         run: |
-          sed -i~ '1s/^/import React from "react";/' tests/*.tsx
-          sed -i~ "s/\/\/ @ts-expect-error.*\[LATEST-TS-ONLY\]//" tests/*.tsx
+          sed -i~ '1s/^/import React from "react";/' tests/*.tsx tests/*/*.tsx
+          sed -i~ "s/\/\/ @ts-expect-error.*\[LATEST-TS-ONLY\]//" tests/*.tsx tests/*/*.tsx
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/\"exactOptionalPropertyTypes\": true,//" tsconfig.json

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -43,9 +43,10 @@ jobs:
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/\"exactOptionalPropertyTypes\": true,//" tsconfig.json
-          sed -i~ "s/\"jotai\": \[\".\/src\/index.ts\"\],/\"jotai\": [\".\/dist\/ts3.4\/index.d.ts\"],/" tsconfig.json
-          sed -i~ "s/\"jotai\/\*\": \[\".\/src\/\*.ts\"\]/\"jotai\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
+          sed -i~ "s/\"jotai\": \[\"\.\/src\/index\.ts\"\],/\"jotai\": [\".\/dist\/ts3.4\/index.d.ts\"],/" tsconfig.json
+          sed -i~ "s/\"jotai\/\*\": \[\"\.\/src\/\*\.ts\"\]/\"jotai\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
+          sed -i~ "s/\"types\": \"index\.d\.ts\",/\"types\": \"dist\/types\/index.d.ts\",/" node_modules/rxjs/package.json
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -52,7 +52,7 @@ jobs:
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/^import type /import /" tests/*.tsx tests/*/*.tsx
           yarn add -D @types/jest@27.4.1 @types/prettier@2.4.4
-          rm -r tests/query tests/urql tests/optics tests/valtio tests/zustand tests/utils/atomWithObservable.test.tsx tests/utils/waitForAll.test.tsx
+          rm -r tests/query tests/urql tests/optics tests/valtio tests/zustand tests/utils/atomWithObservable.* tests/utils/waitForAll.*
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -46,7 +46,7 @@ jobs:
           sed -i~ "s/\"jotai\": \[\"\.\/src\/index\.ts\"\],/\"jotai\": [\".\/dist\/ts3.4\/index.d.ts\"],/" tsconfig.json
           sed -i~ "s/\"jotai\/\*\": \[\"\.\/src\/\*\.ts\"\]/\"jotai\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
-          sed -i~ "s/\"types\": \"index\.d\.ts\",/\"types\": \"dist\/types\/index.d.ts\",/" node_modules/rxjs/package.json
+          sed -i~ "s/\">=4.2\": {/\">=3.4\": {/" node_modules/rxjs/package.json
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -46,8 +46,7 @@ jobs:
           sed -i~ "s/\"jotai\": \[\"\.\/src\/index\.ts\"\],/\"jotai\": [\".\/dist\/ts3.4\/index.d.ts\"],/" tsconfig.json
           sed -i~ "s/\"jotai\/\*\": \[\"\.\/src\/\*\.ts\"\]/\"jotai\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
-          sed -i~ "s/\"types\": \"index\.d\.ts\",/\"types\": \"dist\/types\/index.d.ts\",/" node_modules/rxjs/package.json
-          sed -i~ "s/\"typesVersions\": {/\"_typesVersions\": {/" node_modules/rxjs/package.json
+          sed -i~ "s/\"paths\": {/\"paths\": { \"rxjs\": [\".\/node_modules\/dist\/types\/index.d.ts\"],/" tsconfig.json
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -51,10 +51,11 @@ jobs:
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/^import type /import /" tests/*.tsx tests/*/*.tsx
-          yarn add -D @types/jest@27.4.1 pretty-format@27.5.1
+          sed -i~ "s/^.* from '\.\/utils\/waitForAll';//" dist/ts3.4/utils.d.ts
+          yarn json -I -f package.json -e "this.resolutions['@types/jest']='27.4.1'; this.resolutions['pretty-format']='27.5.1';"
           rm -r tests/query tests/urql tests/optics tests/valtio tests/zustand tests/utils/atomWithObservable.* tests/utils/waitForAll.*
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          rm -fr node_modules/@types/jsdom node_modules/parse5 node_modules/@types/prettier node_modules/**/node_modules/pretty-format
+          rm -fr node_modules/@types/jsdom node_modules/parse5 node_modules/@types/prettier
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -41,7 +41,6 @@ jobs:
           sed -i~ "s/\"jotai\": \[\"\.\/src\/index\.ts\"\],/\"jotai\": [\".\/dist\/ts3.4\/index.d.ts\"],/" tsconfig.json
           sed -i~ "s/\"jotai\/\*\": \[\"\.\/src\/\*\.ts\"\]/\"jotai\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
-          sed -i~ "s/\"paths\": {/\"paths\": { \"rxjs\": [\".\/node_modules\/rxjs\/dist\/types\/index.d.ts\"],/" tsconfig.json
       - name: Patch for Older TS
         if: ${{ matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -38,18 +38,23 @@ jobs:
       - run: yarn build
       - name: Patch for Old TS
         run: |
-          sed -i~ '1s/^/import React from "react";/' tests/*.tsx tests/*/*.tsx
           sed -i~ "s/\/\/ @ts-expect-error.*\[LATEST-TS-ONLY\]//" tests/*.tsx tests/*/*.tsx
-          sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
-          sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/\"exactOptionalPropertyTypes\": true,//" tsconfig.json
           sed -i~ "s/\"jotai\": \[\"\.\/src\/index\.ts\"\],/\"jotai\": [\".\/dist\/ts3.4\/index.d.ts\"],/" tsconfig.json
           sed -i~ "s/\"jotai\/\*\": \[\"\.\/src\/\*\.ts\"\]/\"jotai\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
           sed -i~ "s/\"paths\": {/\"paths\": { \"rxjs\": [\".\/node_modules\/rxjs\/dist\/types\/index.d.ts\"],/" tsconfig.json
+      - name: Patch for Older TS
+        if: ${{ matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}
+        run: |
+          sed -i~ '1s/^/import React from "react";/' tests/*.tsx tests/*/*.tsx
+          sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
+          sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
+          sed -i~ "s/^import type /import /" tests/*.tsx tests/*/*.tsx
+          yarn add -D @types/jest@27.4.1
+          rm -r tests/query tests/urql tests/optics
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          yarn add -D @types/jest@27.4.1
           rm -r node_modules/@types/jsdom node_modules/parse5
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -56,5 +56,5 @@ jobs:
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
           rm -r node_modules/@types/jsdom node_modules/parse5
-          sed -i~ "s/\"types\": \"index\.d\.ts\"/\"types\": \"dist\/types\/index.d.ts\"/" node_modules/rxjs/package.json
+          sed -i~ "s/\">=4.2\": {/\">=4.1\": {/" node_modules/rxjs/package.json
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -1,0 +1,53 @@
+name: Test Old TypeScript
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  test_matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        typescript:
+          - 4.8.4
+          - 4.7.4
+          - 4.6.4
+          - 4.5.5
+          - 4.4.4
+          - 4.3.5
+          - 4.2.3
+          - 4.1.5
+          - 4.0.5
+          - 3.9.7
+          - 3.8.3
+          - 3.7.5
+          - 3.6.3
+          - 3.5.1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          cache: yarn
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - run: yarn install --frozen-lockfile --check-files
+      - run: yarn build
+      - name: Patch for Old TS
+        run: |
+          sed -i~ '1s/^/import React from "react";/' tests/*.tsx
+          sed -i~ "s/\/\/ @ts-expect-error.*\[LATEST-TS-ONLY\]//" tests/*.tsx
+          sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
+          sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
+          sed -i~ "s/\"exactOptionalPropertyTypes\": true,//" tsconfig.json
+          sed -i~ "s/\"jotai\": \[\".\/src\/index.ts\"\],/\"jotai\": [\".\/dist\/index.d.ts\"],/" tsconfig.json
+          sed -i~ "s/\"jotai\/\*\": \[\".\/src\/\*.ts\"\]/\"jotai\/*\": [\".\/dist\/*.d.ts\"]/" tsconfig.json
+          sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
+      - name: Test ${{ matrix.typescript }}
+        run: |
+          yarn add -D typescript@${{ matrix.typescript }}
+          yarn add -D @types/jest@27.4.1
+          yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -52,8 +52,8 @@ jobs:
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/^import type /import /" tests/*.tsx tests/*/*.tsx
           sed -i~ "s/^.* from '\.\/utils\/waitForAll';//" dist/ts3.4/utils.d.ts
-          yarn json -I -f package.json -e "this.resolutions['@types/jest']='27.4.1'; this.resolutions['pretty-format']='27.5.1'; this.resolutions['@types/prettier']='2.4.4';"
-          yarn add -D @types/jest@27.4.1 pretty-format@27.5.1 @types/prettier@2.4.4
+          yarn json -I -f package.json -e "this.resolutions['@types/jest']='26.0.14'; this.resolutions['pretty-format']='26.6.2'; this.resolutions['@types/prettier']='2.4.2';"
+          yarn add -D @types/jest@26.0.14 pretty-format@26.6.2 @types/prettier@2.4.2
           rm -r tests/query tests/urql tests/optics tests/xstate tests/valtio tests/zustand tests/utils/atomWithObservable.* tests/utils/waitForAll.*
       - name: Test ${{ matrix.typescript }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -41,7 +41,6 @@ jobs:
           sed -i~ "s/\"jotai\": \[\"\.\/src\/index\.ts\"\],/\"jotai\": [\".\/dist\/ts3.4\/index.d.ts\"],/" tsconfig.json
           sed -i~ "s/\"jotai\/\*\": \[\"\.\/src\/\*\.ts\"\]/\"jotai\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
-          sed -i~ "s/\"types\": \"index\.d\.ts\"/\"types\": \"dist\/types\/index.d.ts\"/" node_modules/rxjs/package.json
       - name: Patch for Older TS
         if: ${{ matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}
         run: |
@@ -57,4 +56,5 @@ jobs:
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
           rm -r node_modules/@types/jsdom node_modules/parse5
+          sed -i~ "s/\"types\": \"index\.d\.ts\"/\"types\": \"dist\/types\/index.d.ts\"/" node_modules/rxjs/package.json
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -52,8 +52,8 @@ jobs:
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/^import type /import /" tests/*.tsx tests/*/*.tsx
           sed -i~ "s/^.* from '\.\/utils\/waitForAll';//" dist/ts3.4/utils.d.ts
-          yarn json -I -f package.json -e "this.resolutions['@types/jest']='26.0.14'; this.resolutions['pretty-format']='26.6.2'; this.resolutions['@types/prettier']='2.4.2';"
-          yarn add -D @types/jest@26.0.14 pretty-format@26.6.2 @types/prettier@2.4.2
+          yarn json -I -f package.json -e "this.resolutions['@types/jest']='26.0.14'; this.resolutions['pretty-format']='25.5.0'; this.resolutions['@types/prettier']='2.4.2';"
+          yarn add -D @types/jest@26.0.14 pretty-format@25.5.0 @types/prettier@2.4.2
           rm -r tests/query tests/urql tests/optics tests/xstate tests/valtio tests/zustand tests/utils/atomWithObservable.* tests/utils/waitForAll.*
       - name: Test ${{ matrix.typescript }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -46,7 +46,7 @@ jobs:
           sed -i~ "s/\"jotai\": \[\"\.\/src\/index\.ts\"\],/\"jotai\": [\".\/dist\/ts3.4\/index.d.ts\"],/" tsconfig.json
           sed -i~ "s/\"jotai\/\*\": \[\"\.\/src\/\*\.ts\"\]/\"jotai\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
-          sed -i~ "s/\">=4.2\": {/\">=3.4\": {/" node_modules/rxjs/package.json
+          sed -i~ "s/\"types\": \"index\.d\.ts\",/\"types\": \"dist\/types\/index.d.ts\",/" node_modules/rxjs/package.json
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -47,6 +47,7 @@ jobs:
           sed -i~ "s/\"jotai\/\*\": \[\"\.\/src\/\*\.ts\"\]/\"jotai\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
           sed -i~ "s/\"types\": \"index\.d\.ts\",/\"types\": \"dist\/types\/index.d.ts\",/" node_modules/rxjs/package.json
+          sed -i~ "s/\"typesVersions\": {/\"_typesVersions\": {/" node_modules/rxjs/package.json
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -41,7 +41,7 @@ jobs:
           sed -i~ "s/\"jotai\": \[\"\.\/src\/index\.ts\"\],/\"jotai\": [\".\/dist\/ts3.4\/index.d.ts\"],/" tsconfig.json
           sed -i~ "s/\"jotai\/\*\": \[\"\.\/src\/\*\.ts\"\]/\"jotai\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
-          sed -i~ "s/\"types\": \"index\.d\.ts\"/\"types\": \"dist/types/index.d.ts\"/" node_modules/rxjs/package.json
+          sed -i~ "s/\"types\": \"index\.d\.ts\"/\"types\": \"dist\/types\/index.d.ts\"/" node_modules/rxjs/package.json
       - name: Patch for Older TS
         if: ${{ matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -51,7 +51,7 @@ jobs:
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/^import type /import /" tests/*.tsx tests/*/*.tsx
-          yarn add -D @types/jest@27.4.1 @types/prettier@2.4.4
+          yarn add -D @types/jest@27.4.1 @types/prettier@2.4.4 pretty-format@27.5.1
           rm -r tests/query tests/urql tests/optics tests/valtio tests/zustand tests/utils/atomWithObservable.* tests/utils/waitForAll.*
       - name: Test ${{ matrix.typescript }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -46,7 +46,7 @@ jobs:
           sed -i~ "s/\"jotai\": \[\"\.\/src\/index\.ts\"\],/\"jotai\": [\".\/dist\/ts3.4\/index.d.ts\"],/" tsconfig.json
           sed -i~ "s/\"jotai\/\*\": \[\"\.\/src\/\*\.ts\"\]/\"jotai\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
-          sed -i~ "s/\"paths\": {/\"paths\": { \"rxjs\": [\".\/node_modules\/dist\/types\/index.d.ts\"],/" tsconfig.json
+          sed -i~ "s/\"paths\": {/\"paths\": { \"rxjs\": [\".\/node_modules\/rxjs\/dist\/types\/index.d.ts\"],/" tsconfig.json
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -51,8 +51,8 @@ jobs:
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/^import type /import /" tests/*.tsx tests/*/*.tsx
-          yarn add -D @types/jest@27.4.1
-          rm -r tests/query tests/urql tests/optics
+          yarn add -D @types/jest@27.4.1 @types/prettier@2.4.4
+          rm -r tests/query tests/urql tests/optics tests/valtio tests/zustand tests/utils/atomWithObservable.test.tsx tests/utils/waitForAll.test.tsx
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -56,5 +56,5 @@ jobs:
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          rm -r node_modules/@types/jsdom node_modules/parse5 node_modules/@types/jest/node_modules/jest-diff
+          rm -fr node_modules/@types/jsdom node_modules/parse5 node_modules/@types/jest/node_modules/jest-diff node_modules/@sinclair/typebox/typebox.d.ts
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -51,10 +51,10 @@ jobs:
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/^import type /import /" tests/*.tsx tests/*/*.tsx
-          yarn add -D @types/jest@27.4.1 @types/prettier@2.4.4 pretty-format@27.5.1
+          yarn add -D @types/jest@27.4.1 pretty-format@27.5.1
           rm -r tests/query tests/urql tests/optics tests/valtio tests/zustand tests/utils/atomWithObservable.* tests/utils/waitForAll.*
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          rm -fr node_modules/@types/jsdom node_modules/parse5 node_modules/@types/jest/node_modules/jest-diff
+          rm -fr node_modules/@types/jsdom node_modules/parse5 node_modules/**/node_modules/pretty-format
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -56,5 +56,5 @@ jobs:
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          rm -fr node_modules/@types/jsdom node_modules/parse5 node_modules/@types/jest/node_modules/jest-diff node_modules/@sinclair/typebox/typebox.d.ts
+          rm -fr node_modules/@types/jsdom node_modules/parse5 node_modules/@types/jest/node_modules/jest-diff
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -52,11 +52,11 @@ jobs:
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/^import type /import /" tests/*.tsx tests/*/*.tsx
           sed -i~ "s/^.* from '\.\/utils\/waitForAll';//" dist/ts3.4/utils.d.ts
-          yarn json -I -f package.json -e "this.resolutions['@types/jest']='27.4.1'; this.resolutions['pretty-format']='27.5.1';"
-          yarn add -D @types/jest@27.4.1 pretty-format@27.5.1
-          rm -r tests/query tests/urql tests/optics tests/valtio tests/zustand tests/utils/atomWithObservable.* tests/utils/waitForAll.*
+          yarn json -I -f package.json -e "this.resolutions['@types/jest']='27.4.1'; this.resolutions['pretty-format']='27.5.1'; this.resolutions['@types/prettier']='2.4.4';"
+          yarn add -D @types/jest@27.4.1 pretty-format@27.5.1 @types/prettier@2.4.4
+          rm -r tests/query tests/urql tests/optics tests/xstate tests/valtio tests/zustand tests/utils/atomWithObservable.* tests/utils/waitForAll.*
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          rm -r node_modules/@types/jsdom node_modules/parse5 node_modules/@types/prettier
+          rm -r node_modules/@types/jsdom node_modules/parse5
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -41,6 +41,7 @@ jobs:
           sed -i~ "s/\"jotai\": \[\"\.\/src\/index\.ts\"\],/\"jotai\": [\".\/dist\/ts3.4\/index.d.ts\"],/" tsconfig.json
           sed -i~ "s/\"jotai\/\*\": \[\"\.\/src\/\*\.ts\"\]/\"jotai\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
+          sed -i~ "s/\"types\": \"index\.d\.ts\"/\"types\": \"dist/types/index.d.ts\"/" node_modules/rxjs/package.json
       - name: Patch for Older TS
         if: ${{ matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -50,4 +50,5 @@ jobs:
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
           yarn add -D @types/jest@27.4.1
+          rm -r node_modules/@types/jsdom node_modules/parse5
           yarn tsc --noEmit

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -1,7 +1,13 @@
 import { expectType } from 'ts-expect'
 import { atom, useAtom } from 'jotai'
 import type { Atom, PrimitiveAtom, WritableAtom } from 'jotai'
-import type { SetAtom } from '../src/core/atom'
+
+type SetAtom<
+  Update,
+  Result extends void | Promise<void>
+> = undefined extends Update
+  ? (update?: Update) => Result
+  : (update: Update) => Result
 
 it('atom() should return the correct types', () => {
   function Component() {


### PR DESCRIPTION
In https://github.com/pmndrs/zustand/pull/1348, I added a workflow to test against old ts versions. Let's follow it.