### PR TITLE
docs: add a warning for setSelf

### DIFF
--- a/docs/core/atom.mdx
+++ b/docs/core/atom.mdx
@@ -180,6 +180,12 @@ For `fetch` use case, we can simply pass `signal`.
 
 See the below example for `fetch` usage.
 
+#### `options.setSelf`
+
+It's a special function to invoke the write function of the self atom.
+
+⚠️ It's provided primarily for internal usage and third-party library authors. Read the source code carefully to understand the behavior. Check release notes for any breaking/non-breaking changes.
+
 ## codesandbox
 
 <CodeSandbox id="hg665r" />

--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -9,6 +9,9 @@ type SetAtom<Args extends unknown[], Result> = <A extends Args>(
   ...args: A
 ) => Result
 
+/**
+ * setSelf is for internal use only and subject to change without notice.
+ */
 type Read<Value, SetSelf = never> = (
   get: Getter,
   options: { readonly signal: AbortSignal; readonly setSelf: SetSelf }


### PR DESCRIPTION
## Related Issues or Discussions

Discussed in Poimandres Discord server

## Summary

Add warning for setSelf about the internal use.

## Check List

- [x] `yarn run prettier` for formatting code and docs
