### PR TITLE
fix: primitive atom should always have `init` value

### DIFF
--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -59,7 +59,9 @@ export type PrimitiveAtom<Value> = WritableAtom<
   Value,
   [SetStateAction<Value>],
   void
->
+> & {
+  init: Value
+}
 
 let keyCount = 0 // global key count for all atoms
 
@@ -79,9 +81,7 @@ export function atom<Value, Args extends unknown[], Result>(
 ): WritableAtom<Value, Args, Result> & WithInitialValue<Value>
 
 // primitive atom
-export function atom<Value>(
-  initialValue: Value
-): PrimitiveAtom<Value> & WithInitialValue<Value>
+export function atom<Value>(initialValue: Value): PrimitiveAtom<Value>
 
 export function atom<Value, Args extends unknown[], Result>(
   read: Value | Read<Value, SetAtom<Args, Result>>,

--- a/tests/vanilla/types.test.tsx
+++ b/tests/vanilla/types.test.tsx
@@ -1,5 +1,5 @@
 import { expectType } from 'ts-expect'
-import { it } from 'vitest'
+import { expect, it } from 'vitest'
 import { atom } from 'jotai/vanilla'
 import type {
   Atom,
@@ -55,4 +55,15 @@ it('type utils should work', () => {
     expectType<Promise<void>>(result)
   }
   Component
+})
+
+it('init property should exist in primitiveAtom', () => {
+  {
+    const primitiveAtom = atom(1)
+    expectType<number>(primitiveAtom.init)
+  }
+  {
+    const primitiveAtom = atom(Promise.resolve(1))
+    expectType<Promise<number>>(primitiveAtom.init)
+  }
 })


### PR DESCRIPTION
## Related Issues or Discussions

N/A

## Summary

I'm creating a library that will modify the primitive atom in the runtime, which means each runtime could have a different initial value,  onMount...

I read the code and found that primitiveAtom should always property `init` in any case.

In this PR, I update the PrimitiveAtom type, so that in my code, infer `init` property should not case a missing type error:

```ts
function f(atom: PrimitiveAtom<unknown>) {
  atom.init // <-- this does exist
}
```

<img width="815" alt="image" src="https://github.com/pmndrs/jotai/assets/14026360/6e1245b3-a6df-409b-9456-91afb3553230">


## Check List

- [x] `yarn run prettier` for formatting code and docs
