### PR TITLE
fix(build): possibly improve ESM for production build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -60,7 +60,10 @@ function createESMConfig(input, output) {
           ? {
               'import.meta.env?.MODE': 'process.env.NODE_ENV',
             }
-          : {}),
+          : {
+              'import.meta.env?.MODE':
+                '(import.meta.env && import.meta.env.MODE)',
+            }),
         delimiters: ['\\b', '\\b(?!(\\.|/))'],
         preventAssignment: true,
       }),


### PR DESCRIPTION
#1742 broke the if statement.
https://unpkg.com/browse/jotai@2.0.2/esm/vanilla.mjs
```js
if (((_a = import.meta.env) == null ? void 0 : _a.MODE) !== "production") {
```

It doesn't work with this: https://vitejs.dev/guide/env-and-mode.html#production-replacement

This PR should improve it, but unless `import.meta.env` is statically replaced, it doesn't help. (which is true for previous versions)