### PR TITLE
chore(docs): show only npm install

### DIFF
--- a/docs/extensions/cache.mdx
+++ b/docs/extensions/cache.mdx
@@ -18,7 +18,7 @@ a third-party library to help such use cases.
 ### Install
 
 ```
-yarn add jotai-cache
+npm i jotai-cache
 ```
 
 ## atomWithCache

--- a/docs/extensions/effect.mdx
+++ b/docs/extensions/effect.mdx
@@ -10,7 +10,7 @@ keywords: effect, atom effect, side effect, side-effect, sideeffect
 ## install
 
 ```
-yarn add jotai-effect
+npm i jotai-effect
 ```
 
 ## atomEffect

--- a/docs/extensions/immer.mdx
+++ b/docs/extensions/immer.mdx
@@ -7,12 +7,10 @@ keywords: immer
 
 ### Install
 
-You have to install `immer` and `jotai-immer` to use this feature.
+You have to install `immer` and `jotai-immer` to use this feature, with your preferred package manager.
 
 ```
-npm install immer jotai-immer
-# or
-yarn add immer jotai-immer
+npm i immer jotai-immer
 ```
 
 ## atomWithImmer
@@ -108,6 +106,8 @@ const Controls = () => {
 ```
 
 It would be better if you don't use `withImmer` and `atomWithImmer` with `useImmerAtom` because they provide the immer-like `writeFunction` and we don't need to create a new one.
+
+You can use `useSetImmerAtom` if you need only the setter part of `useImmerAtom`.
 
 ### Examples
 

--- a/docs/extensions/immer.mdx
+++ b/docs/extensions/immer.mdx
@@ -7,7 +7,7 @@ keywords: immer
 
 ### Install
 
-You have to install `immer` and `jotai-immer` to use this feature, with your preferred package manager.
+You have to install `immer` and `jotai-immer` to use this feature.
 
 ```
 npm i immer jotai-immer

--- a/docs/extensions/location.mdx
+++ b/docs/extensions/location.mdx
@@ -9,7 +9,7 @@ To deal with `window.location`, we have some functions to create atoms.
 
 ### Install
 
-You have to install `jotai-location` to use this feature, with your preferred package manager.
+You have to install `jotai-location` to use this feature.
 
 ```
 npm i jotai-location

--- a/docs/extensions/location.mdx
+++ b/docs/extensions/location.mdx
@@ -9,10 +9,10 @@ To deal with `window.location`, we have some functions to create atoms.
 
 ### Install
 
-You have to install `jotai-location` to use this feature.
+You have to install `jotai-location` to use this feature, with your preferred package manager.
 
 ```
-yarn add jotai-location
+npm i jotai-location
 ```
 
 ## atomWithLocation

--- a/docs/extensions/optics.mdx
+++ b/docs/extensions/optics.mdx
@@ -7,7 +7,7 @@ keywords: optics
 
 ### Install
 
-You have to install `optics-ts` and `jotai-optics` to use this feature, with your preferred package manager.
+You have to install `optics-ts` and `jotai-optics` to use this feature.
 
 ```
 npm i optics-ts jotai-optics

--- a/docs/extensions/optics.mdx
+++ b/docs/extensions/optics.mdx
@@ -7,12 +7,10 @@ keywords: optics
 
 ### Install
 
-You have to install `optics-ts` and `jotai-optics` to use this feature.
+You have to install `optics-ts` and `jotai-optics` to use this feature, with your preferred package manager.
 
 ```
-npm install optics-ts jotai-optics
-# or
-yarn add optics-ts jotai-optics
+npm i optics-ts jotai-optics
 ```
 
 ## focusAtom

--- a/docs/extensions/query.mdx
+++ b/docs/extensions/query.mdx
@@ -19,7 +19,7 @@ jotai-tanstack-query currently supports TanStack Query v5.
 
 ### Install
 
-In addition to `jotai`, you have to install `jotai-tanstack-query`, `@tanstack/query-core` and `wonka` to use the extension, with your preferred package manager.
+In addition to `jotai`, you have to install `jotai-tanstack-query`, `@tanstack/query-core` and `wonka` to use the extension.
 
 ```bash
 npm i jotai-tanstack-query @tanstack/query-core wonka

--- a/docs/extensions/query.mdx
+++ b/docs/extensions/query.mdx
@@ -19,10 +19,10 @@ jotai-tanstack-query currently supports TanStack Query v5.
 
 ### Install
 
-In addition to `jotai`, you have to install `jotai-tanstack-query`, `@tanstack/query-core` and `wonka` to use the extension.
+In addition to `jotai`, you have to install `jotai-tanstack-query`, `@tanstack/query-core` and `wonka` to use the extension, with your preferred package manager.
 
 ```bash
-yarn add jotai-tanstack-query @tanstack/query-core wonka
+npm i jotai-tanstack-query @tanstack/query-core wonka
 ```
 
 ### Incremental Adoption
@@ -339,11 +339,7 @@ See [a working example](https://codesandbox.io/s/4gfp6z) to learn more.
 In order to use the Devtools, you need to install it additionally.
 
 ```bash
-$ npm i @tanstack/react-query-devtools
-# or
-$ pnpm add @tanstack/react-query-devtools
-# or
-$ yarn add @tanstack/react-query-devtools
+npm i @tanstack/react-query-devtools
 ```
 
 All you have to do is put the `<ReactQueryDevtools />` within `<QueryClientProvider />`.

--- a/docs/extensions/redux.mdx
+++ b/docs/extensions/redux.mdx
@@ -14,7 +14,7 @@ and sync with atoms in Jotai.
 
 ### Install
 
-You have to install `redux` and `jotai-redux` to use this feature, with your preferred package manager.
+You have to install `redux` and `jotai-redux` to use this feature.
 
 ```
 npm i redux jotai-redux

--- a/docs/extensions/redux.mdx
+++ b/docs/extensions/redux.mdx
@@ -14,12 +14,10 @@ and sync with atoms in Jotai.
 
 ### Install
 
-You have to install `redux` and `jotai-redux` to use this feature.
+You have to install `redux` and `jotai-redux` to use this feature, with your preferred package manager.
 
 ```
-npm install redux jotai-redux
-# or
-yarn add redux jotai-redux
+npm i redux jotai-redux
 ```
 
 ## atomWithStore

--- a/docs/extensions/relay.mdx
+++ b/docs/extensions/relay.mdx
@@ -10,10 +10,10 @@ You can use Jotai with [Relay](https://relay.dev).
 
 ### Install
 
-You have to install `jotai-relay` and `relay-runtime`.
+You have to install `jotai-relay` and `relay-runtime`, with your preferred package manager.
 
 ```
-yarn add jotai-relay relay-runtime
+npm i jotai-relay relay-runtime
 ```
 
 ### Usage

--- a/docs/extensions/relay.mdx
+++ b/docs/extensions/relay.mdx
@@ -10,7 +10,7 @@ You can use Jotai with [Relay](https://relay.dev).
 
 ### Install
 
-You have to install `jotai-relay` and `relay-runtime`, with your preferred package manager.
+You have to install `jotai-relay` and `relay-runtime`.
 
 ```
 npm i jotai-relay relay-runtime

--- a/docs/extensions/scope.mdx
+++ b/docs/extensions/scope.mdx
@@ -22,7 +22,7 @@ and the use of those atoms is scoped within the subtree.
 ### Install
 
 ```
-yarn add jotai-scope
+npm i jotai-scope
 ```
 
 ### Counter Example
@@ -105,7 +105,7 @@ See [Motivation](https://github.com/saasquatch/bunshi/tree/v1.1.1#motivation) fo
 ### Install
 
 ```
-yarn add bunshi
+npm i bunshi
 ```
 
 ### Counter Example

--- a/docs/extensions/trpc.mdx
+++ b/docs/extensions/trpc.mdx
@@ -9,7 +9,7 @@ You can use Jotai with [tRPC](https://trpc.io).
 
 ### Install
 
-You have to install `jotai-trpc`, `@trpc/client` and `@trpc/server` to use the extension, with your preferred package manager.
+You have to install `jotai-trpc`, `@trpc/client` and `@trpc/server` to use the extension.
 
 ```
 npm i jotai-trpc @trpc/client @trpc/server

--- a/docs/extensions/trpc.mdx
+++ b/docs/extensions/trpc.mdx
@@ -9,10 +9,10 @@ You can use Jotai with [tRPC](https://trpc.io).
 
 ### Install
 
-You have to install `jotai-trpc`, `@trpc/client` and `@trpc/server` to use the extension.
+You have to install `jotai-trpc`, `@trpc/client` and `@trpc/server` to use the extension, with your preferred package manager.
 
 ```
-yarn add jotai-trpc @trpc/client @trpc/server
+npm i jotai-trpc @trpc/client @trpc/server
 ```
 
 ### Usage

--- a/docs/extensions/urql.mdx
+++ b/docs/extensions/urql.mdx
@@ -15,10 +15,10 @@ From the [Overview docs](https://formidable.com/open-source/urql/docs/):
 
 ### Install
 
-You have to install `jotai-urql`, `@urql/core` and `wonka` to use the extension.
+You have to install `jotai-urql`, `@urql/core` and `wonka` to use the extension, with your preferred package manager.
 
 ```
-yarn add jotai-urql @urql/core wonka
+npm i jotai-urql @urql/core wonka
 ```
 
 ### Exported functions

--- a/docs/extensions/urql.mdx
+++ b/docs/extensions/urql.mdx
@@ -15,7 +15,7 @@ From the [Overview docs](https://formidable.com/open-source/urql/docs/):
 
 ### Install
 
-You have to install `jotai-urql`, `@urql/core` and `wonka` to use the extension, with your preferred package manager.
+You have to install `jotai-urql`, `@urql/core` and `wonka` to use the extension.
 
 ```
 npm i jotai-urql @urql/core wonka

--- a/docs/extensions/valtio.mdx
+++ b/docs/extensions/valtio.mdx
@@ -16,7 +16,7 @@ This only uses the vanilla api of valtio.
 
 ### Install
 
-You have to install `valtio` and `jotai-valtio` to use this feature, with your preferred package manager.
+You have to install `valtio` and `jotai-valtio` to use this feature.
 
 ```
 npm i valtio jotai-valtio

--- a/docs/extensions/valtio.mdx
+++ b/docs/extensions/valtio.mdx
@@ -16,12 +16,10 @@ This only uses the vanilla api of valtio.
 
 ### Install
 
-You have to install `valtio` and `jotai-valtio` to use this feature.
+You have to install `valtio` and `jotai-valtio` to use this feature, with your preferred package manager.
 
 ```
-npm install valtio jotai-valtio
-# or
-yarn add valtio jotai-valtio
+npm i valtio jotai-valtio
 ```
 
 ## atomWithProxy

--- a/docs/extensions/xstate.mdx
+++ b/docs/extensions/xstate.mdx
@@ -12,7 +12,7 @@ a better and safer abstraction for state management.
 
 ### Install
 
-You have to install `xstate` and `jotai-xstate` to use this feature, with your preferred package manager.
+You have to install `xstate` and `jotai-xstate` to use this feature.
 
 ```
 npm i xstate jotai-xstate

--- a/docs/extensions/xstate.mdx
+++ b/docs/extensions/xstate.mdx
@@ -12,12 +12,10 @@ a better and safer abstraction for state management.
 
 ### Install
 
-You have to install `xstate` and `jotai-xstate` to use this feature.
+You have to install `xstate` and `jotai-xstate` to use this feature, with your preferred package manager.
 
 ```
-npm install xstate jotai-xstate
-# or
-yarn add xstate jotai-xstate
+npm i xstate jotai-xstate
 ```
 
 ## atomWithMachine

--- a/docs/extensions/zustand.mdx
+++ b/docs/extensions/zustand.mdx
@@ -16,7 +16,7 @@ This only uses the vanilla api of zustand.
 
 ### Install
 
-You have to install `zustand` and `jotai-zustand` to use this feature, with your preferred package manager.
+You have to install `zustand` and `jotai-zustand` to use this feature.
 
 ```
 npm i zustand jotai-zustand

--- a/docs/extensions/zustand.mdx
+++ b/docs/extensions/zustand.mdx
@@ -16,12 +16,10 @@ This only uses the vanilla api of zustand.
 
 ### Install
 
-You have to install `zustand` and `jotai-zustand` to use this feature.
+You have to install `zustand` and `jotai-zustand` to use this feature, with your preferred package manager.
 
 ```
-npm install zustand jotai-zustand
-# or
-yarn add zustand jotai-zustand
+npm i zustand jotai-zustand
 ```
 
 ## atomWithStore

--- a/docs/guides/nextjs.mdx
+++ b/docs/guides/nextjs.mdx
@@ -90,8 +90,6 @@ Jotai provides SWC plugins for better DX while developing with Next.js. [Find mo
 
 ```bash
 npx create-next-app --example with-jotai with-jotai-app
-# or
-yarn create next-app --example with-jotai with-jotai-app
 ```
 
 Here's a [link](https://github.com/vercel/next.js/tree/canary/examples/with-jotai).

--- a/docs/tools/devtools.mdx
+++ b/docs/tools/devtools.mdx
@@ -7,7 +7,7 @@ keywords: devtools,debug,snapshot
 
 ### Install
 
-Install `jotai-devtools` to your project to get started with your preferred package manager.
+Install `jotai-devtools` to your project to get started.
 
 ```sh
 npm i jotai-devtools @emotion/react

--- a/docs/tools/devtools.mdx
+++ b/docs/tools/devtools.mdx
@@ -7,14 +7,10 @@ keywords: devtools,debug,snapshot
 
 ### Install
 
-Install `jotai-devtools` to your project to get started
+Install `jotai-devtools` to your project to get started with your preferred package manager.
 
 ```sh
-# yarn
-yarn add jotai-devtools @emotion/react
-
-# npm
-npm install jotai-devtools @emotion/react --save
+npm i jotai-devtools @emotion/react
 ```
 
 ### Notes


### PR DESCRIPTION
It's 2024, and we can't list all npm alternatives. Let's simplify.