### PR TITLE
fix: text overflow under Recipes section in introduction page

### DIFF
--- a/website/src/components/toc.js
+++ b/website/src/components/toc.js
@@ -12,7 +12,7 @@ export const TOC = ({ section = '' }) => {
         <Link
           key={sectionLink.slug}
           to={`/docs/${sectionLink.slug}`}
-          className="inline-flex aspect-video items-center justify-center rounded-md border border-gray-200 bg-gray-100 p-2  text-center leading-snug !text-black !no-underline hover:border-blue-200 hover:bg-blue-100 dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-300 dark:!border-none dark:hover:bg-white sm:rounded-lg sm:p-4 dark:hover:!text-black"
+          className="inline-flex aspect-video items-center justify-center rounded-md border border-gray-200 bg-gray-100 p-2  text-center leading-snug !text-black break-all !no-underline hover:border-blue-200 hover:bg-blue-100 dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-300 dark:!border-none dark:hover:bg-white sm:rounded-lg sm:p-4 dark:hover:!text-black"
         >
           {sectionLink.meta.title}
         </Link>


### PR DESCRIPTION
Fixes #2109

As suggested in the discussion, the fix is simple using `break-all`.
