### PR TITLE
feat(atomFamily): exposed keys of an atomFamily

### DIFF
--- a/src/vanilla/utils/atomFamily.ts
+++ b/src/vanilla/utils/atomFamily.ts
@@ -4,6 +4,7 @@ type ShouldRemove<Param> = (createdAt: number, param: Param) => boolean
 
 export interface AtomFamily<Param, AtomType> {
   (param: Param): AtomType
+  keys(): IterableIterator<Param>
   remove(param: Param): void
   setShouldRemove(shouldRemove: ShouldRemove<Param> | null): void
 }
@@ -69,5 +70,8 @@ export function atomFamily<Param, AtomType extends Atom<unknown>>(
       }
     }
   }
+
+  createAtom.keys = () => atoms.keys()
+
   return createAtom
 }


### PR DESCRIPTION
## Related Issues or Discussions
I would like to access all the keys in an `atomFamily `to Iterate through them.

Fixes #

## Summary
- added `keys(): IterableIterator<Param>` to `interface AtomFamily<Param, AtomType>`
- exposed the keys of the atom map ` createAtom.keys = () => atoms.keys();`


## Check List

- [x] `yarn run prettier` for formatting code and docs
