### PR TITLE
fix(utils): unwrap may not return previous value

### DIFF
--- a/src/vanilla/utils/unwrap.ts
+++ b/src/vanilla/utils/unwrap.ts
@@ -95,7 +95,7 @@ export function unwrap<Value, Args extends unknown[], Result, PendingValue>(
       return atom(
         (get) => {
           const state = get(promiseAndValueAtom)
-          if ('f' in state) {
+          if ('f' in state) { // is pending
             return state.f
           }
           return state.v

--- a/src/vanilla/utils/unwrap.ts
+++ b/src/vanilla/utils/unwrap.ts
@@ -76,8 +76,12 @@ export function unwrap<Value, Args extends unknown[], Result, PendingValue>(
               )
               .finally(setSelf)
           }
-          if (prev && 'v' in prev) {
-            return { p: promise, f: fallback(prev.v) }
+          if (prev) {
+            if ('v' in prev) {
+              return { p: promise, f: fallback(prev.v) }
+            } else if ('f' in prev) {
+              return { p: promise, f: prev.f }
+            }
           }
           return { p: promise, f: fallback() }
         },

--- a/src/vanilla/utils/unwrap.ts
+++ b/src/vanilla/utils/unwrap.ts
@@ -95,7 +95,8 @@ export function unwrap<Value, Args extends unknown[], Result, PendingValue>(
       return atom(
         (get) => {
           const state = get(promiseAndValueAtom)
-          if ('f' in state) { // is pending
+          if ('f' in state) {
+            // is pending
             return state.f
           }
           return state.v

--- a/tests/vanilla/utils/unwrap.test.ts
+++ b/tests/vanilla/utils/unwrap.test.ts
@@ -86,6 +86,15 @@ describe('unwrap', () => {
     resolve()
     await new Promise((r) => setTimeout(r)) // wait for a tick
     expect(store.get(syncAtom)).toBe(6)
+
+    store.set(countAtom, 4)
+    expect(store.get(syncAtom)).toBe(6)
+    resolve()
+    store.set(countAtom, 5)
+    expect(store.get(syncAtom)).not.toBe(0) // expect 6 or 8
+    resolve()
+    await new Promise((r) => setTimeout(r)) // wait for a tick
+    expect(store.get(syncAtom)).toBe(10)
   })
 
   it('should unwrap a sync atom which is noop', async () => {


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #2214

## Summary

Fixed to carry over previous values

## Check List

- [x] `yarn run prettier` for formatting code and docs
