### PR TITLE
fix(utils): Do not set a splitted atom when not actually modified

### DIFF
--- a/src/vanilla/utils/splitAtom.ts
+++ b/src/vanilla/utils/splitAtom.ts
@@ -111,11 +111,13 @@ export function splitAtom<Item, Key>(
             const nextItem = isFunction(update)
               ? update(arr[index] as Item)
               : update
-            set(arrAtom as WritableAtom<Item[], [Item[]], void>, [
-              ...arr.slice(0, index),
-              nextItem,
-              ...arr.slice(index + 1),
-            ])
+            if (!Object.is(nextItem, arr[index])) {
+              set(arrAtom as WritableAtom<Item[], [Item[]], void>, [
+                ...arr.slice(0, index),
+                nextItem,
+                ...arr.slice(index + 1),
+              ])
+            }
           }
           atomList[index] = isWritable(arrAtom) ? atom(read, write) : atom(read)
         })

--- a/src/vanilla/utils/splitAtom.ts
+++ b/src/vanilla/utils/splitAtom.ts
@@ -111,7 +111,7 @@ export function splitAtom<Item, Key>(
             const nextItem = isFunction(update)
               ? update(arr[index] as Item)
               : update
-            if (!Object.is(nextItem, arr[index])) {
+            if (!Object.is(arr[index], nextItem)) {
               set(arrAtom as WritableAtom<Item[], [Item[]], void>, [
                 ...arr.slice(0, index),
                 nextItem,

--- a/tests/react/vanilla-utils/splitAtom.test.tsx
+++ b/tests/react/vanilla-utils/splitAtom.test.tsx
@@ -517,8 +517,8 @@ it('should not update splitted atom when single item is set to identical value',
   const collectionAtomsAtom = splitAtom(collectionAtom)
 
   function App() {
-    const collection = useAtomValue(collectionAtomsAtom)
-    const setItem2 = useSetAtom(collection[1]!)
+    const collectionAtoms = useAtomValue(collectionAtomsAtom)
+    const setItem2 = useSetAtom(collectionAtoms[1]!)
     const currentCollection = useAtomValue(collectionAtom)
     return (
       <div>

--- a/tests/react/vanilla-utils/splitAtom.test.tsx
+++ b/tests/react/vanilla-utils/splitAtom.test.tsx
@@ -1,7 +1,7 @@
 import { StrictMode, useEffect, useRef } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { expect, it } from 'vitest'
-import { useAtom, useSetAtom } from 'jotai/react'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
 import type { Atom, PrimitiveAtom } from 'jotai/vanilla'
 import { splitAtom } from 'jotai/vanilla/utils'
@@ -509,4 +509,33 @@ it('variable sized splitted atom', async () => {
 
   fireEvent.click(getByText('button'))
   await findByText('numbers: 1,2')
+})
+
+it('should not update splitted atom when single item is set to identical value', async () => {
+  const initialCollection = [1, 2, 3]
+  const collectionAtom = atom<number[]>(initialCollection)
+  const collectionAtomsAtom = splitAtom(collectionAtom)
+
+  function App() {
+    const collection = useAtomValue(collectionAtomsAtom)
+    const setItem2 = useSetAtom(collection[1]!)
+    const currentCollection = useAtomValue(collectionAtom)
+    return (
+      <div>
+        <button onClick={() => setItem2(2)}>button</button>
+        changed: {(!Object.is(currentCollection, initialCollection)).toString()}
+      </div>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <StrictMode>
+      <App />
+    </StrictMode>
+  )
+
+  await findByText('changed: false')
+
+  fireEvent.click(getByText('button'))
+  await findByText('changed: false')
 })


### PR DESCRIPTION
## Related Issues or Discussions

Fixes https://github.com/pmndrs/jotai/discussions/2079

## Summary

As agreed during the discussion, `set` should not be called when an item remains unmodified.

## Check List

- [x] `yarn run prettier` for formatting code and docs
