### PR TITLE
fix(vanilla): deal with promise resolving race condition

### DIFF
--- a/tests/react/async.test.tsx
+++ b/tests/react/async.test.tsx
@@ -1,10 +1,10 @@
 import { StrictMode, Suspense, useEffect, useRef } from 'react'
 import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { expect, it } from 'vitest'
+import { assert, expect, it } from 'vitest'
 import { Provider, useAtom } from 'jotai/react'
 import { atom, createStore } from 'jotai/vanilla'
-import type { Atom, SetStateAction, Setter } from 'jotai/vanilla'
+import type { Atom, SetStateAction } from 'jotai/vanilla'
 
 const useCommitCount = () => {
   const commitCountRef = useRef(1)
@@ -1145,10 +1145,10 @@ it('multiple derived atoms with dependency chaining and async write (#813)', asy
 })
 
 it('[render] resolves dependencies reliably after a delay', async () => {
-  expect.assertions(2)
+  expect.assertions(1)
   const countAtom = atom(0)
-  const resultAtom = atom<number | null>(null)
 
+  let result: number | null = null
   const resolve: (() => void)[] = []
   const asyncAtom = atom(async (get) => {
     const count = get(countAtom)
@@ -1167,9 +1167,10 @@ it('[render] resolves dependencies reliably after a delay', async () => {
       console.log(`derived (${count})`)
       const resultCount = await get(asyncAtom)
       console.log(`derived (${count})`, resultCount)
-      setSelf(resultAtom, resultCount)
+      result = resultCount
+      if (resultCount === 2) setSelf() // <-- necessary
     },
-    (_get, set, ...args: Parameters<Setter>) => set(...args)
+    () => {}
   )
 
   const derivedSyncAtom = atom((get) => {
@@ -1192,7 +1193,7 @@ it('[render] resolves dependencies reliably after a delay', async () => {
   render(<TestComponent />, { wrapper: Wrapper })
 
   const setCount = (arg: SetStateAction<number>) => store.set(countAtom, arg)
-
+  const increment = (c: number) => c + 1
   await waitFor(() => assert(resolve.length === 1))
 
   resolve[0]!()
@@ -1203,8 +1204,7 @@ it('[render] resolves dependencies reliably after a delay', async () => {
   resolve[1]!()
   resolve[2]!()
 
-  await waitFor(() => assert(store.get(countAtom) === 2))
-  expect(store.get(resultAtom)).toBe(2)
+  await waitFor(() => assert(result === 2))
 
   await act(() => setCount(increment))
   await act(() => setCount(increment))
@@ -1213,72 +1213,5 @@ it('[render] resolves dependencies reliably after a delay', async () => {
   resolve[4]!()
 
   await waitFor(() => assert(store.get(countAtom) === 4))
-  expect(store.get(resultAtom)).toBe(4) // 3
+  expect(result).toBe(4) // 3
 })
-
-it('[unit] resolves dependencies reliably after a delay', async () => {
-  const countAtom = atom(0)
-  const resultAtom = atom<number | null>(null)
-
-  const resolve: (() => void)[] = []
-  const asyncAtom = atom(async (get) => {
-    const count = get(countAtom)
-    await new Promise<void>((r: { (): void; count?: number }) => {
-      r.count = count
-      resolve.push(r)
-    })
-    console.log(`resolved (${count})`)
-    return count
-  })
-
-  const derivedAtom = atom(
-    async (get, { setSelf }) => {
-      const count = get(countAtom)
-      await Promise.resolve()
-      console.log(`derived (${count})`)
-      const asyncCount = await get(asyncAtom)
-      console.log(`derived (${count})`, asyncCount)
-      setSelf(resultAtom, asyncCount)
-    },
-    (_get, set, ...args: Parameters<Setter>) => set(...args)
-  )
-
-  const store = createStore()
-  store.sub(derivedAtom, () => {})
-
-  await waitFor(() => assert(resolve.length === 1))
-
-  resolve[0]!()
-
-  store.set(countAtom, increment)
-  store.set(countAtom, increment)
-
-  await waitFor(() => assert(resolve.length === 3))
-
-  resolve[1]!()
-  resolve[2]!()
-
-  await waitFor(() => assert(store.get(countAtom) === 2))
-  expect(store.get(resultAtom)).toBe(2)
-
-  store.set(countAtom, increment)
-  store.set(countAtom, increment)
-
-  await waitFor(() => assert(resolve.length === 5))
-
-  resolve[3]!()
-  resolve[4]!()
-
-  await waitFor(() => assert(store.get(countAtom) === 4))
-  expect(store.get(resultAtom)).toBe(4) // 3
-})
-
-function assert(condition: boolean): asserts condition {
-  if (!condition) {
-    throw new Error('assertion failed')
-  }
-}
-
-function increment(c: number) {
-  return c + 1
-}

--- a/tests/react/async.test.tsx
+++ b/tests/react/async.test.tsx
@@ -1,10 +1,10 @@
 import { StrictMode, Suspense, useEffect, useRef } from 'react'
 import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { assert, expect, it } from 'vitest'
-import { Provider, useAtom } from 'jotai/react'
-import { atom, createStore } from 'jotai/vanilla'
-import type { Atom, SetStateAction } from 'jotai/vanilla'
+import { expect, it } from 'vitest'
+import { useAtom } from 'jotai/react'
+import { atom } from 'jotai/vanilla'
+import type { Atom } from 'jotai/vanilla'
 
 const useCommitCount = () => {
   const commitCountRef = useRef(1)
@@ -1142,76 +1142,4 @@ it('multiple derived atoms with dependency chaining and async write (#813)', asy
     getByText('aName: alpha')
     getByText('bName: beta')
   })
-})
-
-it('[render] resolves dependencies reliably after a delay', async () => {
-  expect.assertions(1)
-  const countAtom = atom(0)
-
-  let result: number | null = null
-  const resolve: (() => void)[] = []
-  const asyncAtom = atom(async (get) => {
-    const count = get(countAtom)
-    await new Promise<void>((r: { (): void; count?: number }) => {
-      r.count = count
-      resolve.push(r)
-    })
-    console.log(`resolved (${count})`)
-    return count
-  })
-
-  const derivedAtom = atom(
-    async (get, { setSelf }) => {
-      const count = get(countAtom)
-      await Promise.resolve()
-      console.log(`derived (${count})`)
-      const resultCount = await get(asyncAtom)
-      console.log(`derived (${count})`, resultCount)
-      result = resultCount
-      if (resultCount === 2) setSelf() // <-- necessary
-    },
-    () => {}
-  )
-
-  const derivedSyncAtom = atom((get) => {
-    get(derivedAtom)
-  })
-
-  function useTest() {
-    useAtom(derivedSyncAtom)
-    useAtom(countAtom)
-  }
-  function TestComponent() {
-    useTest()
-    return null
-  }
-  const store = createStore()
-
-  const Wrapper = ({ children }: React.PropsWithChildren) => (
-    <Provider store={store}>{children}</Provider>
-  )
-  render(<TestComponent />, { wrapper: Wrapper })
-
-  const setCount = (arg: SetStateAction<number>) => store.set(countAtom, arg)
-  const increment = (c: number) => c + 1
-  await waitFor(() => assert(resolve.length === 1))
-
-  resolve[0]!()
-
-  await act(() => setCount(increment))
-  await act(() => setCount(increment))
-
-  resolve[1]!()
-  resolve[2]!()
-
-  await waitFor(() => assert(result === 2))
-
-  await act(() => setCount(increment))
-  await act(() => setCount(increment))
-
-  resolve[3]!()
-  resolve[4]!()
-
-  await waitFor(() => assert(store.get(countAtom) === 4))
-  expect(result).toBe(4) // 3
 })

--- a/tests/react/async2.test.tsx
+++ b/tests/react/async2.test.tsx
@@ -1,8 +1,8 @@
 import { StrictMode, Suspense } from 'react'
-import { fireEvent, render } from '@testing-library/react'
-import { describe, it } from 'vitest'
-import { useAtomValue, useSetAtom } from 'jotai/react'
-import { atom } from 'jotai/vanilla'
+import { act, fireEvent, render, waitFor } from '@testing-library/react'
+import { assert, describe, expect, it } from 'vitest'
+import { Provider, useAtom, useAtomValue, useSetAtom } from 'jotai/react'
+import { SetStateAction, atom, createStore } from 'jotai/vanilla'
 
 describe('useAtom delay option test', () => {
   it('suspend for Promise.resovle without delay option', async () => {
@@ -140,4 +140,73 @@ describe('atom read function setSelf option test', () => {
     fireEvent.click(getByText('button'))
     await findByText('text: hello1')
   })
+})
+
+it('resolves dependencies reliably after a delay', async () => {
+  expect.assertions(1)
+  const countAtom = atom(0)
+
+  let result: number | null = null
+  const resolve: (() => void)[] = []
+  const asyncAtom = atom(async (get) => {
+    const count = get(countAtom)
+    await new Promise<void>((r: { (): void; count?: number }) => {
+      r.count = count
+      resolve.push(r)
+    })
+    return count
+  })
+
+  const derivedAtom = atom(
+    async (get, { setSelf }) => {
+      get(countAtom)
+      await Promise.resolve()
+      const resultCount = await get(asyncAtom)
+      result = resultCount
+      if (resultCount === 2) setSelf() // <-- necessary
+    },
+    () => {}
+  )
+
+  const derivedSyncAtom = atom((get) => {
+    get(derivedAtom)
+  })
+
+  function useTest() {
+    useAtom(derivedSyncAtom)
+    useAtom(countAtom)
+  }
+  function TestComponent() {
+    useTest()
+    return null
+  }
+  const store = createStore()
+
+  const Wrapper = ({ children }: React.PropsWithChildren) => (
+    <Provider store={store}>{children}</Provider>
+  )
+  render(<TestComponent />, { wrapper: Wrapper })
+
+  const setCount = (arg: SetStateAction<number>) => store.set(countAtom, arg)
+  const increment = (c: number) => c + 1
+  await waitFor(() => assert(resolve.length === 1))
+
+  resolve[0]!()
+
+  await act(() => setCount(increment))
+  await act(() => setCount(increment))
+
+  resolve[1]!()
+  resolve[2]!()
+
+  await waitFor(() => assert(result === 2))
+
+  await act(() => setCount(increment))
+  await act(() => setCount(increment))
+
+  resolve[3]!()
+  resolve[4]!()
+
+  await waitFor(() => assert(store.get(countAtom) === 4))
+  expect(result).toBe(4) // 3
 })

--- a/tests/react/async2.test.tsx
+++ b/tests/react/async2.test.tsx
@@ -1,8 +1,8 @@
 import { StrictMode, Suspense } from 'react'
-import { act, fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import { assert, describe, expect, it } from 'vitest'
-import { Provider, useAtom, useAtomValue, useSetAtom } from 'jotai/react'
-import { SetStateAction, atom, createStore } from 'jotai/vanilla'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai/react'
+import { atom } from 'jotai/vanilla'
 
 describe('useAtom delay option test', () => {
   it('suspend for Promise.resovle without delay option', async () => {
@@ -142,71 +142,76 @@ describe('atom read function setSelf option test', () => {
   })
 })
 
-it('resolves dependencies reliably after a delay', async () => {
-  expect.assertions(1)
-  const countAtom = atom(0)
+describe('timing issue with setSelf', () => {
+  it('resolves dependencies reliably after a delay (#2192)', async () => {
+    expect.assertions(1)
+    const countAtom = atom(0)
 
-  let result: number | null = null
-  const resolve: (() => void)[] = []
-  const asyncAtom = atom(async (get) => {
-    const count = get(countAtom)
-    await new Promise<void>((r: { (): void; count?: number }) => {
-      r.count = count
-      resolve.push(r)
+    let result: number | null = null
+    const resolve: (() => void)[] = []
+    const asyncAtom = atom(async (get) => {
+      const count = get(countAtom)
+      await new Promise<void>((r) => resolve.push(r))
+      return count
     })
-    return count
+
+    const derivedAtom = atom(
+      async (get, { setSelf }) => {
+        get(countAtom)
+        await Promise.resolve()
+        const resultCount = await get(asyncAtom)
+        result = resultCount
+        if (resultCount === 2) setSelf() // <-- necessary
+      },
+      () => {}
+    )
+
+    const derivedSyncAtom = atom((get) => {
+      get(derivedAtom)
+    })
+
+    const increment = (c: number) => c + 1
+    function TestComponent() {
+      useAtom(derivedSyncAtom)
+      const [count, setCount] = useAtom(countAtom)
+      const onClick = () => {
+        setCount(increment)
+        setCount(increment)
+      }
+      return (
+        <>
+          count: {count}
+          <button onClick={onClick}>button</button>
+        </>
+      )
+    }
+
+    const { getByText, findByText } = render(
+      <StrictMode>
+        <TestComponent />
+      </StrictMode>
+    )
+
+    await waitFor(() => assert(resolve.length === 1))
+    resolve[0]!()
+
+    // The use of fireEvent is required to reproduce the issue
+    fireEvent.click(getByText('button'))
+
+    await waitFor(() => assert(resolve.length === 3))
+    resolve[1]!()
+    resolve[2]!()
+
+    await waitFor(() => assert(result === 2))
+
+    // The use of fireEvent is required to reproduce the issue
+    fireEvent.click(getByText('button'))
+
+    await waitFor(() => assert(resolve.length === 5))
+    resolve[3]!()
+    resolve[4]!()
+
+    await findByText('count: 4')
+    expect(result).toBe(4) // 3
   })
-
-  const derivedAtom = atom(
-    async (get, { setSelf }) => {
-      get(countAtom)
-      await Promise.resolve()
-      const resultCount = await get(asyncAtom)
-      result = resultCount
-      if (resultCount === 2) setSelf() // <-- necessary
-    },
-    () => {}
-  )
-
-  const derivedSyncAtom = atom((get) => {
-    get(derivedAtom)
-  })
-
-  function useTest() {
-    useAtom(derivedSyncAtom)
-    useAtom(countAtom)
-  }
-  function TestComponent() {
-    useTest()
-    return null
-  }
-  const store = createStore()
-
-  const Wrapper = ({ children }: React.PropsWithChildren) => (
-    <Provider store={store}>{children}</Provider>
-  )
-  render(<TestComponent />, { wrapper: Wrapper })
-
-  const setCount = (arg: SetStateAction<number>) => store.set(countAtom, arg)
-  const increment = (c: number) => c + 1
-  await waitFor(() => assert(resolve.length === 1))
-
-  resolve[0]!()
-
-  await act(() => setCount(increment))
-  await act(() => setCount(increment))
-
-  resolve[1]!()
-  resolve[2]!()
-
-  await waitFor(() => assert(result === 2))
-
-  await act(() => setCount(increment))
-  await act(() => setCount(increment))
-
-  resolve[3]!()
-  resolve[4]!()
-
-  await waitFor(() => assert(store.get(countAtom) === 4))
-  expect(result).toBe(4) // 3
 })

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -425,7 +425,7 @@ it('should update derived atoms during write (#2107)', async () => {
   expect(store.get(countAtom)).toBe(2)
 })
 
-it.only('resolves dependencies reliably after a delay', async () => {
+it('resolves dependencies reliably after a delay (#2192)', async () => {
   expect.assertions(1)
   const countAtom = atom(0)
   let result: number | null = null
@@ -433,10 +433,7 @@ it.only('resolves dependencies reliably after a delay', async () => {
   const resolve: (() => void)[] = []
   const asyncAtom = atom(async (get) => {
     const count = get(countAtom)
-    await new Promise<void>((r: { (): void; count?: number }) => {
-      r.count = count
-      resolve.push(r)
-    })
+    await new Promise<void>((r) => resolve.push(r))
     return count
   })
 

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -425,7 +425,7 @@ it('should update derived atoms during write (#2107)', async () => {
   expect(store.get(countAtom)).toBe(2)
 })
 
-it.only('[unit] resolves dependencies reliably after a delay', async () => {
+it.only('resolves dependencies reliably after a delay', async () => {
   expect.assertions(1)
   const countAtom = atom(0)
   let result: number | null = null
@@ -437,17 +437,14 @@ it.only('[unit] resolves dependencies reliably after a delay', async () => {
       r.count = count
       resolve.push(r)
     })
-    console.log(`resolved (${count})`)
     return count
   })
 
   const derivedAtom = atom(
     async (get, { setSelf }) => {
-      const count = get(countAtom)
+      get(countAtom)
       await Promise.resolve()
-      console.log(`derived (${count})`)
       result = await get(asyncAtom)
-      console.log(`derived (${count})`, result)
       if (result === 2) setSelf() // <-- necessary
     },
     () => {}


### PR DESCRIPTION
## Related Issues or Discussions
https://github.com/pmndrs/jotai/discussions/2192

## Related Issue
https://github.com/pmndrs/jotai/issues/2191

## Summary
Adds tests for the issue linked above.

## Description of Issue
A primitive atom (`atomP`) exists and has a value (`valueP`)
An async atom (`atomA`) gets the value (`valueAP`) from atomP and then has a delay (`delayA`) before returning the value from atomP.
A derived async atom (`atomB`) gets the value (`valueBP`) from atomP and after a microtask or greater delay (`delayB`) it gets the value (`valueBA`) from atomA.
The bug requires delayB < delayA.
So,
 - atomP is a synchronous dependency of atomA and atomB
 - atomA is an asynchronous dependency of atomB

After all atoms mount,
atomP is changed twice with a delay (`delayC`) less than delayA.
This first multi-change proceeds nominally. ✅

atomP is then changed twice again with a delay (`delayD`) less than delayA.
This second multi-change does NOT proceed nominally.
The first value of this multi-change is used for ALL subsequent values of this multi-change.
Therefore, subsequent values use a stale value. ❌

## Timing
See below for this timing in depth:
```
init valueP to 0
inside atomB.read: before await valueBA, valueBP is 0
change valueP to 1
inside atomB.read: before await valueBA, valueBP is 1
change valueP to 2
inside atomB.read: before await valueBA, valueBP is 2

inside atomA.read: after delayA, valueAP is 0
inside atomA.read: after delayA, valueAP is 1
inside atomA.read: after delayA, valueAP is 2

inside atomB.read: before await valueBA, valueBP is 2, valueBA is 2
inside atomB.read: before await valueBA, valueBP is 1, valueBA is 2
inside atomB.read: before await valueBA, valueBP is 0, valueBA is 2
===== above is nominal ✅ =====

change valueP to 3
inside atomB.read: before await valueBA, valueBP is 3
change valueP to 4
inside atomB.read: before await valueBA, valueBP is 4
inside atomA.read: after delayA, valueAP is 3
inside atomA.read: after delayA, valueAP is 4
inside atomB.read: before await valueBA, valueBP is 3, valueBA is 3 // Error: should be 4
inside atomB.read: before await valueBA, valueBP is 4, valueBA is 3 // Error: should be 4
===== above is anomalous ❌ =====
```

## Theory
Likely, as a performance optimization there is logic in [store.ts](https://github.com/pmndrs/jotai/blob/main/src/vanilla/store.ts) to reuse the existing value. The bug is probably due to caching the incorrect value.

The microsecond delay (delayB) in atomB is significant for some reason. Not sure why yet.

The `store.sub` is also significant for some reason.

## Unit Test
I'm having trouble getting a unit test to work with just the store. Subsequent fires of `setCount(increment)` do not cause asyncAtom.read to refire unless I use a React hook. Not sure why.

It would be preferable to write a unit test and not depend on the React library for testing core Jotai functionality.

## Check List

- [x] `yarn run prettier` for formatting code and docs

https://codesandbox.io/s/jovial-kepler-d9v27h

https://github.com/pmndrs/jotai/assets/5034873/0b873a61-5aa3-4f6a-a99e-cc51cc138258



