### PR TITLE
docs: replace useUpdateAtom with useSetAtom

### DIFF
--- a/docs/guides/resettable.mdx
+++ b/docs/guides/resettable.mdx
@@ -55,7 +55,7 @@ const TodoList = () => {
 ## Derived atom with RESET symbol
 
 ```jsx
-import { atom, useAtom } from 'jotai'
+import { atom, useAtom, useSetAtom } from 'jotai'
 import { atomWithReset, useResetAtom, RESET } from 'jotai/utils'
 
 const dollarsAtom = atomWithReset(0)
@@ -67,7 +67,7 @@ const centsAtom = atom(
 
 const ResetExample = () => {
   const [dollars] = useAtom(dollarsAtom)
-  const setCents = useUpdateAtom(centsAtom)
+  const setCents = useSetAtom(centsAtom)
   const resetCents = useResetAtom(centsAtom)
 
   return (

--- a/docs/recipes/atom-creators.mdx
+++ b/docs/recipes/atom-creators.mdx
@@ -301,8 +301,7 @@ those state changes.
 
 ```ts
 import { useEffect } from 'react'
-import { atom, Getter, Setter, SetStateAction } from 'jotai'
-import { useUpdateAtom } from 'jotai/utils'
+import { atom, useSetAtom, Getter, Setter, SetStateAction } from 'jotai'
 
 type Callback<Value> = (
   get: Getter,
@@ -326,7 +325,7 @@ export function atomWithListeners<Value>(initialValue: Value) {
     }
   )
   const useListener = (callback: Callback<Value>) => {
-    const setListeners = useUpdateAtom(listenersAtom)
+    const setListeners = useSetAtom(listenersAtom)
     useEffect(() => {
       setListeners((prev) => [...prev, callback])
       return () =>

--- a/docs/utilities/resettable.mdx
+++ b/docs/utilities/resettable.mdx
@@ -45,7 +45,7 @@ or writable atom created with `atom` if it accepts `RESET` symbol.
 ### Example
 
 ```jsx
-import { atom } from 'jotai'
+import { atom, useSetAtom } from 'jotai'
 import { atomWithReset, useResetAtom, RESET } from 'jotai/utils'
 
 const dollarsAtom = atomWithReset(0)
@@ -56,7 +56,7 @@ const centsAtom = atom(
 )
 
 const ResetExample = () => {
-  const setDollars = useUpdateAtom(dollarsAtom)
+  const setDollars = useSetAtom(dollarsAtom)
   const resetCents = useResetAtom(centsAtom)
 
   return (


### PR DESCRIPTION
## Related Issues or Discussions
N/A

## Summary
`useUpdateAtom()` had been deprecated since v2. Update the example to use the new API.

## Check List

- [x] `yarn run prettier` for formatting code and docs
