### PR TITLE
fix: prefer PromiseLike where appropriate

### DIFF
--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -7,12 +7,13 @@ import { useStore } from './Provider.ts'
 
 type Store = ReturnType<typeof useStore>
 
-const isPromise = (x: unknown): x is Promise<unknown> => x instanceof Promise
+const isPromiseLike = (x: unknown): x is PromiseLike<unknown> =>
+  typeof (x as any).then === 'function'
 
 const use =
   ReactExports.use ||
   (<T>(
-    promise: Promise<T> & {
+    promise: PromiseLike<T> & {
       status?: 'pending' | 'fulfilled' | 'rejected'
       value?: T
       reason?: unknown
@@ -99,5 +100,5 @@ export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
   }, [store, atom, delay])
 
   useDebugValue(value)
-  return isPromise(value) ? use(value) : (value as Awaited<Value>)
+  return isPromiseLike(value) ? use(value) : (value as Awaited<Value>)
 }

--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -8,7 +8,7 @@ import { useStore } from './Provider.ts'
 type Store = ReturnType<typeof useStore>
 
 const isPromiseLike = (x: unknown): x is PromiseLike<unknown> =>
-  typeof (x as any).then === 'function'
+  typeof (x as any)?.then === 'function'
 
 const use =
   ReactExports.use ||

--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -100,5 +100,8 @@ export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
   }, [store, atom, delay])
 
   useDebugValue(value)
+  // TS doesn't allow using `use` always.
+  // The use of isPromiseLike is to be consistent with `use` type.
+  // `instanceof Promise` actually works fine in this case.
   return isPromiseLike(value) ? use(value) : (value as Awaited<Value>)
 }

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -54,6 +54,9 @@ const rejectPromise = <T>(
   promise.reason = e
 }
 
+const isPromiseLike = (x: unknown): x is PromiseLike<unknown> =>
+  typeof (x as any)?.then === 'function'
+
 /**
  * Immutable map from a dependency to the dependency's atom state
  * when it was last read.
@@ -224,7 +227,7 @@ export const createStore = () => {
     nextDependencies?: NextDependencies,
     abortPromise?: () => void
   ): AtomState<Value> => {
-    if (valueOrPromise instanceof Promise) {
+    if (isPromiseLike(valueOrPromise)) {
       let continuePromise: (next: Promise<Awaited<Value>>) => void
       const promise: Promise<Awaited<Value>> & PromiseMeta<Awaited<Value>> =
         new Promise((resolve, reject) => {
@@ -241,7 +244,7 @@ export const createStore = () => {
                   nextDependencies
                 )
                 resolvePromise(promise, v)
-                resolve(v)
+                resolve(v as Awaited<Value>)
                 if (prevAtomState?.d !== nextAtomState.d) {
                   mountDependencies(atom, nextAtomState, prevAtomState?.d)
                 }

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -39,7 +39,7 @@ type PromiseMeta<T> = {
   status?: 'pending' | 'fulfilled' | 'rejected'
   value?: T
   reason?: AnyError
-  orig?: Promise<T>
+  orig?: PromiseLike<T>
 }
 
 const resolvePromise = <T>(promise: Promise<T> & PromiseMeta<T>, value: T) => {
@@ -299,7 +299,7 @@ export const createStore = () => {
             }
           }
         })
-      promise.orig = valueOrPromise
+      promise.orig = valueOrPromise as PromiseLike<Awaited<Value>>
       promise.status = 'pending'
       registerCancelPromise(promise, (next) => {
         if (next) {


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #1963 

## Summary

Values from outside library should work with PromiseLike (= thenable).

## Check List

- [ ] `yarn run prettier` for formatting code and docs
