### PR TITLE
fix(docs): Added correct imports to testing docs page

### DIFF
--- a/docs/guides/testing.mdx
+++ b/docs/guides/testing.mdx
@@ -19,7 +19,7 @@ Here's an example using [React testing library](https://github.com/testing-libra
 ```jsx
 import { atom, useAtom } from 'jotai'
 
-const countAtom = atom(0)
+export const countAtom = atom(0)
 
 export function Counter() {
   const [count, setCount] = useAtom(countAtom)
@@ -61,6 +61,7 @@ In order to do that, simply use a [Provider](../core/provider.mdx), and export y
 ```tsx
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { useHydrateAtoms } from 'jotai/utils'
 import { countAtom, Counter } from './Counter'
 import { Provider } from 'jotai'
 


### PR DESCRIPTION
## Summary

* There was no import for the `useHydrateAtoms` hook
* The countAtom was not being exported from the file.

## Check List

- [x] `yarn run prettier` for formatting code and docs
