### PR TITLE
fix(build): reorder the types field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,19 +34,19 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./index.d.ts",
       "import": {
         "types": "./esm/index.d.mts",
         "default": "./esm/index.mjs"
       },
-      "types": "./index.d.ts",
       "default": "./index.js"
     },
     "./*": {
+      "types": "./*.d.ts",
       "import": {
         "types": "./esm/*.d.mts",
         "default": "./esm/*.mjs"
       },
-      "types": "./*.d.ts",
       "default": "./*.js"
     }
   },


### PR DESCRIPTION
## Summary
According to the typescript documentation: `Entry-point` for TypeScript resolution must occur first.

>Reference:  
> https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing


Same as：
https://github.com/pmndrs/valtio/pull/655 
https://github.com/pmndrs/zustand/pull/1600