### PR TITLE
fix(vanilla): reading async atom twice before resolving (v2 API)

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -339,6 +339,7 @@ export const createStore = () => {
             resolve(next)
           }
         })
+        promise.status = 'pending'
         registerCancelPromise(promise, (next) => {
           if (next) {
             continuePromise(next as Promise<Awaited<Value>>)

--- a/tests/vanilla/dependency.test.tsx
+++ b/tests/vanilla/dependency.test.tsx
@@ -43,9 +43,10 @@ it('can get async atom with deps more than once before resolving (#1668)', async
   store.set(countAtom, (c) => c + 1)
   store.get(asyncAtom)
   store.set(countAtom, (c) => c + 1)
-  resolve.forEach((fn) => fn())
   const promise = store.get(asyncAtom)
-  resolve.forEach((fn) => fn())
+  resolve.shift()?.()
+  await Promise.resolve()
+  resolve.shift()?.()
   const count = await promise
   expect(count).toBe(2)
 })

--- a/tests/vanilla/dependency.test.tsx
+++ b/tests/vanilla/dependency.test.tsx
@@ -44,6 +44,8 @@ it('can get async atom with deps more than once before resolving (#1668)', async
   store.get(asyncAtom)
   store.set(countAtom, (c) => c + 1)
   resolve.forEach((fn) => fn())
-  const count = await store.get(asyncAtom)
+  const promise = store.get(asyncAtom)
+  resolve.forEach((fn) => fn())
+  const count = await promise
   expect(count).toBe(2)
 })


### PR DESCRIPTION
close #1668.