### PR TITLE
fix(docs): link either to new react docs or legacy docs

### DIFF
--- a/docs/basics/concepts.mdx
+++ b/docs/basics/concepts.mdx
@@ -27,4 +27,4 @@ const offlineAtom = atom((get) => get(dumbAtom).filter((item) => !item.online))
 
 And you could keep going on complexity forever.
 
-Another incredible feature of Jotai is the built-in ability to suspend when using asynchronous atoms. This is a relatively new features that yet needs to get experimented more, but definitely the future of how we build React apps. [Check out the docs](https://reactjs.org/blog/2022/03/29/react-v18.html#new-suspense-features) for more info.
+Another incredible feature of Jotai is the built-in ability to suspend when using asynchronous atoms. This is a relatively new features that yet needs to get experimented more, but definitely the future of how we build React apps. [Check out the docs](https://react.dev/blog/2022/03/29/react-v18#new-suspense-features) for more info.

--- a/docs/guides/debugging.mdx
+++ b/docs/guides/debugging.mdx
@@ -26,7 +26,7 @@ Jotai provides both a Babel and a SWC plugin, that adds a debugLabel automatical
 ## Using React Dev Tools
 
 You can use [React Dev Tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi)
-to inspect Jotai state. To achieve that [useDebugValue](https://reactjs.org/docs/hooks-reference.html#usedebugvalue)
+to inspect Jotai state. To achieve that [useDebugValue](https://react.dev/reference/react/useDebugValue)
 is used inside custom hooks. Keep in mind that it only works in dev mode
 (such as `NODE_ENV === 'development'`).
 

--- a/docs/guides/performance.mdx
+++ b/docs/guides/performance.mdx
@@ -8,7 +8,7 @@ keywords: performance
 **Note**: This guide has room for improvement. Consider it as FYI for now.
 
 Jotai & React gives us quite a few tools to manage the re-renders that happen in the app lifecycle.
-First, please read about the difference [between render & commit](https://reactjs.org/blog/2018/09/10/introducing-the-react-profiler.html#browsing-commits), because that's very important to understand before going further.
+First, please read about the difference [between render & commit](https://legacy.reactjs.org/blog/2018/09/10/introducing-the-react-profiler.html#browsing-commits), because that's very important to understand before going further.
 
 ### Cheap renders
 

--- a/docs/guides/react-native.mdx
+++ b/docs/guides/react-native.mdx
@@ -16,6 +16,6 @@ When it comes to persistence feature, the implementation specific to React Nativ
 
 There is no known specific overhead when using Jotai in your app. Some libraries will add some/lots of additional properties and methods to the stored data for the practical usage, but Jotai behaves differently and you're always manipulating simple stuff that could barely be shortcuted.
 
-Jotai atomical architecture will encourage you to split logic and data, providing a top-most experience to control every one of your render ([or commits, to be precise](https://reactjs.org/blog/2018/09/10/introducing-the-react-profiler.html#browsing-commits)) and therefore reach the best performances.
+Jotai atomical architecture will encourage you to split logic and data, providing a top-most experience to control every one of your render ([or commits, to be precise](https://legacy.reactjs.org/blog/2018/09/10/introducing-the-react-profiler.html#browsing-commits)) and therefore reach the best performances.
 
 And always remember that renders have to be fast, split calculation logic to async actions.


### PR DESCRIPTION
## Summary

The React docs moved to a new domain. This PR updates the URLs in the docs

## Check List

- [x] `yarn run prettier` for formatting code and docs
