### PR TITLE
fix: demo code sandbox of jotai-urql

### DIFF
--- a/docs/integrations/urql.mdx
+++ b/docs/integrations/urql.mdx
@@ -67,9 +67,7 @@ const UserData = () => {
 
 #### Basic demo
 
-FIXME: Update demo
-
-<CodeSandbox id="zujf6" />
+<CodeSandbox id="5rwunq" />
 
 ## atomsWithMutation
 


### PR DESCRIPTION
## Related Issues

Update demo code of `jotai-urql (integration)`

## Summary

The demo code sandbox shown in the doc is outdated, so updated with latest changes.

## Check List

- [x] `yarn run prettier` for formatting code and docs
