### PR TITLE
fix(vanilla): should mount once with atom creator atom

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -652,18 +652,17 @@ export const createStore = () => {
     prevDependencies?: Dependencies,
   ): void => {
     const depSet = new Set(atomState.d.keys())
+    const maybeUnmountAtomSet = new Set<AnyAtom>()
     prevDependencies?.forEach((_, a) => {
       if (depSet.has(a)) {
         // not changed
         depSet.delete(a)
         return
       }
+      maybeUnmountAtomSet.add(a);
       const mounted = mountedMap.get(a)
       if (mounted) {
         mounted.t.delete(atom) // delete from dependents
-        if (canUnmountAtom(a, mounted)) {
-          unmountAtom(a)
-        }
       }
     })
     depSet.forEach((a) => {
@@ -675,6 +674,12 @@ export const createStore = () => {
         // Note: we should revisit this when you find other issues
         // https://github.com/pmndrs/jotai/issues/942
         mountAtom(a, atom)
+      }
+    })
+    maybeUnmountAtomSet.forEach((a) => {
+      const mounted = mountedMap.get(a);
+      if (mounted && canUnmountAtom(a, mounted)) {
+        unmountAtom(a);
       }
     })
   }

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -659,7 +659,7 @@ export const createStore = () => {
         depSet.delete(a)
         return
       }
-      maybeUnmountAtomSet.add(a);
+      maybeUnmountAtomSet.add(a)
       const mounted = mountedMap.get(a)
       if (mounted) {
         mounted.t.delete(atom) // delete from dependents
@@ -677,9 +677,9 @@ export const createStore = () => {
       }
     })
     maybeUnmountAtomSet.forEach((a) => {
-      const mounted = mountedMap.get(a);
+      const mounted = mountedMap.get(a)
       if (mounted && canUnmountAtom(a, mounted)) {
-        unmountAtom(a);
+        unmountAtom(a)
       }
     })
   }

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -488,3 +488,17 @@ it('should not recompute a derived atom value if unchanged (#2168)', async () =>
   expect(store.get(derived2Atom)).toBe(0)
   expect(derive2Fn).toHaveBeenCalledTimes(1)
 })
+
+it('should mount once with atom creator atom (#2314)', async () => {
+  const countAtom = atom(1)
+  countAtom.onMount = vi.fn((setAtom) => {
+    setAtom(2)
+  })
+  const atomCreatorAtom = atom((get) => {
+    const derivedAtom = atom((get) => get(countAtom))
+    get(derivedAtom)
+  })
+  const store = createStore()
+  store.sub(atomCreatorAtom, () => {})
+  expect(countAtom.onMount).toHaveBeenCalledTimes(1)
+})

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -491,7 +491,7 @@ it('should not recompute a derived atom value if unchanged (#2168)', async () =>
 
 it('should mount once with atom creator atom (#2314)', async () => {
   const countAtom = atom(1)
-  countAtom.onMount = vi.fn((setAtom) => {
+  countAtom.onMount = vi.fn((setAtom: (v: number) => void) => {
     setAtom(2)
   })
   const atomCreatorAtom = atom((get) => {


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #2314

## Summary
I'm sorry about the previous PR.
Changed evaluation of canUnmountAtom in mountDependencies function after mountAtom.

## Check List

- [ ] `yarn run prettier` for formatting code and docs
