### PR TITLE
fix(vanilla): update atoms with tree structure dependencies (reggression from v1)

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -445,7 +445,7 @@ export const createStore = () => {
       })
     }
     loop1(atom)
-    while (invalidatedMap.size) {
+    const loop2 = () => {
       for (const [a, [dirty, changed]] of invalidatedMap.entries()) {
         if (!dirty) {
           invalidatedMap.delete(a)
@@ -468,7 +468,11 @@ export const createStore = () => {
           })
         }
       }
+      if (invalidatedMap.size) {
+        loop2()
+      }
     }
+    loop2()
   }
 
   const writeAtomState = <Value, Args extends unknown[], Result>(

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -286,3 +286,21 @@ it('should notify subscription with tree dependencies (#1956)', async () => {
   expect(cb).toBeCalledTimes(1)
   expect(store.get(dep3Atom)).toBe(4)
 })
+
+it('should notify subscription with tree dependencies with bail-out', async () => {
+  const valueAtom = atom(1)
+  const dep1Atom = atom((get) => get(valueAtom) * 2)
+  const dep2Atom = atom((get) => get(valueAtom) * 0)
+  const dep3Atom = atom((get) => get(dep1Atom) + get(dep2Atom))
+
+  const cb = vi.fn()
+  const store = createStore()
+  store.sub(dep1Atom, vi.fn())
+  store.sub(dep3Atom, cb)
+
+  expect(cb).toBeCalledTimes(0)
+  expect(store.get(dep3Atom)).toBe(2)
+  store.set(valueAtom, (c) => c + 1)
+  expect(cb).toBeCalledTimes(1)
+  expect(store.get(dep3Atom)).toBe(4)
+})


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #1956

## Summary

When the core is re-implemented in v2, we missed something for dependency (dependent) atoms re-calculation. In v1, it was fully pull based. In v2, it's pull and push. It tries to eagerly bail out. There was a regression and this should fix it.

(That brings me to a further refactoring. Can it be `dependents` in atom state instead of `dependencies`?? Let's explore it in the future.)
