### PR TITLE
fix(utils/atomWithStorage): Prevent createJSONStorage from adding subscribe method when window.Storage is not defined

### DIFF
--- a/src/vanilla/utils/atomWithStorage.ts
+++ b/src/vanilla/utils/atomWithStorage.ts
@@ -85,7 +85,8 @@ export function createJSONStorage<Value>(
   }
   if (
     typeof window !== 'undefined' &&
-    typeof window.addEventListener === 'function'
+    typeof window.addEventListener === 'function' &&
+    window.Storage
   ) {
     storage.subscribe = (key, callback, initialValue) => {
       if (!(getStringStorage() instanceof window.Storage)) {


### PR DESCRIPTION
## Related Issues or Discussions
Related to https://github.com/pmndrs/jotai/pull/1375. In other environments (React Native in my case) `window.addEventListener` may be polyfilled, but `window.Storage` is not, so `instanceof window.Storage` fails.

## Summary
`storage.subscribe` should only be defined if `window.Storage` is available in the environment.


## Check List

- [x] `yarn run prettier` for formatting code and docs
