### PR TITLE
fix(atomWithStorage): handle RESET/removeItem from cross-tab storage updates

### DIFF
--- a/docs/utilities/storage.mdx
+++ b/docs/utilities/storage.mdx
@@ -34,10 +34,14 @@ The `atomWithStorage` function creates an atom with a value persisted in `localS
 
 **initialValue** (required): the initial value of the atom
 
-**storage** (optional): an object with:
+**storage** (optional): an object with the following methods:
 
-- `getItem`, `setItem` and `removeItem` methods for storing/retrieving/deleting persisted state; defaults to using `localStorage` for storage/retrieval and `JSON.stringify()`/`JSON.parse()` for serialization/deserialization.
-- Optionally, the storage has a `subscribe` property, which can be used to synchronize storage. The default `localStorage` handles `storage` events for cross-tab synchronization.
+- **getItem(key, initialValue)** (required): Reads an item from storage, or falls back to the `intialValue`
+- **setItem(key, value)** (required): Saves an item to storage
+- **removeItem(key)** (required): Deletes the item from storage
+- **subscribe(key, callback, initialValue)** (optional): A method which subscribes to external storage updates.
+
+If not specified, the default storage implementation uses `localStorage` for storage/retrieval, `JSON.stringify()`/`JSON.parse()` for serialization/deserialization, and subscribes to `storage` events for cross-tab synchronization.
 
 <CodeSandbox id="vuwi7" />
 
@@ -110,4 +114,51 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 const storage = createJSONStorage(() => AsyncStorage)
 const content = {} // anything JSON serializable
 const storedAtom = atomWithStorage('stored-key', content, storage)
+```
+
+### Validating stored values
+
+To add runtime validation to your storage atoms, you will need to create a custom implementation of storage.
+
+Below is an example that utilizes Zod to validate values stored in `localStorage` with cross-tab synchronization.
+
+```js
+import { atomWithStorage, createJSONStorage } from 'jotai/utils'
+import { z } from 'zod'
+
+const myNumberSchema = z.number().int().nonnegative()
+
+const storedNumberAtom = atomWithStorage('my-number', 0, {
+  getItem(key, initialValue) {
+    const storedValue = localStorage.getItem(key)
+    try {
+      return myNumberSchema.parse(JSON.parse(storedValue ?? ''))
+    } catch {
+      return initialValue
+    }
+  },
+  setItem(key, value) {
+    localStorage.setItem(JSON.stringify(value))
+  },
+  removeItem(key) {
+    localStorage.removeItem(key)
+  },
+  subscribe(key, callback, initialValue) {
+    if (
+      typeof window === 'undefined' ||
+      typeof window.addEventListener === 'undefined'
+    ) {
+      return
+    }
+    window.addEventListener('storage', (e) => {
+      if (e.storageArea === localStorage && e.key === key) {
+        try {
+          return myNumberSchema.parse(JSON.parse(e.newValue ?? ''))
+        } catch {
+          return initialValue
+        }
+      }
+    })
+  },
+})
 ```

--- a/docs/utilities/storage.mdx
+++ b/docs/utilities/storage.mdx
@@ -152,11 +152,13 @@ const storedNumberAtom = atomWithStorage('my-number', 0, {
     }
     window.addEventListener('storage', (e) => {
       if (e.storageArea === localStorage && e.key === key) {
+        let newValue
         try {
-          return myNumberSchema.parse(JSON.parse(e.newValue ?? ''))
+          newValue = myNumberSchema.parse(JSON.parse(e.newValue ?? ''))
         } catch {
-          return initialValue
+          newValue = initialValue
         }
+        callback(newValue)
       }
     })
   },

--- a/src/vanilla/utils.ts
+++ b/src/vanilla/utils.ts
@@ -6,11 +6,7 @@ export { selectAtom } from './utils/selectAtom.ts'
 export { freezeAtom, freezeAtomCreator } from './utils/freezeAtom.ts'
 export { splitAtom } from './utils/splitAtom.ts'
 export { atomWithDefault } from './utils/atomWithDefault.ts'
-export {
-  NO_STORAGE_VALUE as unstable_NO_STORAGE_VALUE,
-  atomWithStorage,
-  createJSONStorage,
-} from './utils/atomWithStorage.ts'
+export { atomWithStorage, createJSONStorage } from './utils/atomWithStorage.ts'
 export { atomWithObservable } from './utils/atomWithObservable.ts'
 export { loadable } from './utils/loadable.ts'
 export { unwrap as unstable_unwrap } from './utils/unwrap.ts'


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #1815

## Summary

* **BREAKING CHANGE:** `SyncStorage` and `AsyncStorage` now receive `initialValue` as an argument to `getItem` and `subscribe`
* **BREAKING CHANGE:** Removed export `unstable_NO_STORAGE_VALUE`
* Updated `createJSONStorage` to correctly handle incoming `storage` events triggered by `removeItem` in another window
* Updated `createJSONStorage` to avoid attaching `storage` event handler when the storage is not browser storage (this happens on mount, so it shouldn't conflict with SSR)
* Added unit tests to cover both of the updates to `createJSONStorage` behavior.
* Updated mock "listeners" in unit tests to more correctly reflect browser storage behavior ([the `storage` event is not triggered by updates from the current window](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event))
* Updated documentation to reflect the new storage API
* Added documentation example for `atomWithStorage` with a custom storage that performs runtime validation

## Check List

- [x] `yarn run prettier` for formatting code and docs
