### PR TITLE
fix(docs): rename to jotai-optics

### DIFF
--- a/docs/advanced-recipes/custom-useatom-hooks.mdx
+++ b/docs/advanced-recipes/custom-useatom-hooks.mdx
@@ -55,7 +55,7 @@ export function useSplitAtom(anAtom) {
 
 ```js
 import { useAtom } from 'jotai'
-import { focusAtom } from 'jotai/optics'
+import { focusAtom } from 'jotai-optics'
 
 /* if an atom is created here, please use `useMemo(() => atom(initValue), [initValue])` instead. */
 export function useFocusAtom(anAtom, keyFn) {

--- a/docs/advanced-recipes/large-objects.mdx
+++ b/docs/advanced-recipes/large-objects.mdx
@@ -41,13 +41,13 @@ const initialData = {
 
 ## focusAtom
 
-> `focusAtom` creates a new atom, based on the focus that you pass to it. [jotai/optics](../integrations/optics.mdx#focus-atom)
+> `focusAtom` creates a new atom, based on the focus that you pass to it. [jotai-optics](../integrations/optics.mdx#focus-atom)
 
 We use this utility to focus an atom and create an atom from a specific part of the data. For example we may need to consume the people property of the above data, Here's how we do it:
 
 ```js
 import { atom } from 'jotai'
-import { focusAtom } from 'jotai/optics'
+import { focusAtom } from 'jotai-optics'
 
 const dataAtom = atom(initialData)
 

--- a/docs/guides/composing-atoms.mdx
+++ b/docs/guides/composing-atoms.mdx
@@ -101,7 +101,7 @@ So, if we use this atom in two different Providers,
 There will be an inconsistency between the two `persistedAtom` values.
 This could be solved if the external value had a subscription mechanism.
 
-For example, `atomWithProxy` in `jotai/valtio` comes with subscription,
+For example, `atomWithProxy` in `jotai-valtio` comes with subscription,
 so we don't have such a limitation. Values in different Providers
 will be in sync.
 


### PR DESCRIPTION
a leftover in #1573.