### PR TITLE
refactor(vanilla/utils): avoid refAtom in selectAtom (v2 API)

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -4,7 +4,11 @@
  */
 export { atom } from './vanilla/atom'
 export type { Atom, WritableAtom, PrimitiveAtom } from './vanilla/atom'
-export { createStore, getDefaultStore } from './vanilla/store'
+export {
+  createStore,
+  getDefaultStore,
+  NoAtomInitError as unstable_NoAtomInitError,
+} from './vanilla/store'
 export type {
   Getter,
   Setter,

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -8,6 +8,8 @@ type OnUnmount = () => void
 type Getter = Parameters<AnyAtom['read']>[0]
 type Setter = Parameters<AnyWritableAtom['write']>[1]
 
+export const NoAtomInitError = new Error('no atom init')
+
 const hasInitialValue = <T extends Atom<AnyValue>>(
   atom: T
 ): atom is T & (T extends Atom<infer Value> ? { init: Value } : never) =>
@@ -265,7 +267,7 @@ export const createStore = () => {
           return a.init
         }
         // NOTE invalid derived atoms can reach here
-        throw new Error('no atom init')
+        throw NoAtomInitError
       }
       // a !== atom
       const aState = readAtomState(a)


### PR DESCRIPTION
So, this applies the idea from @justjake in #936 to the v2 API.
It's now possible because in the v2 API, `get` doesn't throw promises.
