### PR TITLE
test: custom atom names case

### DIFF
--- a/tests/babel/plugin-debug-label.test.ts
+++ b/tests/babel/plugin-debug-label.test.ts
@@ -133,9 +133,11 @@ it('Should handle all atom types', () => {
 
 it('Handles custom atom names a debugLabel to an atom', () => {
   expect(
-    transform(`const mySpecialThing = atom(0);`, undefined, ['mySpecialThing'])
+    transform(`const mySpecialThing = myCustomAtom(0);`, undefined, [
+      'myCustomAtom',
+    ])
   ).toMatchInlineSnapshot(`
-    "const mySpecialThing = atom(0);
+    "const mySpecialThing = myCustomAtom(0);
     mySpecialThing.debugLabel = "mySpecialThing";"
   `)
 })

--- a/tests/babel/plugin-react-refresh.test.ts
+++ b/tests/babel/plugin-react-refresh.test.ts
@@ -169,9 +169,11 @@ it('Should handle atoms returned from functions (#891)', () => {
 
 it('Should handle custom atom names', () => {
   expect(
-    transform(`const mySpecialThing = atom(0);`, '/src/atoms/index.ts', [
-      'mySpecialThing',
-    ])
+    transform(
+      `const mySpecialThing = myCustomAtom(0);`,
+      '/src/atoms/index.ts',
+      ['myCustomAtom']
+    )
   ).toMatchInlineSnapshot(`
     "globalThis.jotaiAtomCache = globalThis.jotaiAtomCache || {
       cache: new Map(),
@@ -183,6 +185,6 @@ it('Should handle custom atom names', () => {
         return inst;
       }
     };
-    const mySpecialThing = globalThis.jotaiAtomCache.get("/src/atoms/index.ts/mySpecialThing", atom(0));"
+    const mySpecialThing = globalThis.jotaiAtomCache.get("/src/atoms/index.ts/mySpecialThing", myCustomAtom(0));"
   `)
 })

--- a/tests/babel/preset.test.ts
+++ b/tests/babel/preset.test.ts
@@ -141,8 +141,8 @@ it('Should fail if no filename is available', () => {
 
 it('Should handle custom atom names', () => {
   expect(
-    transform(`const mySpecialThing = atom(0);`, '/src/atoms.ts', [
-      'mySpecialThing',
+    transform(`const mySpecialThing = myCustomAtom(0);`, '/src/atoms.ts', [
+      'myCustomAtom',
     ])
   ).toMatchInlineSnapshot(`
     "globalThis.jotaiAtomCache = globalThis.jotaiAtomCache || {
@@ -155,7 +155,7 @@ it('Should handle custom atom names', () => {
         return inst;
       }
     };
-    const mySpecialThing = globalThis.jotaiAtomCache.get("/src/atoms.ts/mySpecialThing", atom(0));
+    const mySpecialThing = globalThis.jotaiAtomCache.get("/src/atoms.ts/mySpecialThing", myCustomAtom(0));
     mySpecialThing.debugLabel = "mySpecialThing";"
   `)
 })


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/pmndrs/jotai/pull/1480

## Summary
The test case about custom atom names should test the node's initializer expression.


## Check List

- [x] `yarn run prettier` for formatting code and docs
