### PR TITLE
Simplify `splitAtom()` by using the `Array.prototype.toSpliced()` method

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "patch-readme": "shx sed -i 's/.*Jotai \\(dark mode\\).*//' dist/readme.md"
   },
   "engines": {
-    "node": ">=12.20.0"
+    "node": ">=20.0.0"
   },
   "prettier": {
     "semi": false,
@@ -176,5 +176,6 @@
     "@types/react": {
       "optional": true
     }
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/src/vanilla/utils/splitAtom.ts
+++ b/src/vanilla/utils/splitAtom.ts
@@ -158,10 +158,10 @@ export function splitAtom<Item, Key>(
                   const index = get(splittedAtom).indexOf(action.atom)
                   if (index >= 0) {
                     const arr = get(arrAtom)
-                    set(arrAtom as WritableAtom<Item[], [Item[]], void>, [
-                      ...arr.slice(0, index),
-                      ...arr.slice(index + 1),
-                    ])
+                    set(
+                      arrAtom as WritableAtom<Item[], [Item[]], void>,
+                      arr.toSpliced(index, 1)
+                    )
                   }
                   break
                 }
@@ -171,11 +171,10 @@ export function splitAtom<Item, Key>(
                     : get(splittedAtom).length
                   if (index >= 0) {
                     const arr = get(arrAtom)
-                    set(arrAtom as WritableAtom<Item[], [Item[]], void>, [
-                      ...arr.slice(0, index),
-                      action.value,
-                      ...arr.slice(index),
-                    ])
+                    set(
+                      arrAtom as WritableAtom<Item[], [Item[]], void>,
+                      arr.toSpliced(index, 0, action.value)
+                    )
                   }
                   break
                 }
@@ -186,21 +185,16 @@ export function splitAtom<Item, Key>(
                     : get(splittedAtom).length
                   if (index1 >= 0 && index2 >= 0) {
                     const arr = get(arrAtom)
-                    if (index1 < index2) {
-                      set(arrAtom as WritableAtom<Item[], [Item[]], void>, [
-                        ...arr.slice(0, index1),
-                        ...arr.slice(index1 + 1, index2),
-                        arr[index1] as Item,
-                        ...arr.slice(index2),
-                      ])
-                    } else {
-                      set(arrAtom as WritableAtom<Item[], [Item[]], void>, [
-                        ...arr.slice(0, index2),
-                        arr[index1] as Item,
-                        ...arr.slice(index2, index1),
-                        ...arr.slice(index1 + 1),
-                      ])
-                    }
+
+                    // when moving item up, its place shifted after the first toSpliced call, so we adjust the index
+                    const removeIndex = index1 < index2 ? index1 : index1 + 1
+
+                    set(
+                      arrAtom as WritableAtom<Item[], [Item[]], void>,
+                      arr
+                        .toSpliced(index2, 0, arr[index1] as Item)
+                        .toSpliced(removeIndex, 1)
+                    )
                   }
                   break
                 }

--- a/tests/react/vanilla-utils/splitAtom.test.tsx
+++ b/tests/react/vanilla-utils/splitAtom.test.tsx
@@ -288,7 +288,12 @@ it('moving atoms', async () => {
           <TaskItem
             key={`${anAtom}`}
             onMoveLeft={() => {
-              if (index > 0) {
+              if (index === 0) {
+                dispatch({
+                  type: 'move',
+                  atom: anAtom,
+                })
+              } else if (index > 0) {
                 dispatch({
                   type: 'move',
                   atom: anAtom,
@@ -370,6 +375,13 @@ it('moving atoms', async () => {
   await waitFor(() => {
     expect(queryByTestId('list')?.textContent).toBe(
       'help nana<>get dragon food<>get cat food<>'
+    )
+  })
+
+  fireEvent.click(getByTestId('help nana-leftbutton'))
+  await waitFor(() => {
+    expect(queryByTestId('list')?.textContent).toBe(
+      'get dragon food<>get cat food<>help nana<>'
     )
   })
 })


### PR DESCRIPTION
## Summary

A small refactor to use the new [immutable change-array-by-copy methods](https://github.com/tc39/proposal-change-array-by-copy). I believe this makes code more readable and performant, as less calls & copying is made.
The methods are available since TypeScript 5.2 and [Node 20](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#v8-113) which is stable/current since October.

I've noticed untested behavior for the `move` action, that the first item can be moved like in a carousel to the end of the list. I've updated the test to make the behavior official.

For tests to pass, I had to upgrade the node from v18, to v20. I've signaled that in the `engine` field in the `package.json`.
Lastly, I've set the `packageManager` so it can be easily installed with `corepack install`. That should simplify further contributions.

## Check List

- [x] `yarn run prettier` for formatting code and docs
