### PR TITLE
fix(vanilla): async derived atom not updated (race condition in an edge case)

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -321,27 +321,25 @@ export const createStore = () => {
         const promise: Promise<Awaited<Value>> & PromiseMeta<Awaited<Value>> =
           new Promise((resolve, reject) => {
             let settled = false
-            value
-              .then(
-                (v) => {
-                  if (!settled) {
-                    resolvePromise(promise, v)
-                    resolve(v)
-                  }
-                },
-                (e) => {
-                  if (!settled) {
-                    rejectPromise(promise, e)
-                    reject(e)
-                  }
+            value.then(
+              (v) => {
+                if (!settled) {
+                  settled = true
+                  // update dependencies, that could have changed
+                  setAtomValue(atom, promise as Value, depSet)
+                  resolvePromise(promise, v)
+                  resolve(v)
                 }
-              )
-              .finally(() => {
+              },
+              (e) => {
                 if (!settled) {
                   settled = true
                   setAtomValue(atom, promise as Value, depSet)
+                  rejectPromise(promise, e)
+                  reject(e)
                 }
-              })
+              }
+            )
             continuePromise = (next) => {
               if (!settled) {
                 settled = true

--- a/tests/vanilla/dependency.test.tsx
+++ b/tests/vanilla/dependency.test.tsx
@@ -51,3 +51,24 @@ it('can get async atom with deps more than once before resolving (#1668)', async
   const count = await promise
   expect(count).toBe(2)
 })
+
+it('correctly updates async derived atom after get/set update', async () => {
+  const baseAtom = atom(0)
+  const derivedAsyncAtom = atom(
+    async (get) => get(baseAtom) + 1,
+    async (get, set, val) => set(baseAtom, val as number)
+  )
+
+  const store = createStore()
+
+  // NOTE: Have to .set() straight after await on .get(), so that it executes
+  // in the same JS event loop cycle!
+  let derived = await store.get(derivedAsyncAtom)
+  await store.set(derivedAsyncAtom, 2)
+
+  expect(derived).toBe(1)
+  expect(store.get(baseAtom)).toBe(2)
+
+  derived = await store.get(derivedAsyncAtom)
+  expect(derived).toBe(3)
+})


### PR DESCRIPTION
## Related Issues

No issue was created.
See: https://github.com/pmndrs/jotai/discussions/1761

## Summary

When async derived atom is set immediately following an 'await' on get, it fails to get marked for re-calculation, so subsequent get will return the old value.

Included a unit test that has a minimal failure reproduction scenario, and a fix that makes the test pass.

## Check List

- [x] `yarn run prettier` for formatting code and docs
