### PR TITLE
docs: add urql and jotai-urql description. add jotai-urql github repo link

### DIFF
--- a/docs/integrations/urql.mdx
+++ b/docs/integrations/urql.mdx
@@ -5,6 +5,15 @@ nav: 4.03
 keywords: urql
 ---
 
+[urql](https://formidable.com/open-source/urql/) offers a toolkit for GraphQL querying, caching, and state management.
+
+
+From the [Overview docs](https://formidable.com/open-source/urql/docs/):
+
+> urql is a highly customizable and versatile GraphQL client with which you add on features like normalized caching as you grow. It's built to be both easy to use for newcomers to GraphQL, and extensible, to grow to support dynamic single-app applications and highly customized GraphQL infrastructure. In short, urql prioritizes usability and adaptability.
+
+[jotai-urql](https://github.com/jotaijs/jotai-urql) is a Jotai integration library for URQL. It offers a cohesive interface that incorporates all of URQL's GraphQL features, allowing you to leverage these functionalities alongside your existing Jotai state.
+
 ### Install
 
 You have to install `jotai-urql`, `@urql/core` and `wonka` to use the integration.

--- a/docs/integrations/urql.mdx
+++ b/docs/integrations/urql.mdx
@@ -7,7 +7,6 @@ keywords: urql
 
 [urql](https://formidable.com/open-source/urql/) offers a toolkit for GraphQL querying, caching, and state management.
 
-
 From the [Overview docs](https://formidable.com/open-source/urql/docs/):
 
 > urql is a highly customizable and versatile GraphQL client with which you add on features like normalized caching as you grow. It's built to be both easy to use for newcomers to GraphQL, and extensible, to grow to support dynamic single-app applications and highly customized GraphQL infrastructure. In short, urql prioritizes usability and adaptability.


### PR DESCRIPTION
## Summary
I keep forgetting that jotai-urql github repo isn't linked in the docs unlike jotai-tanstack-query, and it bothered me 😄 

## Check List

- [x] `yarn run prettier` for formatting code and docs
