### PR TITLE
docs: add a warning for selectAtom

### DIFF
--- a/docs/utilities/select.mdx
+++ b/docs/utilities/select.mdx
@@ -7,7 +7,9 @@ published: false
 
 ## selectAtom
 
-Ref: https://github.com/pmndrs/jotai/issues/36
+⚠️  Unlike its name, `selectAtom` is provided as an escape hatch. Using it means building not 100% pure atom model. Prefer using derived atoms and use `selectAtom` only when `equalityFn` or `prevSlice` is unavoidable.
+
+### Signatures
 
 ```ts
 function selectAtom<Value, Slice>(


### PR DESCRIPTION
## Related Issues or Discussions

Fixes https://github.com/pmndrs/jotai/discussions/2209#discussioncomment-7380257

## Summary

Warn not to overuse selectAtom

## Check List

- [ ] `yarn run prettier` for formatting code and docs
