### PR TITLE
Fix documentation for useAtomCallback.

### DIFF
--- a/docs/utilities/callback.mdx
+++ b/docs/utilities/callback.mdx
@@ -65,4 +65,4 @@ const Monitor = () => {
 
 ### Codesandbox
 
-<CodeSandbox id="6ur43" />
+<CodeSandbox id="95gxnt" />

--- a/docs/utilities/callback.mdx
+++ b/docs/utilities/callback.mdx
@@ -12,14 +12,15 @@ Ref: https://github.com/pmndrs/jotai/issues/60
 ### Usage
 
 ```ts
-useAtomCallback(
-  callback: (get: Getter, set: Setter, arg: Arg) => Result
-): (arg: Arg) => Promise<Result>
+useAtomCallback<Result, Args extends unknown[]>(
+  callback: (get: Getter, set: Setter, ...arg: Args) => Result,
+  options?: Options
+): (...args: Args) => Result
 ```
 
-This hook allows to interact with atoms imperatively.
+This hook is for interacting with atoms imperatively.
 It takes a callback function that works like atom write function,
-and returns a function that returns a promise.
+and returns a function that returns an atom value.
 
 The callback to pass in the hook must be stable (should be wrapped with useCallback).
 
@@ -52,7 +53,7 @@ const Monitor = () => {
   )
   useEffect(() => {
     const timer = setInterval(async () => {
-      console.log(await readCount())
+      console.log(readCount())
     }, 1000)
     return () => {
       clearInterval(timer)


### PR DESCRIPTION
Update the `useAtomCallback` documentation.

The docs were for Jotai v1; update for v2. The change is that the callback function passed to `useAtomCallback` no longer returns a Promise; it just returns the atom value.

@dai-shi I forked the CodeSanbox example [here](https://codesandbox.io/s/react-typescript-forked-95gxnt), removing the `await` that is no longer needed. However I wasn't sure how to update the CodeSanbox link (id) in the docs.

## Related Issues or Discussions

Fixes #2149 

## Summary

Update the `useAtomCallback documentation for v2.

## Check List

- [x] `yarn run prettier` for formatting code and docs
