### PR TITLE
docs: describe sync/async atoms creation in TypeScript

### DIFF
--- a/docs/guides/async.mdx
+++ b/docs/guides/async.mdx
@@ -110,6 +110,14 @@ const Component = () => {
 }
 ```
 
+### Usage in TypeScript
+
+In TypeScript `atom(0)` is inferred as `PrimitiveAtom<number>`. It cannot accept `Promise<number>` as a value so preceding code would not typecheck. To accomodate for that you need to type your atom explicitly and add `Promise<number>` as accepted value.
+
+```ts
+const baseAtom = atom<number | Promise<number>>(0) // Will accept sync and async values
+```
+
 ## Async forever
 
 Sometimes you may want to suspend until an unpredetermined moment (or never).


### PR DESCRIPTION
## Related Issues

Fixes problem mentioned in discussion #1589

## Summary
Jotai atoms might start as sync atoms and later become async when provided with async value (Promise). Without explicit typing using sync atom as async does not typecheck in TypeScript. It's useful to add this information to documentation and describe a solution.


## Check List

- [x] `yarn run prettier` for formatting code and docs
