### PR TITLE
feat(utils/useHydrateAtoms) - Optionally rehydrate with force hydrate

### DIFF
--- a/docs/utilities/ssr.mdx
+++ b/docs/utilities/ssr.mdx
@@ -48,6 +48,19 @@ useHydrateAtoms(new Map([[count, 42]]))
 ```
 
 Atoms can only be hydrated once per store. Therefore, if the initial value used is changed during rerenders, it won't update the atom value.
+If there is a unique need to re-hydrate a previously hydrated atom, pass the optional forceHydrate as true.
+
+```js
+useHydrateAtoms(
+  [
+    [countAtom, 42],
+    [frameworkAtom, 'Next.js'],
+  ],
+  {
+    forceHydrate: true,
+  }
+)
+```
 
 If there's a need to hydrate in multiple stores, use multiple `useHydrateAtoms` hooks to achieve that.
 

--- a/docs/utilities/ssr.mdx
+++ b/docs/utilities/ssr.mdx
@@ -48,7 +48,8 @@ useHydrateAtoms(new Map([[count, 42]]))
 ```
 
 Atoms can only be hydrated once per store. Therefore, if the initial value used is changed during rerenders, it won't update the atom value.
-If there is a unique need to re-hydrate a previously hydrated atom, pass the optional forceHydrate as true.
+If there is a unique need to re-hydrate a previously hydrated atom, pass the optional dangerouslyForceHydrate as true
+and note that it may behave wrongly in concurrent rendering.
 
 ```js
 useHydrateAtoms(
@@ -57,7 +58,7 @@ useHydrateAtoms(
     [frameworkAtom, 'Next.js'],
   ],
   {
-    forceHydrate: true,
+    dangerouslyForceHydrate: true,
   }
 )
 ```

--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -3,7 +3,7 @@ import type { WritableAtom } from '../../vanilla.ts'
 
 type Store = ReturnType<typeof useStore>
 type Options = Parameters<typeof useStore>[0] & {
-  forceHydrate?: boolean
+  dangerouslyForceHydrate?: boolean
 }
 type AnyWritableAtom = WritableAtom<unknown, any[], any>
 type AtomMap<A = AnyWritableAtom, V = unknown> = Map<A, V>
@@ -38,12 +38,7 @@ export function useHydrateAtoms<T extends Iterable<AtomTuple>>(
 
   const hydratedSet = getHydratedSet(store)
   for (const [atom, value] of values) {
-    const isHydratedAtom = hydratedSet.has(atom)
-    if (!isHydratedAtom || options?.forceHydrate) {
-      if (options?.forceHydrate && isHydratedAtom) {
-        hydratedSet.delete(atom)
-      }
-
+    if (!hydratedSet.has(atom) || options?.dangerouslyForceHydrate) {
       hydratedSet.add(atom)
       store.set(atom, value)
     }

--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -2,7 +2,9 @@ import { useStore } from '../../react.ts'
 import type { WritableAtom } from '../../vanilla.ts'
 
 type Store = ReturnType<typeof useStore>
-type Options = Parameters<typeof useStore>[0]
+type Options = Parameters<typeof useStore>[0] & {
+  forceHydrate?: boolean
+}
 type AnyWritableAtom = WritableAtom<unknown, any[], any>
 type AtomMap<A = AnyWritableAtom, V = unknown> = Map<A, V>
 type AtomTuple<A = AnyWritableAtom, V = unknown> = readonly [A, V]
@@ -36,7 +38,12 @@ export function useHydrateAtoms<T extends Iterable<AtomTuple>>(
 
   const hydratedSet = getHydratedSet(store)
   for (const [atom, value] of values) {
-    if (!hydratedSet.has(atom)) {
+    const isHydratedAtom = hydratedSet.has(atom)
+    if (!isHydratedAtom || options?.forceHydrate) {
+      if (options?.forceHydrate && isHydratedAtom) {
+        hydratedSet.delete(atom)
+      }
+
       hydratedSet.add(atom)
       store.set(atom, value)
     }

--- a/tests/react/utils/useHydrateAtoms.test.tsx
+++ b/tests/react/utils/useHydrateAtoms.test.tsx
@@ -241,7 +241,7 @@ it('useHydrateAtoms should respect onMount', async () => {
   expect(onMountFn).toHaveBeenCalledTimes(1)
 })
 
-it.only('passing dangerouslyForceHydrate to useHydrateAtoms will re-hydrated atoms', async () => {
+it('passing dangerouslyForceHydrate to useHydrateAtoms will re-hydrated atoms', async () => {
   const countAtom = atom(0)
   const statusAtom = atom('fulfilled')
 

--- a/tests/react/utils/useHydrateAtoms.test.tsx
+++ b/tests/react/utils/useHydrateAtoms.test.tsx
@@ -240,3 +240,74 @@ it('useHydrateAtoms should respect onMount', async () => {
   await findByText('count: 42')
   expect(onMountFn).toHaveBeenCalledTimes(1)
 })
+
+it.only('passing forceHydrate to useHydrateAtoms will re-hydrated atoms', async () => {
+  const countAtom = atom(0)
+  const statusAtom = atom('fulfilled')
+
+  const Counter = ({
+    initialCount,
+    initialStatus,
+    forceHydrate = false,
+  }: {
+    initialCount: number
+    initialStatus: string
+    forceHydrate?: boolean
+  }) => {
+    useHydrateAtoms(
+      [
+        [countAtom, initialCount],
+        [statusAtom, initialStatus],
+      ],
+      {
+        forceHydrate,
+      }
+    )
+    const [countValue, setCount] = useAtom(countAtom)
+    const [statusValue, setStatus] = useAtom(statusAtom)
+
+    return (
+      <>
+        <div>count: {countValue}</div>
+        <button onClick={() => setCount((count) => count + 1)}>dispatch</button>
+        <div>status: {statusValue}</div>
+        <button
+          onClick={() =>
+            setStatus((status) =>
+              status === 'fulfilled' ? 'rejected' : 'fulfilled'
+            )
+          }>
+          update
+        </button>
+      </>
+    )
+  }
+  const { findByText, getByText, rerender } = render(
+    <StrictMode>
+      <Counter initialCount={42} initialStatus="rejected" />
+    </StrictMode>
+  )
+
+  await findByText('count: 42')
+  await findByText('status: rejected')
+  fireEvent.click(getByText('dispatch'))
+  fireEvent.click(getByText('update'))
+  await findByText('count: 43')
+  await findByText('status: fulfilled')
+
+  rerender(
+    <StrictMode>
+      <Counter initialCount={65} initialStatus="rejected" />
+    </StrictMode>
+  )
+  await findByText('count: 43')
+  await findByText('status: fulfilled')
+
+  rerender(
+    <StrictMode>
+      <Counter initialCount={11} initialStatus="rejected" forceHydrate={true} />
+    </StrictMode>
+  )
+  await findByText('count: 11')
+  await findByText('status: rejected')
+})

--- a/tests/react/utils/useHydrateAtoms.test.tsx
+++ b/tests/react/utils/useHydrateAtoms.test.tsx
@@ -241,18 +241,18 @@ it('useHydrateAtoms should respect onMount', async () => {
   expect(onMountFn).toHaveBeenCalledTimes(1)
 })
 
-it.only('passing forceHydrate to useHydrateAtoms will re-hydrated atoms', async () => {
+it.only('passing dangerouslyForceHydrate to useHydrateAtoms will re-hydrated atoms', async () => {
   const countAtom = atom(0)
   const statusAtom = atom('fulfilled')
 
   const Counter = ({
     initialCount,
     initialStatus,
-    forceHydrate = false,
+    dangerouslyForceHydrate = false,
   }: {
     initialCount: number
     initialStatus: string
-    forceHydrate?: boolean
+    dangerouslyForceHydrate?: boolean
   }) => {
     useHydrateAtoms(
       [
@@ -260,7 +260,7 @@ it.only('passing forceHydrate to useHydrateAtoms will re-hydrated atoms', async 
         [statusAtom, initialStatus],
       ],
       {
-        forceHydrate,
+        dangerouslyForceHydrate,
       }
     )
     const [countValue, setCount] = useAtom(countAtom)
@@ -305,7 +305,11 @@ it.only('passing forceHydrate to useHydrateAtoms will re-hydrated atoms', async 
 
   rerender(
     <StrictMode>
-      <Counter initialCount={11} initialStatus="rejected" forceHydrate={true} />
+      <Counter
+        initialCount={11}
+        initialStatus="rejected"
+        dangerouslyForceHydrate={true}
+      />
     </StrictMode>
   )
   await findByText('count: 11')


### PR DESCRIPTION
## Related Issues or Discussions

The useHydrateAtom discussion has been live since August of 2021 in https://github.com/pmndrs/jotai/discussions/669.

## Summary

We found a use case within our project that required a rehydration after a specific event. We had to manually rely on conditional useEffect actions to manually update the store rather than hydrating back from a fully reset SSR page. After review, a forceHydration option meets that requirement and a lot of the cases mentioned within that option discussion.

## Check List

- [X] `yarn run prettier` for formatting code and docs
