### PR TITLE
feat(vanilla): rename unwrapAtom to unwrap (v2 API)

### DIFF
--- a/src/vanilla/utils.ts
+++ b/src/vanilla/utils.ts
@@ -17,4 +17,4 @@ export {
 } from './utils/atomWithStorage'
 export { atomWithObservable } from './utils/atomWithObservable'
 export { loadable } from './utils/loadable'
-export { unwrapAtom as unstable_unwrapAtom } from './utils/unwrapAtom'
+export { unwrap as unstable_unwrap } from './utils/unwrap'

--- a/src/vanilla/utils/unwrap.ts
+++ b/src/vanilla/utils/unwrap.ts
@@ -5,7 +5,7 @@ const cache1 = new WeakMap()
 const memo1 = <T>(create: () => T, dep1: object): T =>
   (cache1.has(dep1) ? cache1 : cache1.set(dep1, create())).get(dep1)
 
-export function unwrapAtom<Value>(
+export function unwrap<Value>(
   anAtom: Atom<Promise<Value>>,
   defaultValue: Awaited<Value>
 ): Atom<Awaited<Value>> {

--- a/tests/vanilla/utils/unwrap.test.tsx
+++ b/tests/vanilla/utils/unwrap.test.tsx
@@ -1,7 +1,7 @@
 import { atom, createStore } from 'jotai/vanilla'
-import { unstable_unwrapAtom as unwrapAtom } from 'jotai/vanilla/utils'
+import { unstable_unwrap as unwrap } from 'jotai/vanilla/utils'
 
-describe('unwrapAtom', () => {
+describe('unwrap', () => {
   it('should unwrap a promise', async () => {
     const store = createStore()
     const countAtom = atom(1)
@@ -11,7 +11,7 @@ describe('unwrapAtom', () => {
       await new Promise<void>((r) => (resolve = r))
       return count * 2
     })
-    const syncAtom = unwrapAtom(asyncAtom, 0)
+    const syncAtom = unwrap(asyncAtom, 0)
     expect(store.get(syncAtom)).toBe(0)
     resolve()
     await new Promise((r) => setTimeout(r)) // wait a tick


### PR DESCRIPTION
follow up #1515.

(this is still an unstable feature.)