### PR TITLE
fix: Returning the same Promise twice from an atom getter causes Promise chaining cycle.

### DIFF
--- a/tests/vanilla/dependency.test.tsx
+++ b/tests/vanilla/dependency.test.tsx
@@ -72,3 +72,24 @@ it('correctly updates async derived atom after get/set update', async () => {
   derived = await store.get(derivedAsyncAtom)
   expect(derived).toBe(3)
 })
+
+it('correctly handles the same promise being returned twice from an atom getter', async () => {
+  const asyncDataAtom = atom(async () => {
+    return 'Asynchronous Data'
+  })
+
+  const counterAtom = atom(0)
+
+  const derivedAtom = atom((get) => {
+    get(counterAtom) // depending on sync data
+    return get(asyncDataAtom) // returning a promise from another atom
+  })
+
+  const store = createStore()
+
+  store.get(derivedAtom)
+  // setting the `counterAtom` dependency on the same JS event loop cycle, before
+  // the `derivedAtom` promise resolves.
+  store.set(counterAtom, 1)
+  await expect(store.get(derivedAtom)).resolves.toBe('Asynchronous Data')
+})


### PR DESCRIPTION
## Related Issues or Discussions

Fixes https://github.com/pmndrs/jotai/discussions/2151

## Summary


## Check List

- [ ] `yarn run prettier` for formatting code and docs
