### PR TITLE
chore(docs): duplicate verb in multiple tenses

### DIFF
--- a/docs/guides/async.mdx
+++ b/docs/guides/async.mdx
@@ -96,7 +96,7 @@ const Component = () => {
 
 ## Async sometimes
 
-An interesting pattern that can be achieved with Jotai are is switching from async to sync to trigger suspending when wanted.
+An interesting pattern that can be achieved with Jotai is switching from async to sync to trigger suspending when wanted.
 
 ```js
 const request = async () => fetch('https://...').then((res) => res.json())


### PR DESCRIPTION
## Summary

Fixes documentation that had grammatically incorrect sentence.

## Check List

- [x] `yarn run prettier` for formatting code and docs
