### PR TITLE
fix(utils): add init property to the return type of atomWithReset

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -1,5 +1,10 @@
 export { atom } from './vanilla/atom.ts'
-export type { Atom, WritableAtom, PrimitiveAtom } from './vanilla/atom.ts'
+export type {
+  Atom,
+  WritableAtom,
+  PrimitiveAtom,
+  WithInitialValue,
+} from './vanilla/atom.ts'
 export { createStore, getDefaultStore } from './vanilla/store.ts'
 export type {
   Getter,

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -1,10 +1,5 @@
 export { atom } from './vanilla/atom.ts'
-export type {
-  Atom,
-  WritableAtom,
-  PrimitiveAtom,
-  WithInitialValue,
-} from './vanilla/atom.ts'
+export type { Atom, WritableAtom, PrimitiveAtom } from './vanilla/atom.ts'
 export { createStore, getDefaultStore } from './vanilla/store.ts'
 export type {
   Getter,

--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -23,7 +23,7 @@ type Write<Args extends unknown[], Result> = (
   ...args: Args
 ) => Result
 
-type WithInitialValue<Value> = {
+export type WithInitialValue<Value> = {
   init: Value
 }
 

--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -23,6 +23,8 @@ type Write<Args extends unknown[], Result> = (
   ...args: Args
 ) => Result
 
+// This is an internal type and not part of public API.
+// Do not depend on it as it can change without notice.
 type WithInitialValue<Value> = {
   init: Value
 }

--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -23,7 +23,7 @@ type Write<Args extends unknown[], Result> = (
   ...args: Args
 ) => Result
 
-export type WithInitialValue<Value> = {
+type WithInitialValue<Value> = {
   init: Value
 }
 

--- a/src/vanilla/utils/atomWithReset.ts
+++ b/src/vanilla/utils/atomWithReset.ts
@@ -7,6 +7,8 @@ type SetStateActionWithReset<Value> =
   | typeof RESET
   | ((prev: Value) => Value | typeof RESET)
 
+// This is an internal type and not part of public API.
+// Do not depend on it as it can change without notice.
 type WithInitialValue<Value> = {
   init: Value
 }

--- a/src/vanilla/utils/atomWithReset.ts
+++ b/src/vanilla/utils/atomWithReset.ts
@@ -1,5 +1,5 @@
 import { atom } from '../../vanilla.ts'
-import type { WritableAtom } from '../../vanilla.ts'
+import type { WithInitialValue, WritableAtom } from '../../vanilla.ts'
 import { RESET } from './constants.ts'
 
 type SetStateActionWithReset<Value> =
@@ -20,5 +20,5 @@ export function atomWithReset<Value>(initialValue: Value) {
       set(anAtom, nextValue === RESET ? initialValue : nextValue)
     },
   )
-  return anAtom as WritableAtom<Value, [Update], void>
+  return anAtom as WritableAtom<Value, [Update], void> & WithInitialValue<Value>
 }

--- a/src/vanilla/utils/atomWithReset.ts
+++ b/src/vanilla/utils/atomWithReset.ts
@@ -1,11 +1,15 @@
 import { atom } from '../../vanilla.ts'
-import type { WithInitialValue, WritableAtom } from '../../vanilla.ts'
+import type { WritableAtom } from '../../vanilla.ts'
 import { RESET } from './constants.ts'
 
 type SetStateActionWithReset<Value> =
   | Value
   | typeof RESET
   | ((prev: Value) => Value | typeof RESET)
+
+type WithInitialValue<Value> = {
+  init: Value
+}
 
 export function atomWithReset<Value>(initialValue: Value) {
   type Update = SetStateActionWithReset<Value>


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #2303 

## Summary

Changed return type of `atomWithReset()`,  
``` typescript
return anAtom as WritableAtom<Value, [Update], void>
```
to
``` typescript
return anAtom as WritableAtom<Value, [Update], void> & WithInitialValue<Value>
```

## Check List

- [x] `yarn run prettier` for formatting code and docs
