### PR TITLE
fix: trigger dev store listener cb when promise resolves

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -245,6 +245,9 @@ export const createStore = () => {
                 if (prevAtomState?.d !== nextAtomState.d) {
                   mountDependencies(atom, nextAtomState, prevAtomState?.d)
                 }
+                if (import.meta.env?.MODE !== 'production') {
+                  storeListeners.forEach((l) => l('state'))
+                }
               }
             },
             (e) => {
@@ -261,6 +264,9 @@ export const createStore = () => {
                 reject(e)
                 if (prevAtomState?.d !== nextAtomState.d) {
                   mountDependencies(atom, nextAtomState, prevAtomState?.d)
+                }
+                if (import.meta.env?.MODE !== 'production') {
+                  storeListeners.forEach((l) => l('state'))
                 }
               }
             }

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -123,6 +123,46 @@ describe('[DEV-ONLY] dev-only methods', () => {
       unsub?.()
       unsubAtomSecond?.()
     })
+
+    it('should call the callback when async atom is resolved', async () => {
+      const store = createStore()
+      const callback = vi.fn()
+      const unsub = store.dev_subscribe_store?.(callback)
+
+      const countAtom = atom(async () => {
+        const result = await Promise.resolve(1)
+        return result
+      })
+
+      expect(callback).toHaveBeenCalledTimes(0)
+
+      await expect(store.get(countAtom)).resolves.toBe(1)
+
+      expect(callback).toHaveBeenNthCalledWith(1, 'state')
+      expect(callback).toHaveBeenCalledTimes(1)
+
+      unsub?.()
+    })
+
+    it('should call the callback when async atom is rejected', async () => {
+      const store = createStore()
+      const callback = vi.fn()
+      const unsub = store.dev_subscribe_store?.(callback)
+
+      const countAtom = atom(async () => {
+        const result = await Promise.reject(1)
+        return result
+      })
+
+      expect(callback).toHaveBeenCalledTimes(0)
+
+      await expect(store.get(countAtom)).rejects.toBeTruthy()
+
+      expect(callback).toHaveBeenNthCalledWith(1, 'state')
+      expect(callback).toHaveBeenCalledTimes(1)
+
+      unsub?.()
+    })
   })
 })
 


### PR DESCRIPTION
## Summary
We're only triggering `'state'` change callbacks for non-async atoms. This change allows the DevTools to capture the snapshot history of the state before and after the promise is resolved/rejected

**Changes**
- Trigger dev store listener callback when promise is resolved or rejected. 


## Check List

- [x] `yarn run prettier` for formatting code and docs
- [ ] Check with @dai-shi if there is a better place to add these callbacks
- [ ] Test it with the new time travel feature of devtools
