### PR TITLE
Doc atom effect no async

### DIFF
--- a/docs/integrations/effect.mdx
+++ b/docs/integrations/effect.mdx
@@ -22,10 +22,7 @@ yarn add jotai-effect
 ```ts
 type CleanupFn = () => void
 
-type EffectFn = (
-  get: Getter,
-  set: Setter
-) => CleanupFn | void | Promise<CleanupFn | void>
+type EffectFn = (get: Getter, set: Setter) => CleanupFn | void
 
 function atomEffect(effectFn: EffectFn): Atom<void>
 ```
@@ -219,28 +216,6 @@ Aside from mount events, the effect runs when any of its dependencies change val
 
   ```js
   atomEffect((get, set) => {
-    // updates whenever `anAtom` changes value but not when `anotherAtom` changes value
-    get(anAtom)
-    setTimeout(() => {
-      get(anotherAtom)
-    }, 5000)
-  })
-  ```
-
-  </details>
-
-- **Async:**
-  For effects that return a promise, all atoms accessed with `get` prior to the returned promise resolving are added to the atom's internal dependency map. Atoms that have been watched after the promise has resolved, for instance in a `setTimeout`, are not included in the dependency map.
-
-  ⚠️ Use [caution](https://github.com/jotaijs/jotai-effect/discussions/10) when using async effects
-
-  <!-- prettier-ignore -->
-  <details style="cursor: pointer; user-select: none;">
-    <summary>Example</summary>
-
-  ```js
-  atomEffect(async (get, set) => {
-    await new Promise((resolve) => setTimeout(resolve, 1000))
     // updates whenever `anAtom` changes value but not when `anotherAtom` changes value
     get(anAtom)
     setTimeout(() => {


### PR DESCRIPTION
## Related Issues or Discussions
https://github.com/jotaijs/jotai-effect/discussions/10


## Summary
Given the caveats of managing atom dependencies with async effects, it will be best to deprecate support for async effects.

## Check List

- [x] `yarn run prettier` for formatting code and docs
