### PR TITLE
docs: fix typo in docs/recipes/custom-useatom-hooks

### DIFF
--- a/docs/recipes/custom-useatom-hooks.mdx
+++ b/docs/recipes/custom-useatom-hooks.mdx
@@ -22,7 +22,7 @@ export function useSelectAtom(anAtom, keyFn) {
 // how to use it
 useSelectAtom(
   useMemo(() => atom(initValue), [initValue]),
-  useCallBack((state) => state.prop, [])
+  useCallback((state) => state.prop, [])
 )
 ```
 


### PR DESCRIPTION
## Summary

Fixes minor typo.

## Check List

- [x] `yarn run prettier` for formatting code and docs