### PR TITLE
fix(utils): revert atomWithStorage typing

### DIFF
--- a/src/vanilla/utils/atomWithStorage.ts
+++ b/src/vanilla/utils/atomWithStorage.ts
@@ -123,8 +123,8 @@ export function atomWithStorage<Value>(
   storage: AsyncStorage<Value>,
   unstable_options?: { unstable_getOnInit?: boolean }
 ): WritableAtom<
-  Promise<Value> | Value,
-  [SetStateActionWithReset<Promise<Value> | Value>],
+  Value | Promise<Value>,
+  [SetStateActionWithReset<Value | Promise<Value>>],
   Promise<void>
 >
 
@@ -167,13 +167,13 @@ export function atomWithStorage<Value>(
 
   const anAtom = atom(
     (get) => get(baseAtom),
-    (get, set, update: SetStateActionWithReset<Promise<Value> | Value>) => {
+    (get, set, update: SetStateActionWithReset<Value | Promise<Value>>) => {
       const nextValue =
         typeof update === 'function'
           ? (
               update as (
-                prev: Promise<Value> | Value
-              ) => Promise<Value> | Value | typeof RESET
+                prev: Value | Promise<Value>
+              ) => Value | Promise<Value> | typeof RESET
             )(get(baseAtom))
           : update
       if (nextValue === RESET) {

--- a/src/vanilla/utils/atomWithStorage.ts
+++ b/src/vanilla/utils/atomWithStorage.ts
@@ -123,9 +123,9 @@ export function atomWithStorage<Value>(
   storage: AsyncStorage<Value>,
   unstable_options?: { unstable_getOnInit?: boolean }
 ): WritableAtom<
-  PromiseLike<Value> | Value,
-  [SetStateActionWithReset<PromiseLike<Value> | Value>],
-  PromiseLike<void>
+  Promise<Value> | Value,
+  [SetStateActionWithReset<Promise<Value> | Value>],
+  Promise<void>
 >
 
 export function atomWithStorage<Value>(
@@ -145,7 +145,9 @@ export function atomWithStorage<Value>(
 ): any {
   const getOnInit = unstable_options?.unstable_getOnInit
   const baseAtom = atom(
-    getOnInit ? storage.getItem(key, initialValue) : initialValue
+    getOnInit
+      ? (storage.getItem(key, initialValue) as Value | Promise<Value>)
+      : initialValue
   )
 
   if (import.meta.env?.MODE !== 'production') {
@@ -154,7 +156,7 @@ export function atomWithStorage<Value>(
 
   baseAtom.onMount = (setAtom) => {
     if (!getOnInit) {
-      setAtom(storage.getItem(key, initialValue))
+      setAtom(storage.getItem(key, initialValue) as Value | Promise<Value>)
     }
     let unsub: Unsubscribe | undefined
     if (storage.subscribe) {
@@ -165,20 +167,20 @@ export function atomWithStorage<Value>(
 
   const anAtom = atom(
     (get) => get(baseAtom),
-    (get, set, update: SetStateActionWithReset<PromiseLike<Value> | Value>) => {
+    (get, set, update: SetStateActionWithReset<Promise<Value> | Value>) => {
       const nextValue =
         typeof update === 'function'
           ? (
               update as (
-                prev: PromiseLike<Value> | Value
-              ) => PromiseLike<Value> | Value | typeof RESET
+                prev: Promise<Value> | Value
+              ) => Promise<Value> | Value | typeof RESET
             )(get(baseAtom))
           : update
       if (nextValue === RESET) {
         set(baseAtom, initialValue)
         return storage.removeItem(key)
       }
-      if (isPromiseLike(nextValue)) {
+      if (nextValue instanceof Promise) {
         return nextValue.then((resolvedValue) => {
           set(baseAtom, resolvedValue)
           return storage.setItem(key, resolvedValue)


### PR DESCRIPTION
This is to fix (partially revert) the change in #1967.
Atom values are guaranteed to be Promise instead of PromiseLike, and this gives more interoperability with other utils.