### PR TITLE
fix(readme): clarify write-only atoms are derived atoms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,7 +125,7 @@ function Counter() {
       ...
 ```
 
-### Write only atoms
+### Write only derived atoms
 
 Just do not define a read function.
 


### PR DESCRIPTION
read-only atoms, read-write atoms, and write-only atoms are all derived atoms.