### PR TITLE
fix(react): atom type inference in hooks

### DIFF
--- a/src/react/useAtom.ts
+++ b/src/react/useAtom.ts
@@ -32,11 +32,6 @@ export function useAtom<
   SetAtom<ExtractAtomArgs<AtomType>, ExtractAtomResult<AtomType>>
 ]
 
-export function useAtom<AtomType extends Atom<unknown>>(
-  atom: AtomType,
-  options?: Options
-): [Awaited<ExtractAtomValue<AtomType>>, never]
-
 export function useAtom<Value, Args extends unknown[], Result>(
   atom: Atom<Value> | WritableAtom<Value, Args, Result>,
   options?: Options

--- a/src/react/useAtom.ts
+++ b/src/react/useAtom.ts
@@ -8,11 +8,11 @@ import type {
 import { useAtomValue } from './useAtomValue'
 import { useSetAtom } from './useSetAtom'
 
-type SetAtom<Args extends unknown[], Result> = (...args: Args) => Result
+type SetAtom<Args extends any[], Result> = (...args: Args) => Result
 
 type Options = Parameters<typeof useAtomValue>[1]
 
-export function useAtom<Value, Args extends unknown[], Result>(
+export function useAtom<Value, Args extends any[], Result>(
   atom: WritableAtom<Value, Args, Result>,
   options?: Options
 ): [Awaited<Value>, SetAtom<Args, Result>]
@@ -22,9 +22,7 @@ export function useAtom<Value>(
   options?: Options
 ): [Awaited<Value>, never]
 
-export function useAtom<
-  AtomType extends WritableAtom<unknown, unknown[], unknown>
->(
+export function useAtom<AtomType extends WritableAtom<any, any[], any>>(
   atom: AtomType,
   options?: Options
 ): [
@@ -32,7 +30,12 @@ export function useAtom<
   SetAtom<ExtractAtomArgs<AtomType>, ExtractAtomResult<AtomType>>
 ]
 
-export function useAtom<Value, Args extends unknown[], Result>(
+export function useAtom<AtomType extends Atom<any>>(
+  atom: AtomType,
+  options?: Options
+): [Awaited<ExtractAtomValue<AtomType>>, never]
+
+export function useAtom<Value, Args extends any[], Result>(
   atom: Atom<Value> | WritableAtom<Value, Args, Result>,
   options?: Options
 ) {

--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -50,7 +50,7 @@ export function useAtomValue<Value>(
   options?: Options
 ): Awaited<Value>
 
-export function useAtomValue<AtomType extends Atom<unknown>>(
+export function useAtomValue<AtomType extends Atom<any>>(
   atom: AtomType,
   options?: Options
 ): Awaited<ExtractAtomValue<AtomType>>

--- a/src/react/useSetAtom.ts
+++ b/src/react/useSetAtom.ts
@@ -6,26 +6,24 @@ import type {
 } from 'jotai/vanilla'
 import { useStore } from './Provider'
 
-type SetAtom<Args extends unknown[], Result> = (...args: Args) => Result
+type SetAtom<Args extends any[], Result> = (...args: Args) => Result
 type Store = ReturnType<typeof useStore>
 
 type Options = {
   store?: Store
 }
 
-export function useSetAtom<Value, Args extends unknown[], Result>(
+export function useSetAtom<Value, Args extends any[], Result>(
   atom: WritableAtom<Value, Args, Result>,
   options?: Options
 ): SetAtom<Args, Result>
 
-export function useSetAtom<
-  AtomType extends WritableAtom<unknown, unknown[], unknown>
->(
+export function useSetAtom<AtomType extends WritableAtom<any, any[], any>>(
   atom: AtomType,
   options?: Options
 ): SetAtom<ExtractAtomArgs<AtomType>, ExtractAtomResult<AtomType>>
 
-export function useSetAtom<Value, Args extends unknown[], Result>(
+export function useSetAtom<Value, Args extends any[], Result>(
   atom: WritableAtom<Value, Args, Result>,
   options?: Options
 ) {

--- a/tests/react/types.test.tsx
+++ b/tests/react/types.test.tsx
@@ -30,3 +30,19 @@ it('useAtom should return the correct types', () => {
   }
   Component
 })
+
+it('useAtom should handle inference of atoms (#1831 #1387)', () => {
+  const fieldAtoms = {
+    username: atom(''),
+    age: atom(0),
+    checked: atom(false),
+  }
+
+  const useField = <T extends keyof typeof fieldAtoms>(prop: T) => {
+    return useAtom(fieldAtoms[prop])
+  }
+
+  expectType<[string, (arg: string) => void]>(useField('username'))
+  expectType<[number, (arg: number) => void]>(useField('age'))
+  expectType<[boolean, (arg: boolean) => void]>(useField('checked'))
+})

--- a/tests/react/types.test.tsx
+++ b/tests/react/types.test.tsx
@@ -41,8 +41,10 @@ it('useAtom should handle inference of atoms (#1831 #1387)', () => {
   const useField = <T extends keyof typeof fieldAtoms>(prop: T) => {
     return useAtom(fieldAtoms[prop])
   }
-
-  expectType<[string, (arg: string) => void]>(useField('username'))
-  expectType<[number, (arg: number) => void]>(useField('age'))
-  expectType<[boolean, (arg: boolean) => void]>(useField('checked'))
+  function Component() {
+    expectType<[string, (arg: string) => void]>(useField('username'))
+    expectType<[number, (arg: number) => void]>(useField('age'))
+    expectType<[boolean, (arg: boolean) => void]>(useField('checked'))
+  }
+  Component
 })


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #1831

## Summary

Draft. Lets iterate on solving this inference issue with `useAtom`.

