### PR TITLE
docs(effect): add async section and clean up wording

### DIFF
--- a/docs/integrations/effect.mdx
+++ b/docs/integrations/effect.mdx
@@ -64,13 +64,13 @@ After defining an effect using `atomEffect`, it can be integrated within another
 const anAtom = atom((get) => {
   // mounts the atomEffect when anAtom mounts
   get(loggingEffect)
-  // ... other logic
+  // ...
 })
 
 // mounts the atomEffect when the component mounts
 function MyComponent() {
   useAtom(subscriptionEffect)
-  ...
+  // ...
 }
 ```
 
@@ -147,7 +147,7 @@ function MyComponent() {
   ```js
   const enabledAtom = atom(false)
   const countAtom = atom(0)
-  const updateLettersAndNumbers = atom(null, (get, set) => {
+  const updateEnabledAndCount = atom(null, (get, set) => {
     set(enabledAtom, (value) => !value)
     set(countAtom, (value) => value + 1)
   })
@@ -155,7 +155,7 @@ function MyComponent() {
   const combosEffect = atomEffect((get, set) => {
     set(combos, (arr) => [...arr, [get(enabledAtom), get(countAtom)]])
   })
-  store.set(updateLettersAndNumbers)
+  store.set(updateEnabledAndCount)
   store.get(combos) // [[false, 0], [true, 1]]
   ```
 
@@ -226,6 +226,39 @@ Aside from mount events, the effect runs when any of its dependencies change val
 
   </details>
 
+- **Async:**
+  For async effects, you should use an abort controller to cancel pending fetch requests and promises.
+
+  <!-- prettier-ignore -->
+  <details style="cursor: pointer; user-select: none;">
+    <summary>Example</summary>
+
+  ```js
+  atomEffect((get, set) => {
+    const count = get(countAtom) // countAtom is an atom dependency
+    const abortController = new AbortController()
+    ;(async () => {
+      try {
+        await delay(1000)
+        abortController.signal.throwIfAborted()
+        get(dataAtom) // dataAtom is not an atom dependency
+      } catch (e) {
+        if (e instanceof AbortError) {
+          // async cleanup logic here
+        } else {
+          console.error(e)
+        }
+      }
+    })()
+    return () => {
+      // abort when countAtom changes
+      abortController.abort(new AbortError())
+    }
+  })
+  ```
+
+  </details>
+
 - **Cleanup:**
   Accessing atoms with `get` in the cleanup function does not add them to the atom's internal dependency map.
 
@@ -235,11 +268,11 @@ Aside from mount events, the effect runs when any of its dependencies change val
 
   ```js
   atomEffect((get, set) => {
-    // runs once on atom mount
+    // runs once on mount or when valueAtom changes
     // does not update when `idAtom` changes
     const unsubscribe = subscribe((value) => {
-      const id = get(idAtom)
-      set(valueAtom, { id value })
+      const value = get(valueAtom)
+      // ...
     })
     return () => {
       unsubscribe(get(idAtom))
@@ -293,7 +326,7 @@ atomEffects are more appropriate for modeling logic in atoms.
 They are scoped to the store context rather than the component.
 This guarantees that a single effect will be used regardless of how many calls they have.
 
-The same guarantee can be achieved with the useEffect hook if you ensure that the useEffect has only one actioning call.
+The same guarantee can be achieved with the useEffect hook if you ensure that the useEffect is idempotent.
 
 atomEffects are distinguished from useEffect in a few other ways. The can directly react to atom state changes, are resistent to infinite loops, and can be mounted conditionally.
 


### PR DESCRIPTION
## Summary
Update jotai-effect docs:
 - include section on async iffe
 - clean up wording, simplify examples, fix mistakes

## Check List
- [x] `yarn run prettier` for formatting code and docs
