### PR TITLE
test(splitAtom): moving first item to the end

### DIFF
--- a/tests/react/vanilla-utils/splitAtom.test.tsx
+++ b/tests/react/vanilla-utils/splitAtom.test.tsx
@@ -288,7 +288,12 @@ it('moving atoms', async () => {
           <TaskItem
             key={`${anAtom}`}
             onMoveLeft={() => {
-              if (index > 0) {
+              if (index === 0) {
+                dispatch({
+                  type: 'move',
+                  atom: anAtom,
+                })
+              } else if (index > 0) {
                 dispatch({
                   type: 'move',
                   atom: anAtom,
@@ -370,6 +375,13 @@ it('moving atoms', async () => {
   await waitFor(() => {
     expect(queryByTestId('list')?.textContent).toBe(
       'help nana<>get dragon food<>get cat food<>'
+    )
+  })
+
+  fireEvent.click(getByTestId('help nana-leftbutton'))
+  await waitFor(() => {
+    expect(queryByTestId('list')?.textContent).toBe(
+      'get dragon food<>get cat food<>help nana<>'
     )
   })
 })


### PR DESCRIPTION

## Summary
When the `before` is unspecified for the first item, it is being moved to the end of the list.

## Check List

- [x] `yarn run prettier` for formatting code and docs
