### PR TITLE
feat(docs): add devtools setup example for react+vite projects

### DIFF
--- a/docs/tools/devtools.mdx
+++ b/docs/tools/devtools.mdx
@@ -59,9 +59,7 @@ export default defineConfig({
   plugins: [
     react({
       babel: {
-        presets: [
-          'jotai/babel/preset',
-        ],
+        presets: ['jotai/babel/preset'],
       },
     }),
   ],

--- a/docs/tools/devtools.mdx
+++ b/docs/tools/devtools.mdx
@@ -41,7 +41,7 @@ Enhance your development experience with the UI based Jotai DevTool.
 
 Use Jotai babel plugins for optimal debugging experience. Find the complete guide on the [babel](../tools/babel) page and/or [swc](../tools/swc) page.
 
-Eg.
+Example:
 
 ```ts
 {
@@ -52,6 +52,23 @@ Eg.
     "jotai/babel/plugin-debug-label"
   ]
 }
+```
+
+Example for Vite + React project:
+
+
+```ts
+// vite.config.ts
+
+export default defineConfig({
+  plugins: [
+    react({
+      babel: {
+        plugins: ["jotai/babel/plugin-debug-label", "jotai/babel/plugin-react-refresh"],
+      },
+    }),
+  ],
+});
 ```
 
 ### Next JS setup

--- a/docs/tools/devtools.mdx
+++ b/docs/tools/devtools.mdx
@@ -52,7 +52,6 @@ Example:
 
 Example for Vite + React project:
 
-
 ```ts
 // vite.config.ts
 
@@ -60,11 +59,14 @@ export default defineConfig({
   plugins: [
     react({
       babel: {
-        plugins: ["jotai/babel/plugin-debug-label", "jotai/babel/plugin-react-refresh"],
+        plugins: [
+          'jotai/babel/plugin-debug-label',
+          'jotai/babel/plugin-react-refresh',
+        ],
       },
     }),
   ],
-});
+})
 ```
 
 ### Next JS setup

--- a/docs/tools/devtools.mdx
+++ b/docs/tools/devtools.mdx
@@ -41,11 +41,8 @@ Example:
 
 ```ts
 {
-  "plugins": [
-    // Enables hot reload for atoms
-    "jotai/babel/plugin-react-refresh",
-    // Automatically adds debug labels to the atoms
-    "jotai/babel/plugin-debug-label"
+  "presets": [
+    'jotai/babel/preset'
   ]
 }
 ```
@@ -59,7 +56,7 @@ export default defineConfig({
   plugins: [
     react({
       babel: {
-        plugins: [
+        presets: [
           'jotai/babel/preset',
         ],
       },

--- a/docs/tools/devtools.mdx
+++ b/docs/tools/devtools.mdx
@@ -60,8 +60,7 @@ export default defineConfig({
     react({
       babel: {
         plugins: [
-          'jotai/babel/plugin-debug-label',
-          'jotai/babel/plugin-react-refresh',
+          'jotai/babel/preset',
         ],
       },
     }),

--- a/docs/tools/devtools.mdx
+++ b/docs/tools/devtools.mdx
@@ -42,6 +42,9 @@ Example:
 ```ts
 {
   "presets": [
+    // The preset includes two plugins:
+    // - jotai/babel/plugin-react-refresh to enable hot reaload for atoms
+    // - jotai/babel/plugin-debug-label to automatically adds debug labels to atoms
     'jotai/babel/preset'
   ]
 }


### PR DESCRIPTION
## Summary

Essentially adds another example for the setup of Jotai Devtools in a React project (with Vite). More convenient than searching for it, like in my case.