### PR TITLE
docs: how to use urql client with the jotai provider.

### DIFF
--- a/docs/integrations/urql.mdx
+++ b/docs/integrations/urql.mdx
@@ -132,7 +132,7 @@ TODO: create example
 
 ## Refferencing the same instance of the client for both atoms and urql provider
 
-To ensure that you reference the same urqlClient object, be sure to wrap the root of your project in a <Provider> and initialise clientAtom with the same urqlClient value you provided to UrqlProvider.
+To ensure that you reference the same urqlClient object, be sure to wrap the root of your project in a `<Provider>` and initialise clientAtom with the same urqlClient value you provided to UrqlProvider.
 
 Without this step, you may end up specifying client each time when you use `atomsWithQuery`. Now you can just ignore the optional `getClient` parameter, and it will use the client from the context.
 

--- a/docs/integrations/urql.mdx
+++ b/docs/integrations/urql.mdx
@@ -129,3 +129,43 @@ const FooData = () => {
 ### Examples
 
 TODO: create example
+
+## Refferencing the same instance of the client for both atoms and urql provider 
+
+To ensure that you reference the same urqlClient object, be sure to wrap the root of your project in a <Provider> and initialise clientAtom with the same urqlClient value you provided to UrqlProvider.
+
+Without this step, you may end up specifying client each time when you use `atomsWithQuery`. Now you can just ignore the optional `getClient` parameter, and it will use the client from the context.
+
+```jsx
+import { Suspense } from "react";
+import { Provider } from "jotai";
+import { clientAtom } from "jotai-urql";
+
+import {
+  createClient,
+  dedupExchange,
+  cacheExchange,
+  fetchExchange,
+  Provider as UrqlProvider,
+} from "urql";
+
+const urqlClient = createClient({
+  url: "https://countries.trevorblades.com/",
+  exchanges: [dedupExchange, cacheExchange, fetchExchange],
+  fetchOptions: () => {
+    return { headers: {} };
+  },
+});
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <UrqlProvider value={urqlClient}>
+      <Provider initialValues={[[clientAtom, urqlClient]]}>
+        <Suspense fallback="Loading...">
+          <Component {...pageProps} />
+        </Suspense>
+      </Provider>
+    </UrqlProvider>
+  );
+}
+```

--- a/docs/integrations/urql.mdx
+++ b/docs/integrations/urql.mdx
@@ -130,16 +130,16 @@ const FooData = () => {
 
 TODO: create example
 
-## Refferencing the same instance of the client for both atoms and urql provider 
+## Refferencing the same instance of the client for both atoms and urql provider
 
 To ensure that you reference the same urqlClient object, be sure to wrap the root of your project in a <Provider> and initialise clientAtom with the same urqlClient value you provided to UrqlProvider.
 
 Without this step, you may end up specifying client each time when you use `atomsWithQuery`. Now you can just ignore the optional `getClient` parameter, and it will use the client from the context.
 
 ```jsx
-import { Suspense } from "react";
-import { Provider } from "jotai";
-import { clientAtom } from "jotai-urql";
+import { Suspense } from 'react'
+import { Provider } from 'jotai'
+import { clientAtom } from 'jotai-urql'
 
 import {
   createClient,
@@ -147,15 +147,15 @@ import {
   cacheExchange,
   fetchExchange,
   Provider as UrqlProvider,
-} from "urql";
+} from 'urql'
 
 const urqlClient = createClient({
-  url: "https://countries.trevorblades.com/",
+  url: 'https://countries.trevorblades.com/',
   exchanges: [dedupExchange, cacheExchange, fetchExchange],
   fetchOptions: () => {
-    return { headers: {} };
+    return { headers: {} }
   },
-});
+})
 
 export default function MyApp({ Component, pageProps }) {
   return (
@@ -166,6 +166,6 @@ export default function MyApp({ Component, pageProps }) {
         </Suspense>
       </Provider>
     </UrqlProvider>
-  );
+  )
 }
 ```


### PR DESCRIPTION
## Summary

I have added a new section in `jotai-urql` integration docs, Where it explains how to pass `urqlClient` to the jotai `provider`.

## Check List

- [x] `yarn run prettier` for formatting code and docs
