### PR TITLE
feat(babel): Support custom atom names

### DIFF
--- a/docs/api/babel.mdx
+++ b/docs/api/babel.mdx
@@ -51,6 +51,16 @@ With a `babel` configuration file:
 }
 ```
 
+You can also supply your atom names to the plugin:
+
+```json
+{
+  "plugins": [
+    ["jotai/babel/plugin-debug-label", { "customAtomNames": ["customAtom"] }]
+  ]
+}
+```
+
 Examples can be found below.
 
 ## plugin-react-refresh
@@ -67,6 +77,16 @@ With a `babel` configuration file:
 }
 ```
 
+You can also supply your atom names to the plugin:
+
+```json
+{
+  "plugins": [
+    ["jotai/babel/plugin-react-refresh", { "customAtomNames": ["customAtom"] }]
+  ]
+}
+```
+
 Examples can be found below.
 
 ## preset
@@ -80,6 +100,14 @@ With a `babel` configuration file:
 ```json
 {
   "presets": ["jotai/babel/preset"]
+}
+```
+
+You can also supply your atom names to the preset:
+
+```json
+{
+  "presets": [["jotai/babel/preset", { "customAtomNames": ["customAtom"] }]]
 }
 ```
 

--- a/src/babel/plugin-debug-label.ts
+++ b/src/babel/plugin-debug-label.ts
@@ -1,20 +1,21 @@
 import path from 'path'
 import babel, { PluginObj } from '@babel/core'
 import _templateBuilder from '@babel/template'
-import { isAtom } from './utils'
+import { PluginOptions, isAtom } from './utils'
 
 const templateBuilder = (_templateBuilder as any).default || _templateBuilder
 
-export default function debugLabelPlugin({
-  types: t,
-}: typeof babel): PluginObj {
+export default function debugLabelPlugin(
+  { types: t }: typeof babel,
+  options?: PluginOptions
+): PluginObj {
   return {
     visitor: {
       ExportDefaultDeclaration(nodePath, state) {
         const { node } = nodePath
         if (
           t.isCallExpression(node.declaration) &&
-          isAtom(t, node.declaration.callee)
+          isAtom(t, node.declaration.callee, options?.customAtomNames)
         ) {
           const filename = state.filename || 'unknown'
 
@@ -40,7 +41,7 @@ export default function debugLabelPlugin({
         if (
           t.isIdentifier(path.node.id) &&
           t.isCallExpression(path.node.init) &&
-          isAtom(t, path.node.init.callee)
+          isAtom(t, path.node.init.callee, options?.customAtomNames)
         ) {
           path.parentPath.insertAfter(
             t.expressionStatement(

--- a/src/babel/plugin-debug-label.ts
+++ b/src/babel/plugin-debug-label.ts
@@ -1,7 +1,8 @@
 import path from 'path'
 import babel, { PluginObj } from '@babel/core'
 import _templateBuilder from '@babel/template'
-import { PluginOptions, isAtom } from './utils'
+import { isAtom } from './utils'
+import type { PluginOptions } from './utils'
 
 const templateBuilder = (_templateBuilder as any).default || _templateBuilder
 

--- a/src/babel/plugin-react-refresh.ts
+++ b/src/babel/plugin-react-refresh.ts
@@ -1,6 +1,7 @@
 import babel, { PluginObj } from '@babel/core'
 import _templateBuilder from '@babel/template'
-import { PluginOptions, isAtom } from './utils'
+import { isAtom } from './utils'
+import type { PluginOptions } from './utils'
 
 const templateBuilder = (_templateBuilder as any).default || _templateBuilder
 

--- a/src/babel/plugin-react-refresh.ts
+++ b/src/babel/plugin-react-refresh.ts
@@ -1,12 +1,13 @@
 import babel, { PluginObj } from '@babel/core'
 import _templateBuilder from '@babel/template'
-import { isAtom } from './utils'
+import { PluginOptions, isAtom } from './utils'
 
 const templateBuilder = (_templateBuilder as any).default || _templateBuilder
 
-export default function reactRefreshPlugin({
-  types: t,
-}: typeof babel): PluginObj {
+export default function reactRefreshPlugin(
+  { types: t }: typeof babel,
+  options?: PluginOptions
+): PluginObj {
   return {
     pre({ opts }) {
       if (!opts.filename) {
@@ -34,7 +35,7 @@ export default function reactRefreshPlugin({
         const { node } = nodePath
         if (
           t.isCallExpression(node.declaration) &&
-          isAtom(t, node.declaration.callee)
+          isAtom(t, node.declaration.callee, options?.customAtomNames)
         ) {
           const filename = state.filename || 'unknown'
           const atomKey = `${filename}/defaultExport`
@@ -53,7 +54,7 @@ export default function reactRefreshPlugin({
         if (
           t.isIdentifier(nodePath.node.id) &&
           t.isCallExpression(nodePath.node.init) &&
-          isAtom(t, nodePath.node.init.callee) &&
+          isAtom(t, nodePath.node.init.callee, options?.customAtomNames) &&
           // Make sure atom declaration is in module scope
           (nodePath.parentPath.parentPath?.isProgram() ||
             nodePath.parentPath.parentPath?.isExportNamedDeclaration())

--- a/src/babel/preset.ts
+++ b/src/babel/preset.ts
@@ -1,9 +1,16 @@
 import babel from '@babel/core'
 import pluginDebugLabel from './plugin-debug-label'
 import pluginReactRefresh from './plugin-react-refresh'
+import { PluginOptions } from './utils'
 
-export default function jotaiPreset(): { plugins: babel.PluginItem[] } {
+export default function jotaiPreset(
+  _: typeof babel,
+  options?: PluginOptions
+): { plugins: babel.PluginItem[] } {
   return {
-    plugins: [pluginDebugLabel, pluginReactRefresh],
+    plugins: [
+      [pluginDebugLabel, options],
+      [pluginReactRefresh, options],
+    ],
   }
 }

--- a/src/babel/utils.ts
+++ b/src/babel/utils.ts
@@ -7,7 +7,7 @@ export interface PluginOptions {
 export function isAtom(
   t: typeof types,
   callee: babel.types.Expression | babel.types.V8IntrinsicIdentifier,
-  customAtomNames: PluginOptions['customAtomNames'] | undefined = []
+  customAtomNames: PluginOptions['customAtomNames'] = []
 ) {
   if (t.isIdentifier(callee) && atomFunctionNames.includes(callee.name)) {
     return true

--- a/src/babel/utils.ts
+++ b/src/babel/utils.ts
@@ -1,8 +1,13 @@
 import { types } from '@babel/core'
 
+export interface PluginOptions {
+  customAtomNames?: string[]
+}
+
 export function isAtom(
   t: typeof types,
-  callee: babel.types.Expression | babel.types.V8IntrinsicIdentifier
+  callee: babel.types.Expression | babel.types.V8IntrinsicIdentifier,
+  customAtomNames: PluginOptions['customAtomNames'] | undefined = []
 ) {
   if (t.isIdentifier(callee) && atomFunctionNames.includes(callee.name)) {
     return true
@@ -10,7 +15,10 @@ export function isAtom(
 
   if (t.isMemberExpression(callee)) {
     const { property } = callee
-    if (t.isIdentifier(property) && atomFunctionNames.includes(property.name)) {
+    if (
+      t.isIdentifier(property) &&
+      [...atomFunctionNames, ...customAtomNames].includes(property.name)
+    ) {
       return true
     }
   }

--- a/tests/babel/plugin-debug-label.test.ts
+++ b/tests/babel/plugin-debug-label.test.ts
@@ -3,12 +3,16 @@ import { transformSync } from '@babel/core'
 
 const plugin = path.join(__dirname, '../../src/babel/plugin-debug-label')
 
-const transform = (code: string, filename?: string) =>
+const transform = (
+  code: string,
+  filename?: string,
+  customAtomNames?: string[]
+) =>
   transformSync(code, {
     babelrc: false,
     configFile: false,
     filename,
-    plugins: [[plugin]],
+    plugins: [[plugin, { customAtomNames }]],
   })?.code
 
 it('Should add a debugLabel to an atom', () => {
@@ -124,5 +128,14 @@ it('Should handle all atom types', () => {
     selectedValueAtom.debugLabel = "selectedValueAtom";
     const splittedAtom = splitAtom(atom([]));
     splittedAtom.debugLabel = "splittedAtom";"
+  `)
+})
+
+it('Handles custom atom names a debugLabel to an atom', () => {
+  expect(
+    transform(`const mySpecialThing = atom(0);`, undefined, ['mySpecialThing'])
+  ).toMatchInlineSnapshot(`
+    "const mySpecialThing = atom(0);
+    mySpecialThing.debugLabel = "mySpecialThing";"
   `)
 })

--- a/tests/babel/preset.test.ts
+++ b/tests/babel/preset.test.ts
@@ -3,12 +3,16 @@ import { transformSync } from '@babel/core'
 
 const preset = path.join(__dirname, '../../src/babel/preset')
 
-const transform = (code: string, filename?: string) =>
+const transform = (
+  code: string,
+  filename?: string,
+  customAtomNames?: string[]
+) =>
   transformSync(code, {
     babelrc: false,
     configFile: false,
     filename,
-    presets: [[preset]],
+    presets: [[preset, { customAtomNames }]],
   })?.code
 
 it('Should add a debugLabel and cache to an atom', () => {
@@ -148,4 +152,28 @@ it('Should fail if no filename is available', () => {
   expect(() => transform(`const countAtom = atom(0);`)).toThrowError(
     'Filename must be available'
   )
+})
+
+it('Should handle custom atom names', () => {
+  expect(
+    transform(`const mySpecialThing = atom(0);`, '/src/atoms.ts', [
+      'mySpecialThing',
+    ])
+  ).toMatchInlineSnapshot(`
+    "globalThis.jotaiAtomCache = globalThis.jotaiAtomCache || {
+      cache: new Map(),
+
+      get(name, inst) {
+        if (this.cache.has(name)) {
+          return this.cache.get(name);
+        }
+
+        this.cache.set(name, inst);
+        return inst;
+      }
+
+    };
+    const mySpecialThing = globalThis.jotaiAtomCache.get("/src/atoms.ts/mySpecialThing", atom(0));
+    mySpecialThing.debugLabel = "mySpecialThing";"
+  `)
 })


### PR DESCRIPTION
## Related Issues

Fixes #1414.

## Summary

This PR adds support for custom atom names for the Babel plugins.
