### PR TITLE
Fix English error in migration to v2 api doc

### DIFF
--- a/docs/guides/migrating-to-v2-api.mdx
+++ b/docs/guides/migrating-to-v2-api.mdx
@@ -79,7 +79,7 @@ In general, we should avoid using `WritableAtom` type directly.
 
 - Provider's `initialValues` prop is removed, because `store` is more flexible.
 - Provider's scope props is removed, because you can create own context.
-- `abortableAtom` util is removed, becuase the feature is included by default
+- `abortableAtom` util is removed, because the feature is included by default
 - `waitForAll` util is removed, because `Promise.all` just works
 
 ## Migration guides


### PR DESCRIPTION
## Related Issues

Fixes English error in migration to v2 api doc

## Summary



## Check List

- [ ] `yarn run prettier` for formatting code and docs
