### PR TITLE
fix(vanilla): avoid re-computing unmounted derived atoms in an edge case

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -368,9 +368,13 @@ export const createStore = () => {
       // Otherwise, check if the dependencies have changed.
       // If all dependencies haven't changed, we can use the cache.
       if (
-        Array.from(atomState.d).every(
-          ([a, s]) => a === atom || readAtomState(a) === s
-        )
+        Array.from(atomState.d).every(([a, s]) => {
+          if (a === atom) {
+            return true
+          }
+          const aState = readAtomState(a)
+          return aState === s || (aState && !hasPromiseAtomValue(aState))
+        })
       ) {
         return atomState
       }

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -373,7 +373,11 @@ export const createStore = () => {
             return true
           }
           const aState = readAtomState(a)
-          return aState === s || (aState && !hasPromiseAtomValue(aState))
+          return (
+            aState === s ||
+            // We need to check values in case only dependencies are changed
+            (aState && isEqualAtomValue(aState, s))
+          )
         })
       ) {
         return atomState

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -423,3 +423,15 @@ it('should update derived atoms during write (#2107)', async () => {
   store.set(countAtom, 2)
   expect(store.get(countAtom)).toBe(2)
 })
+
+it('should not recompute a derived atom value if unchanged (#2168)', async () => {
+  const store = createStore()
+  const countAtom = atom(1)
+  const derived1Atom = atom((get) => get(countAtom) * 0)
+  const derive2Fn = vi.fn((get: Getter) => get(derived1Atom))
+  const derived2Atom = atom(derive2Fn)
+  expect(store.get(derived2Atom)).toBe(0)
+  store.set(countAtom, (c) => c + 1)
+  expect(store.get(derived2Atom)).toBe(0)
+  expect(derive2Fn).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #2168 

## Summary



## Check List

- [ x] `yarn run prettier` for formatting code and docs
