### PR TITLE
fix(babel): improve debug label support for third-party jotai libraries

### DIFF
--- a/src/babel/utils.ts
+++ b/src/babel/utils.ts
@@ -24,25 +24,41 @@ export function isAtom(
 }
 
 const atomFunctionNames = [
-  'abortableAtom',
+  // Core
   'atom',
   'atomFamily',
   'atomWithDefault',
-  'atomWithHash',
-  'atomWithImmer',
-  'atomWithInfiniteQuery',
-  'atomWithMachine',
-  'atomWithMutation',
   'atomWithObservable',
-  'atomWithProxy',
-  'atomWithQuery',
   'atomWithReducer',
   'atomWithReset',
-  'atomWithSubscription',
   'atomWithStorage',
-  'atomWithStore',
   'freezeAtom',
   'loadable',
   'selectAtom',
   'splitAtom',
+  'unstable_unwrap',
+  // jotai-xstate
+  'atomWithMachine',
+  // jotai-immer
+  'atomWithImmer',
+  // jotai-valtio
+  'atomWithProxy',
+  // jotai-trpc + jotai-relay
+  'atomWithQuery',
+  'atomWithMutation',
+  'atomWithSubscription',
+  // jotai-redux + jotai-zustand
+  'atomWithStore',
+  // jotai-location
+  'atomWithHash',
+  'atomWithLocation',
+  // jotai-optics
+  'focusAtom',
+  // jotai-form
+  'atomWithValidate',
+  'validateAtoms',
+  // jotai-cache
+  'atomWithCache',
+  // jotai-recoil
+  'atomWithRecoilValue',
 ]

--- a/tests/babel/plugin-debug-label.test.ts
+++ b/tests/babel/plugin-debug-label.test.ts
@@ -99,6 +99,27 @@ it('Should handle all atom types', () => {
       const selectedValueAtom = selectAtom(atom({ a: 0, b: 'othervalue' }), (v) => v.a);
 
       const splittedAtom = splitAtom(atom([]));
+
+      const unwrappedAtom = unstable_unwrap(asyncArrayAtom, () => []);
+
+      const someatomWithSubscription = atomWithSubscription(() => {});
+
+      const someAtomWithStore = atomWithStore(() => {});
+
+      const someAtomWithHash = atomWithHash('', '');
+      
+      const someAtomWithLocation = atomWithLocation();
+
+      const someFocusAtom = focusAtom(someAtom, () => {});
+
+      const someAtomWithValidate = atomWithValidate('', {});
+
+      const someValidateAtoms = validateAtoms({}, () => {});
+
+      const someAtomWithCache = atomWithCache(async () => {});
+
+      const someAtomWithRecoilValue = atomWithRecoilValue({});
+      
     `,
       'atoms/index.ts'
     )
@@ -129,7 +150,27 @@ it('Should handle all atom types', () => {
     }), v => v.a);
     selectedValueAtom.debugLabel = "selectedValueAtom";
     const splittedAtom = splitAtom(atom([]));
-    splittedAtom.debugLabel = "splittedAtom";"
+    splittedAtom.debugLabel = "splittedAtom";
+    const unwrappedAtom = unstable_unwrap(asyncArrayAtom, () => []);
+    unwrappedAtom.debugLabel = "unwrappedAtom";
+    const someatomWithSubscription = atomWithSubscription(() => {});
+    someatomWithSubscription.debugLabel = "someatomWithSubscription";
+    const someAtomWithStore = atomWithStore(() => {});
+    someAtomWithStore.debugLabel = "someAtomWithStore";
+    const someAtomWithHash = atomWithHash('', '');
+    someAtomWithHash.debugLabel = "someAtomWithHash";
+    const someAtomWithLocation = atomWithLocation();
+    someAtomWithLocation.debugLabel = "someAtomWithLocation";
+    const someFocusAtom = focusAtom(someAtom, () => {});
+    someFocusAtom.debugLabel = "someFocusAtom";
+    const someAtomWithValidate = atomWithValidate('', {});
+    someAtomWithValidate.debugLabel = "someAtomWithValidate";
+    const someValidateAtoms = validateAtoms({}, () => {});
+    someValidateAtoms.debugLabel = "someValidateAtoms";
+    const someAtomWithCache = atomWithCache(async () => {});
+    someAtomWithCache.debugLabel = "someAtomWithCache";
+    const someAtomWithRecoilValue = atomWithRecoilValue({});
+    someAtomWithRecoilValue.debugLabel = "someAtomWithRecoilValue";"
   `)
 })
 


### PR DESCRIPTION
## Summary
- Add debug label support for third-party jotai libraries like `jotai-optics`, `jotai-location`, `jotai-form`, `jotai-cache`, `jotai-recoil`, etc.


## Check List

- [x] `yarn run prettier` for formatting code and docs
