### PR TITLE
fix(react): Infer useHydrateAtoms value types from atom.read ReturnType

### DIFF
--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -3,7 +3,7 @@ import type { WritableAtom } from '../../vanilla.ts'
 
 type Store = ReturnType<typeof useStore>
 type Options = Parameters<typeof useStore>[0]
-type AnyWritableAtom = WritableAtom<unknown, any[], any>
+export type AnyWritableAtom = WritableAtom<unknown, any[], any>
 
 const hydratedMap: WeakMap<Store, WeakSet<AnyWritableAtom>> = new WeakMap()
 

--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -5,20 +5,18 @@ type Store = ReturnType<typeof useStore>
 type Options = Parameters<typeof useStore>[0]
 type AnyWritableAtom = WritableAtom<unknown, any[], any>
 type AtomTuple<A = AnyWritableAtom, V = unknown> = readonly [A, V]
-type InferAtoms<
-  T extends Array<AtomTuple>,
-  S extends Array<AtomTuple> = []
-> = S['length'] extends T['length']
-  ? S
-  : T extends Array<AtomTuple<infer A>>
-  ? A extends AnyWritableAtom
-    ? InferAtoms<T, [AtomTuple<A, ReturnType<A['read']>>, ...S]>
-    : T
-  : T
+
+type InferAtoms<T extends Iterable<AtomTuple>> = {
+  [K in keyof T]: T[K] extends AtomTuple<infer A>
+    ? A extends AnyWritableAtom
+      ? AtomTuple<A, ReturnType<A['read']>>
+      : T[K]
+    : never
+}
 
 const hydratedMap: WeakMap<Store, WeakSet<AnyWritableAtom>> = new WeakMap()
 
-export function useHydrateAtoms<T extends Array<AtomTuple>>(
+export function useHydrateAtoms<T extends Iterable<AtomTuple>>(
   values: InferAtoms<T>,
   options?: Options
 ) {

--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -4,17 +4,26 @@ import type { WritableAtom } from '../../vanilla.ts'
 type Store = ReturnType<typeof useStore>
 type Options = Parameters<typeof useStore>[0]
 type AnyWritableAtom = WritableAtom<unknown, any[], any>
+type AtomMap<A = AnyWritableAtom, V = unknown> = Map<A, V>
 type AtomTuple<A = AnyWritableAtom, V = unknown> = readonly [A, V]
 type InferAtoms<T extends Iterable<AtomTuple>> = {
   [K in keyof T]: T[K] extends AtomTuple<infer A>
     ? A extends AnyWritableAtom
       ? AtomTuple<A, ReturnType<A['read']>>
       : T[K]
-    : any
+    : never
 }
 
 const hydratedMap: WeakMap<Store, WeakSet<AnyWritableAtom>> = new WeakMap()
 
+export function useHydrateAtoms<T extends AtomMap>(
+  values: T,
+  options?: Options
+): void
+export function useHydrateAtoms<T extends Array<AtomTuple>>(
+  values: InferAtoms<T>,
+  options?: Options
+): void
 export function useHydrateAtoms<T extends Iterable<AtomTuple>>(
   values: InferAtoms<T>,
   options?: Options

--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -5,7 +5,6 @@ type Store = ReturnType<typeof useStore>
 type Options = Parameters<typeof useStore>[0]
 type AnyWritableAtom = WritableAtom<unknown, any[], any>
 type AtomTuple<A = AnyWritableAtom, V = unknown> = readonly [A, V]
-
 type InferAtoms<T extends Iterable<AtomTuple>> = {
   [K in keyof T]: T[K] extends AtomTuple<infer A>
     ? A extends AnyWritableAtom

--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -16,11 +16,15 @@ type InferAtoms<T extends Iterable<AtomTuple>> = {
 
 const hydratedMap: WeakMap<Store, WeakSet<AnyWritableAtom>> = new WeakMap()
 
+export function useHydrateAtoms<T extends Array<AtomTuple>>(
+  values: InferAtoms<T>,
+  options?: Options
+): void
 export function useHydrateAtoms<T extends AtomMap>(
   values: T,
   options?: Options
 ): void
-export function useHydrateAtoms<T extends Array<AtomTuple>>(
+export function useHydrateAtoms<T extends Iterable<AtomTuple>>(
   values: InferAtoms<T>,
   options?: Options
 ): void

--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -11,7 +11,7 @@ type InferAtoms<T extends Iterable<AtomTuple>> = {
     ? A extends AnyWritableAtom
       ? AtomTuple<A, ReturnType<A['read']>>
       : T[K]
-    : never
+    : any
 }
 
 const hydratedMap: WeakMap<Store, WeakSet<AnyWritableAtom>> = new WeakMap()

--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -3,7 +3,7 @@ import type { WritableAtom } from '../../vanilla.ts'
 
 type Store = ReturnType<typeof useStore>
 type Options = Parameters<typeof useStore>[0]
-export type AnyWritableAtom = WritableAtom<unknown, any[], any>
+type AnyWritableAtom = WritableAtom<unknown, any[], any>
 
 const hydratedMap: WeakMap<Store, WeakSet<AnyWritableAtom>> = new WeakMap()
 

--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -7,8 +7,8 @@ export type AnyWritableAtom = WritableAtom<unknown, any[], any>
 
 const hydratedMap: WeakMap<Store, WeakSet<AnyWritableAtom>> = new WeakMap()
 
-export function useHydrateAtoms(
-  values: Iterable<readonly [AnyWritableAtom, unknown]>,
+export function useHydrateAtoms<T extends AnyWritableAtom, V = T['read']>(
+  values: Iterable<readonly [T, V]>,
   options?: Options
 ) {
   const store = useStore(options)

--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -4,11 +4,22 @@ import type { WritableAtom } from '../../vanilla.ts'
 type Store = ReturnType<typeof useStore>
 type Options = Parameters<typeof useStore>[0]
 type AnyWritableAtom = WritableAtom<unknown, any[], any>
+type AtomTuple<A = AnyWritableAtom, V = unknown> = readonly [A, V]
+type InferAtoms<
+  T extends Array<AtomTuple>,
+  S extends Array<AtomTuple> = []
+> = S['length'] extends T['length']
+  ? S
+  : T extends Array<AtomTuple<infer A>>
+  ? A extends AnyWritableAtom
+    ? InferAtoms<T, [AtomTuple<A, ReturnType<A['read']>>, ...S]>
+    : T
+  : T
 
 const hydratedMap: WeakMap<Store, WeakSet<AnyWritableAtom>> = new WeakMap()
 
-export function useHydrateAtoms<T extends AnyWritableAtom, V = T['read']>(
-  values: Iterable<readonly [T, V]>,
+export function useHydrateAtoms<T extends Array<AtomTuple>>(
+  values: InferAtoms<T>,
   options?: Options
 ) {
   const store = useStore(options)

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -11,6 +11,16 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
       [countAtom, 'foo'],
       [activeAtom, 0],
     ])
+    // @ts-expect-error TS2769
+    useHydrateAtoms([
+      [countAtom, 1],
+      [activeAtom, 0],
+    ])
+    // @ts-expect-error TS2769
+    useHydrateAtoms([
+      [countAtom, true],
+      [activeAtom, false],
+    ])
   }
   Component
 })

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -1,0 +1,16 @@
+import { it } from '@jest/globals'
+import { useHydrateAtoms } from 'jotai/react/utils'
+import { atom } from 'jotai/vanilla'
+
+it('useHydrateAtoms should not allow invalid atom types when array is passed', () => {
+  function Component() {
+    const countAtom = atom(0)
+    const activeAtom = atom(true)
+    // @ts-expect-error TS2769
+    useHydrateAtoms([
+      [countAtom, 'foo'],
+      [activeAtom, 0],
+    ])
+  }
+  Component
+})

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -6,16 +6,25 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
   function Component() {
     const countAtom = atom(0)
     const activeAtom = atom(true)
+    // Adding @ts-ignore for typescript 3.8 support
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     // @ts-expect-error TS2769
     useHydrateAtoms([
       [countAtom, 'foo'],
       [activeAtom, 0],
     ])
+    // Adding @ts-ignore for typescript 3.8 support
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     // @ts-expect-error TS2769
     useHydrateAtoms([
       [countAtom, 1],
       [activeAtom, 0],
     ])
+    // Adding @ts-ignore for typescript 3.8 support
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     // @ts-expect-error TS2769
     useHydrateAtoms([
       [countAtom, true],

--- a/tests/react/utils/useHydrateAtoms.test.tsx
+++ b/tests/react/utils/useHydrateAtoms.test.tsx
@@ -46,7 +46,7 @@ it('useHydrateAtoms should only hydrate on first render', async () => {
   )
 
   await findByText('count: 42')
-  await findByText('status: 42')
+  await findByText('status: rejected')
   fireEvent.click(getByText('dispatch'))
   fireEvent.click(getByText('update'))
   await findByText('count: 43')

--- a/tests/react/utils/useHydrateAtoms.test.tsx
+++ b/tests/react/utils/useHydrateAtoms.test.tsx
@@ -7,34 +7,58 @@ import { atom } from 'jotai/vanilla'
 
 it('useHydrateAtoms should only hydrate on first render', async () => {
   const countAtom = atom(0)
+  const statusAtom = atom('fulfilled')
 
-  const Counter = ({ initialCount }: { initialCount: number }) => {
-    useHydrateAtoms([[countAtom, initialCount]])
+  const Counter = ({
+    initialCount,
+    initialStatus,
+  }: {
+    initialCount: number
+    initialStatus: string
+  }) => {
+    useHydrateAtoms([
+      [countAtom, initialCount],
+      [statusAtom, initialStatus],
+    ])
     const [countValue, setCount] = useAtom(countAtom)
+    const [statusValue, setStatus] = useAtom(statusAtom)
 
     return (
       <>
         <div>count: {countValue}</div>
         <button onClick={() => setCount((count) => count + 1)}>dispatch</button>
+        <div>status: {statusValue}</div>
+        <button
+          onClick={() =>
+            setStatus((status) =>
+              status === 'fulfilled' ? 'rejected' : 'fulfilled'
+            )
+          }>
+          update
+        </button>
       </>
     )
   }
   const { findByText, getByText, rerender } = render(
     <StrictMode>
-      <Counter initialCount={42} />
+      <Counter initialCount={42} initialStatus="rejected" />
     </StrictMode>
   )
 
   await findByText('count: 42')
+  await findByText('status: 42')
   fireEvent.click(getByText('dispatch'))
+  fireEvent.click(getByText('update'))
   await findByText('count: 43')
+  await findByText('status: fulfilled')
 
   rerender(
     <StrictMode>
-      <Counter initialCount={65} />
+      <Counter initialCount={65} initialStatus="rejected" />
     </StrictMode>
   )
   await findByText('count: 43')
+  await findByText('status: fulfilled')
 })
 
 it('useHydrateAtoms should not trigger unnecessary re-renders', async () => {

--- a/tests/react/utils/useHydrateAtoms.test.tsx
+++ b/tests/react/utils/useHydrateAtoms.test.tsx
@@ -37,7 +37,7 @@ it('useHydrateAtoms should only hydrate on first render', async () => {
   await findByText('count: 43')
 })
 
-it('useHydrateAtoms should not trigger unnessesary rerenders', async () => {
+it('useHydrateAtoms should not trigger unnecessary re-renders', async () => {
   const countAtom = atom(0)
 
   const Counter = ({ initialCount }: { initialCount: number }) => {

--- a/tests/react/utils/useHydrateAtoms.test.tsx
+++ b/tests/react/utils/useHydrateAtoms.test.tsx
@@ -145,52 +145,6 @@ it('useHydrateAtoms can only restore an atom once', async () => {
   await findByText('count: 44')
 })
 
-it('useHydrateAtoms can only restore an atom once', async () => {
-  const countAtom = atom(0)
-
-  const Counter = ({ initialCount }: { initialCount: number }) => {
-    useHydrateAtoms([[countAtom, initialCount]])
-    const [countValue, setCount] = useAtom(countAtom)
-
-    return (
-      <>
-        <div>count: {countValue}</div>
-        <button onClick={() => setCount((count) => count + 1)}>dispatch</button>
-      </>
-    )
-  }
-  const Counter2 = ({ count }: { count: number }) => {
-    useHydrateAtoms([[countAtom, count]])
-    const [countValue, setCount] = useAtom(countAtom)
-
-    return (
-      <>
-        <div>count: {countValue}</div>
-        <button onClick={() => setCount((count) => count + 1)}>dispatch</button>
-      </>
-    )
-  }
-  const { findByText, getByText, rerender } = render(
-    <StrictMode>
-      <Counter initialCount={42} />
-    </StrictMode>
-  )
-
-  await findByText('count: 42')
-  fireEvent.click(getByText('dispatch'))
-  await findByText('count: 43')
-
-  rerender(
-    <StrictMode>
-      <Counter2 count={65} />
-    </StrictMode>
-  )
-
-  await findByText('count: 43')
-  fireEvent.click(getByText('dispatch'))
-  await findByText('count: 44')
-})
-
 it('useHydrateAtoms should respect onMount', async () => {
   const countAtom = atom(0)
   const onMountFn = jest.fn(() => {})

--- a/tests/react/utils/useHydrateAtoms.test.tsx
+++ b/tests/react/utils/useHydrateAtoms.test.tsx
@@ -5,42 +5,6 @@ import { useAtom } from 'jotai/react'
 import { useHydrateAtoms } from 'jotai/react/utils'
 import { atom } from 'jotai/vanilla'
 
-it('useHydrateAtoms should only hydrate on first render using a Map', async () => {
-  const countAtom = atom(0)
-
-  const Counter = ({ initialCount }: { initialCount: number }) => {
-    useHydrateAtoms(
-      new Map<typeof countAtom, ReturnType<(typeof countAtom)['read']>>([
-        [countAtom, initialCount],
-      ])
-    )
-    const [countValue, setCount] = useAtom(countAtom)
-
-    return (
-      <>
-        <div>count: {countValue}</div>
-        <button onClick={() => setCount((count) => count + 1)}>dispatch</button>
-      </>
-    )
-  }
-  const { findByText, getByText, rerender } = render(
-    <StrictMode>
-      <Counter initialCount={42} />
-    </StrictMode>
-  )
-
-  await findByText('count: 42')
-  fireEvent.click(getByText('dispatch'))
-  await findByText('count: 43')
-
-  rerender(
-    <StrictMode>
-      <Counter initialCount={65} />
-    </StrictMode>
-  )
-  await findByText('count: 43')
-})
-
 it('useHydrateAtoms should only hydrate on first render', async () => {
   const countAtom = atom(0)
   const statusAtom = atom('fulfilled')
@@ -95,6 +59,42 @@ it('useHydrateAtoms should only hydrate on first render', async () => {
   )
   await findByText('count: 43')
   await findByText('status: fulfilled')
+})
+
+it('useHydrateAtoms should only hydrate on first render using a Map', async () => {
+  const countAtom = atom(0)
+
+  const Counter = ({ initialCount }: { initialCount: number }) => {
+    useHydrateAtoms(
+      new Map<typeof countAtom, ReturnType<(typeof countAtom)['read']>>([
+        [countAtom, initialCount],
+      ])
+    )
+    const [countValue, setCount] = useAtom(countAtom)
+
+    return (
+      <>
+        <div>count: {countValue}</div>
+        <button onClick={() => setCount((count) => count + 1)}>dispatch</button>
+      </>
+    )
+  }
+  const { findByText, getByText, rerender } = render(
+    <StrictMode>
+      <Counter initialCount={42} />
+    </StrictMode>
+  )
+
+  await findByText('count: 42')
+  fireEvent.click(getByText('dispatch'))
+  await findByText('count: 43')
+
+  rerender(
+    <StrictMode>
+      <Counter initialCount={65} />
+    </StrictMode>
+  )
+  await findByText('count: 43')
 })
 
 it('useHydrateAtoms should not trigger unnecessary re-renders', async () => {

--- a/tests/react/utils/useHydrateAtoms.test.tsx
+++ b/tests/react/utils/useHydrateAtoms.test.tsx
@@ -5,6 +5,42 @@ import { useAtom } from 'jotai/react'
 import { useHydrateAtoms } from 'jotai/react/utils'
 import { atom } from 'jotai/vanilla'
 
+it('useHydrateAtoms should only hydrate on first render using a Map', async () => {
+  const countAtom = atom(0)
+
+  const Counter = ({ initialCount }: { initialCount: number }) => {
+    useHydrateAtoms(
+      new Map<typeof countAtom, ReturnType<(typeof countAtom)['read']>>([
+        [countAtom, initialCount],
+      ])
+    )
+    const [countValue, setCount] = useAtom(countAtom)
+
+    return (
+      <>
+        <div>count: {countValue}</div>
+        <button onClick={() => setCount((count) => count + 1)}>dispatch</button>
+      </>
+    )
+  }
+  const { findByText, getByText, rerender } = render(
+    <StrictMode>
+      <Counter initialCount={42} />
+    </StrictMode>
+  )
+
+  await findByText('count: 42')
+  fireEvent.click(getByText('dispatch'))
+  await findByText('count: 43')
+
+  rerender(
+    <StrictMode>
+      <Counter initialCount={65} />
+    </StrictMode>
+  )
+  await findByText('count: 43')
+})
+
 it('useHydrateAtoms should only hydrate on first render', async () => {
   const countAtom = atom(0)
   const statusAtom = atom('fulfilled')


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #990

## Summary
Currently `useHydrateAtoms` allows any unknown value to be passed for all atoms being hydrated. Instead this should be type safe and infer the type for the value(s) passed based on the atom.read function return type.

Cleaned up test title and removed duplicate test.


## Screenshots
|     BEFORE      |      AFTER      |
|:---------------:|:---------------:|
| ![Screenshot 2023-04-27 at 12 09 19 PM](https://user-images.githubusercontent.com/525506/234938179-85d745ed-f534-4e11-8e3c-7ac94ca60f60.png) | ![Screenshot 2023-04-27 at 12 08 29 PM](https://user-images.githubusercontent.com/525506/234938218-bb9c6124-51a6-4bf6-b39e-4548f50a599f.png) |
| ![Screenshot 2023-04-27 at 12 09 36 PM](https://user-images.githubusercontent.com/525506/234938262-a5c374fd-7f71-43db-bf5d-12371f9b2fe2.png) | ![Screenshot 2023-04-27 at 12 10 24 PM](https://user-images.githubusercontent.com/525506/234938306-11940af4-7284-4c84-b46d-cfbc1ca13cdb.png) |
| ![Screenshot 2023-05-01 at 9 11 40 PM](https://user-images.githubusercontent.com/525506/235564901-e24cee2c-5679-4b74-ae19-157b429663c2.png) | ![Screenshot 2023-05-01 at 9 12 23 PM](https://user-images.githubusercontent.com/525506/235564921-ef720fed-01dc-4d6f-a6af-8426c6cfa89e.png) |
| ![Screenshot 2023-05-01 at 9 14 45 PM](https://user-images.githubusercontent.com/525506/235565251-da312497-8ec6-40f7-b114-b6a1457a2b7b.png) | ![Screenshot 2023-05-01 at 9 15 43 PM](https://user-images.githubusercontent.com/525506/235565269-74291486-0999-44d8-a2c5-e8addd7f4503.png) |


## Check List

- [x] `yarn run prettier` for formatting code and docs
