### PR TITLE
fix(vanilla): make restore atoms dev only (v2 API)

### DIFF
--- a/docs/guides/migrating-to-v2-api.mdx
+++ b/docs/guides/migrating-to-v2-api.mdx
@@ -220,3 +220,4 @@ const allAtom = atom((get) => Promise.all([get(fooAtom), get(barAtom)]))
 ## Some other changes
 
 - `atomWithStorage` util's `delayInit` is removed as being default.
+- `useHydrateAtoms` can only accept writable atoms.

--- a/src/react/devtools/useGotoAtomsSnapshot.ts
+++ b/src/react/devtools/useGotoAtomsSnapshot.ts
@@ -16,8 +16,8 @@ export function useGotoAtomsSnapshot(options?: Options) {
   const store = useStore(options)
   return useCallback(
     (snapshot: AtomsSnapshot) => {
-      if (store.dev_subscribe_state) {
-        store.res(snapshot.values)
+      if (store.dev_restore_atoms) {
+        store.dev_restore_atoms(snapshot.values)
       }
     },
     [store]

--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -1,28 +1,24 @@
 import { useStore } from 'jotai/react'
-import type { Atom } from 'jotai/vanilla'
+import type { WritableAtom } from 'jotai/vanilla'
 
 type Store = ReturnType<typeof useStore>
 type Options = Parameters<typeof useStore>[0]
+type AnyWritableAtom = WritableAtom<unknown, any[], any>
 
-const hydratedMap: WeakMap<Store, WeakSet<Atom<unknown>>> = new WeakMap()
+const hydratedMap: WeakMap<Store, WeakSet<AnyWritableAtom>> = new WeakMap()
 
 export function useHydrateAtoms(
-  values: Iterable<readonly [Atom<unknown>, unknown]>,
+  values: Iterable<readonly [AnyWritableAtom, unknown]>,
   options?: Options
 ) {
   const store = useStore(options)
 
   const hydratedSet = getHydratedSet(store)
-  const tuplesToRestore: (readonly [Atom<unknown>, unknown])[] = []
-  for (const tuple of values) {
-    const atom = tuple[0]
+  for (const [atom, value] of values) {
     if (!hydratedSet.has(atom)) {
       hydratedSet.add(atom)
-      tuplesToRestore.push(tuple)
+      store.set(atom, value)
     }
-  }
-  if (tuplesToRestore.length) {
-    store.res(tuplesToRestore)
   }
 }
 

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -550,24 +550,11 @@ export const createStore = () => {
     }
   }
 
-  const restoreAtoms = (
-    values: Iterable<readonly [AnyAtom, AnyValue]>
-  ): void => {
-    for (const [atom, value] of values) {
-      if (hasInitialValue(atom)) {
-        setAtomValue(atom, value)
-        recomputeDependents(atom)
-      }
-    }
-    flushPending()
-  }
-
   if (__DEV__) {
     return {
       get: readAtom,
       set: writeAtom,
       sub: subscribeAtom,
-      res: restoreAtoms,
       // store dev methods (these are tentative and subject to change)
       dev_subscribe_state: (l: StateListener) => {
         stateListeners.add(l)
@@ -578,13 +565,21 @@ export const createStore = () => {
       dev_get_mounted_atoms: () => mountedAtoms.values(),
       dev_get_atom_state: (a: AnyAtom) => atomStateMap.get(a),
       dev_get_mounted: (a: AnyAtom) => mountedMap.get(a),
+      dev_restore_atoms: (values: Iterable<readonly [AnyAtom, AnyValue]>) => {
+        for (const [atom, value] of values) {
+          if (hasInitialValue(atom)) {
+            setAtomValue(atom, value)
+            recomputeDependents(atom)
+          }
+        }
+        flushPending()
+      },
     }
   }
   return {
     get: readAtom,
     set: writeAtom,
     sub: subscribeAtom,
-    res: restoreAtoms,
   }
 }
 


### PR DESCRIPTION
When I worked on #1515, I was very skeptical about it. `restoreAtoms` is like a hack as public api. This PR make it dev-only. We may revisit it after v2 release, but this feels more comfortable and should make sense.

#1646 reminds me of this. Thanks.