### PR TITLE
fix(website): hover only when supported by device

### DIFF
--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -38,4 +38,7 @@ module.exports = {
     },
   },
   plugins: [require('@tailwindcss/forms')],
+  future: {
+    hoverOnlyWhenSupported: true,
+  },
 };


### PR DESCRIPTION
This PR changes the Tailwind `hover` prefix behavior to apply only when supported by the device (laptop, desktop, etc).