### PR TITLE
fix: declare @types/react as peerDep to avoid phantom dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,10 +166,14 @@
     "wonka": "^6.3.2"
   },
   "peerDependencies": {
-    "react": ">=17.0.0"
+    "react": ">=17.0.0",
+    "@types/react": ">=17.0.0"
   },
   "peerDependenciesMeta": {
     "react": {
+      "optional": true
+    },
+    "@types/react": {
       "optional": true
     }
   }


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #2047 

## Summary



## Check List

- [ ] `yarn run prettier` for formatting code and docs
