### PR TITLE
fix(docs): setItem argument missing from storage example

### DIFF
--- a/docs/utilities/storage.mdx
+++ b/docs/utilities/storage.mdx
@@ -138,7 +138,7 @@ const storedNumberAtom = atomWithStorage('my-number', 0, {
     }
   },
   setItem(key, value) {
-    localStorage.setItem(JSON.stringify(value))
+    localStorage.setItem(key, JSON.stringify(value))
   },
   removeItem(key) {
     localStorage.removeItem(key)


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #

## Summary
setItem argument missing from storage example


## Check List

- [x] `yarn run prettier` for formatting code and docs
