### PR TITLE
fix(vanilla): bail out recomputing with the same value

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -373,9 +373,18 @@ export const createStore = () => {
       // If a dependency changed since this atom was last computed,
       // then we're out of date and need to recompute.
       if (
-        Array.from(atomState.d).every(
-          ([a, s]) => a === atom || getAtomState(a) === s
-        )
+        Array.from(atomState.d).every(([a, s]) => {
+          if (a === atom) {
+            return true
+          }
+          const atomState = getAtomState(a)
+          return (
+            atomState === s ||
+            (atomState &&
+              !hasPromiseAtomValue(atomState) &&
+              isEqualAtomValue(atomState, s))
+          )
+        })
       ) {
         return atomState
       }

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -374,16 +374,8 @@ export const createStore = () => {
       // then we're out of date and need to recompute.
       if (
         Array.from(atomState.d).every(([a, s]) => {
-          if (a === atom) {
-            return true
-          }
-          const atomState = getAtomState(a)
-          return (
-            atomState === s ||
-            (atomState &&
-              !hasPromiseAtomValue(atomState) &&
-              isEqualAtomValue(atomState, s))
-          )
+          const aState = getAtomState(a)
+          return a === atom || (aState && isEqualAtomValue(aState, s))
         })
       ) {
         return atomState

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -375,7 +375,14 @@ export const createStore = () => {
       if (
         Array.from(atomState.d).every(([a, s]) => {
           const aState = getAtomState(a)
-          return a === atom || (aState && isEqualAtomValue(aState, s))
+          return (
+            a === atom ||
+            aState === s ||
+            // TODO This is a hack, we should find a better solution.
+            (aState &&
+              !hasPromiseAtomValue(aState) &&
+              isEqualAtomValue(aState, s))
+          )
         })
       ) {
         return atomState

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -351,20 +351,6 @@ it('should notify subscription with tree dependencies with bail-out', async () =
 
 it('should bail out with the same value with chained dependency (#2014)', async () => {
   const store = createStore()
-  const bigAtom = atom({ count: 1, theSelectedField: 5 })
-  const selectedAtom = atom((get) => get(bigAtom).theSelectedField)
-  const deriveFn = vi.fn((get: Getter) => get(selectedAtom))
-  const derivedAtom = atom(deriveFn)
-  const derivedFurtherAtom = atom((get) => get(derivedAtom))
-  expect(store.get(derivedFurtherAtom)).toBe(5)
-  expect(deriveFn).toHaveBeenCalledTimes(1)
-  store.set(bigAtom, (obj) => ({ ...obj, count: obj.count + 1 }))
-  expect(store.get(derivedFurtherAtom)).toBe(5)
-  expect(deriveFn).toHaveBeenCalledTimes(1)
-})
-
-it('should bail out with the same value with sub', async () => {
-  const store = createStore()
   const objAtom = atom({ count: 1 })
   const countAtom = atom((get) => get(objAtom).count)
   const deriveFn = vi.fn((get: Getter) => get(countAtom))

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -348,3 +348,20 @@ it('should notify subscription with tree dependencies with bail-out', async () =
   expect(cb).toBeCalledTimes(1)
   expect(store.get(dep3Atom)).toBe(4)
 })
+
+it('should bail out with the same value with chained dependency (#2014)', async () => {
+  const store = createStore()
+  const bigAtom = atom({
+    count: 1,
+    theSelectedField: 5,
+  })
+  const selectedAtom = atom((get) => get(bigAtom).theSelectedField)
+  const deriveFn = vi.fn((get: Getter) => get(selectedAtom))
+  const derivedAtom = atom(deriveFn)
+  const derivedFurtherAtom = atom((get) => get(derivedAtom))
+  expect(store.get(derivedFurtherAtom)).toBe(5)
+  expect(deriveFn).toHaveBeenCalledTimes(1)
+  store.set(bigAtom, (obj) => ({ ...obj, count: obj.count + 1 }))
+  expect(store.get(derivedFurtherAtom)).toBe(5)
+  expect(deriveFn).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #2014 

## Summary

It's a regression from v1. It now checks atom values.

## Check List

- [x] `yarn run prettier` for formatting code and docs
