### PR TITLE
fix(docs): migration guide about createStore usage

### DIFF
--- a/docs/guides/initialize-atom-on-render.mdx
+++ b/docs/guides/initialize-atom-on-render.mdx
@@ -56,21 +56,21 @@ const UpdateTextInput = () => {
   )
 }
 
-export const TextDisplay = ({ initialTextValue }) => {
-  const storeRef = useRef()
-  if (!storeRef.current) {
-    // initialising on state with prop on render here
-    storeRef.current = createStore()
-    storeRef.current.set(textAtom, initialTextValue)
-  }
-  return (
-    <Provider store={storeRef.current}>
+const HydrateAtoms = ({ initialValues, children }) => {
+  // initialising on state with prop on render here
+  useHydrateAtoms(initialValues)
+  return children
+}
+
+export const TextDisplay = ({ initialTextValue }) => (
+  <Provider store={storeRef.current}>
+    <HydrateAtoms initialValues={[[textAtom, initialTextValue]]}>
       <PrettyText />
       <br />
       <UpdateTextInput />
-    </Provider>
-  )
-}
+    </HydrateAtoms>
+  </Provider>
+)
 ```
 
 Now, we can easily resue `TextDisplay` component with different initial text values despite them referencing the "same" atom.

--- a/docs/guides/migrating-to-v2-api.mdx
+++ b/docs/guides/migrating-to-v2-api.mdx
@@ -115,9 +115,9 @@ const derivedAtom = atom((get) => get(asyncAtom).then((x) => x.toUppercase()))
 ```jsx
 const countAtom = atom(0)
 
+  // in component
   <Provider initialValues={[[countAtom, 1]]}>
     ...
-  </Provider>
 ```
 
 #### New API
@@ -125,14 +125,15 @@ const countAtom = atom(0)
 ```jsx
 const countAtom = atom(0)
 
-const HydrateAtoms = ({ children }) => {
-  useHydrateAtoms([[countAtom, 1]])
+const HydrateAtoms = ({ initialValues, children }) => {
+  useHydrateAtoms(initialValues)
   return children
 }
 
-;<Provider>
-  <HydrateAtoms>...</HydrateAtoms>
-</Provider>
+  // in component
+  <Provider>
+    <HydrateAtoms initialValues={[[countAtom, 1]]}>
+      ...
 ```
 
 ### Provider's `scope` prop

--- a/docs/guides/migrating-to-v2-api.mdx
+++ b/docs/guides/migrating-to-v2-api.mdx
@@ -87,7 +87,7 @@ In general, we should avoid using `WritableAtom` type directly.
 ### Async atoms
 
 `get` function for read function of async atoms
-doesn't resolve promises, so you have to put `await`.
+doesn't resolve promises, so you have to put `await` or `.then()`.
 
 In short, the change is something like the following.
 (If you are TypeScript users, types will tell where to changes.)
@@ -104,6 +104,8 @@ const derivedAtom = atom((get) => get(asyncAtom).toUppercase())
 ```js
 const asyncAtom = atom(async () => 'hello')
 const derivedAtom = atom(async (get) => (await get(asyncAtom)).toUppercase())
+// or
+const derivedAtom = atom((get) => get(asyncAtom).then((x) => x.toUppercase()))
 ```
 
 ### Provider's `initialValues` prop
@@ -122,12 +124,15 @@ const countAtom = atom(0)
 
 ```jsx
 const countAtom = atom(0)
-const store = createStore()
-store.set(countAtom, 1)
 
-  <Provider store={store}>
-    ...
-  </Provider>
+const HydrateAtoms = ({ children }) => {
+  useHydrateAtoms([[countAtom, 1]])
+  return children
+}
+
+;<Provider>
+  <HydrateAtoms>...</HydrateAtoms>
+</Provider>
 ```
 
 ### Provider's `scope` prop

--- a/docs/integrations/query.mdx
+++ b/docs/integrations/query.mdx
@@ -167,8 +167,8 @@ Although they reference methods same query key (`'todos'`), the `onSuccess` inva
 This will result in `todosAtom` showing stale data as it was not prompted to refetch.
 
 ```jsx
-import { createStore } from 'jotai/vanilla'
 import { Provider } from 'jotai/react'
+import { useHydrateAtoms } from 'jotai/react/utils'
 import {
   useMutation,
   useQueryClient,
@@ -178,19 +178,24 @@ import {
 import { atomsWithQuery, queryClientAtom } from 'jotai-tanstack-query'
 
 const queryClient = new QueryClient()
+
+const HydrateAtoms = ({ children }) => {
+  useHydrateAtoms([[queryClientAtom, queryClient]])
+  return children
+}
+
 export const App = () => {
-  // This Provider initialisation step is needed so that we reference the same
-  // queryClient in both atomWithQuery and other parts of the app. Without this,
-  // our useQueryClient() hook will return a different QueryClient object
-  const storeRef = useRef()
-  if (!storeRef.current) {
-    storeRef.current = createStore()
-    storeRef.current.set(queryclientAtom, queryClient)
-  }
   return (
     <QueryClientProvider client={queryClient}>
-      <Provider store={storeRef.current}>
-        <App />
+      <Provider>
+        {/*
+   This Provider initialisation step is needed so that we reference the same
+   queryClient in both atomWithQuery and other parts of the app. Without this,
+   our useQueryClient() hook will return a different QueryClient object
+	*/}
+        <HydrateAtoms>
+          <App />
+        </HydrateAtoms>
       </Provider>
     </QueryClientProvider>
   )
@@ -262,16 +267,19 @@ const queryClient = new QueryClient({
     },
   },
 })
+
+const HydrateAtoms = ({ children }) => {
+  useHydrateAtoms([[queryClientAtom, queryClient]])
+  return children
+}
+
 export const App = () => {
-  const storeRef = useRef()
-  if (!storeRef.current) {
-    storeRef.current = createStore()
-    storeRef.current.set(queryclientAtom, queryClient)
-  }
   return (
     <QueryClientProvider client={queryClient}>
-      <Provider store={storeRef.current}>
-        <App />
+      <Provider>
+        <HydrateAtoms>
+          <App />
+        </HydrateAtoms>
       </Provider>
       <ReactQueryDevtools />
     </QueryClientProvider>

--- a/docs/integrations/urql.mdx
+++ b/docs/integrations/urql.mdx
@@ -138,8 +138,8 @@ Without this step, you may end up specifying client each time when you use `atom
 
 ```jsx
 import { Suspense } from 'react'
-import { createStore } from 'jotai/vanilla'
 import { Provider } from 'jotai/react'
+import { useHydrateAtoms } from 'jotai/react/utils'
 import { clientAtom } from 'jotai-urql'
 
 import {
@@ -158,18 +158,20 @@ const urqlClient = createClient({
   },
 })
 
+const HydrateAtoms = ({ children }) => {
+  useHydrateAtoms([[clientAtom, urqlClient]])
+  return children
+}
+
 export default function MyApp({ Component, pageProps }) {
-  const storeRef = useRef()
-  if (!storeRef.current) {
-    storeRef.current = createStore()
-    storeRef.current.set(clientAtom, urqlClient)
-  }
   return (
     <UrqlProvider value={urqlClient}>
       <Provider store={storeRef.current}>
-        <Suspense fallback="Loading...">
-          <Component {...pageProps} />
-        </Suspense>
+        <HydrateAtoms>
+          <Suspense fallback="Loading...">
+            <Component {...pageProps} />
+          </Suspense>
+        </HydrateAtoms>
       </Provider>
     </UrqlProvider>
   )


### PR DESCRIPTION
- Mitigate misleading async atom usage in v2 (Looking at a tweet from @azu )
- Guide `useHydrateAtoms` in place of `createStore` for migrating from Provider's `initialValues` prop (Discussing with @sandren )