### PR TITLE
feat(vanilla): prefer using `this` for atom config

### DIFF
--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -92,14 +92,22 @@ export function atom<Value, Args extends unknown[], Result>(
     config.read = read as Read<Value, SetAtom<Args, Result>>
   } else {
     config.init = read
-    config.read = (get) => get(config)
-    config.write = ((get: Getter, set: Setter, arg: SetStateAction<Value>) =>
-      set(
-        config as unknown as PrimitiveAtom<Value>,
+    config.read = function (get) {
+      return get(this)
+    }
+    config.write = function (
+      this: PrimitiveAtom<Value>,
+      get: Getter,
+      set: Setter,
+      arg: SetStateAction<Value>
+    ) {
+      return set(
+        this,
         typeof arg === 'function'
-          ? (arg as (prev: Value) => Value)(get(config))
+          ? (arg as (prev: Value) => Value)(get(this))
           : arg
-      )) as unknown as Write<Args, Result>
+      )
+    } as unknown as Write<Args, Result>
   }
   if (write) {
     config.write = write

--- a/src/vanilla/utils/freezeAtom.ts
+++ b/src/vanilla/utils/freezeAtom.ts
@@ -34,7 +34,9 @@ export function freezeAtomCreator<
   return ((...params: any[]) => {
     const anAtom = createAtom(...params)
     const origRead = anAtom.read
-    anAtom.read = (get, options) => deepFreeze(origRead(get, options))
+    anAtom.read = function (get, options) {
+      return deepFreeze(origRead.call(this, get, options))
+    }
     return anAtom
   }) as CreateAtom
 }

--- a/src/vanilla/utils/unwrap.ts
+++ b/src/vanilla/utils/unwrap.ts
@@ -100,7 +100,8 @@ export function unwrap<Value, Args extends unknown[], Result, PendingValue>(
           }
           return state.f
         },
-        (anAtom as WritableAtom<Value, unknown[], unknown>).write
+        (_get, set, ...args) =>
+          set(anAtom as WritableAtom<Value, unknown[], unknown>, ...args)
       )
     },
     anAtom,


### PR DESCRIPTION
It was intentional to avoid `this` so that it's never confusing when copying atom config objects.
(btw, this was the reason we avoided using class syntax suggested by @Thisen. so, it might be reconsiderable. Though, I'm not sure the final decision because of bundle size / little performance trade-off.)

As it turns out, not using `this` blocks some extended patterns. https://github.com/jotaijs/jotai-scope/issues/4
(And, I ended up with a suboptimal solution https://github.com/jotaijs/jotai-scope/pull/2.)

Let's see how it can change the situation.