### PR TITLE
readAtomState is called many times redundantly before atoms are mounted

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -592,8 +592,8 @@ export const createStore = (opts?: { unmountedCacheEnabled: boolean }) => {
         l({ type: 'write', flushed: flushed as Set<AnyAtom> }),
       )
     }
-    if (unmountedCacheEnabled && !mountedAtoms.has(atom)) {
-      // A value was manually changed in the store, invalidate all unmounted atoms
+    if (unmountedCacheEnabled) {
+      // A value was changed in the store, invalidate all unmounted atoms
       unmountedAtomReadCache = new WeakSet<AnyAtom>()
     }
     return result

--- a/tests/react/optimization.test.tsx
+++ b/tests/react/optimization.test.tsx
@@ -272,7 +272,7 @@ it('no extra rerenders after commit with derived atoms (#1213)', async () => {
   expect(renderCount1).toBe(renderCount1AfterCommit)
 })
 
-const readAtomStateTestCase = (markPure: boolean) => {
+const readAtomStateTestCase = (enableOptimization: boolean) => {
   const queryParams = atom({
     key: '123',
     query: 'foobar',
@@ -313,10 +313,7 @@ const readAtomStateTestCase = (markPure: boolean) => {
     return get(queryAtom).data.cart
   })
 
-  const store = createStore()
-  if (markPure) {
-    store.dev_mark_atom_immutable_before_mount?.(queryAtom)
-  }
+  const store = createStore({ unmountedCacheEnabled: enableOptimization })
   const MyPage = () => {
     useAtom(alertAtom)
     useAtom(contentAtom)
@@ -332,9 +329,9 @@ const readAtomStateTestCase = (markPure: boolean) => {
   store.dev_print_call_counts?.()
   store.dev_clear_call_counts?.()
 }
-it('Avoid redundant readAtomState before mount', () => {
-  console.debug('Test case without immutable flag')
+it('Avoid redundant readAtomState while unmount', () => {
+  console.debug('Test case without unmounted cache')
   readAtomStateTestCase(false)
-  console.debug('Test case with immutable flag')
+  console.debug('Test case with unmounted cache')
   readAtomStateTestCase(true)
 })

--- a/tests/react/optimization.test.tsx
+++ b/tests/react/optimization.test.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { expect, it } from 'vitest'
 import { Provider, useAtom } from 'jotai/react'
-import { atom, createStore, getDefaultStore } from 'jotai/vanilla'
+import { atom, createStore } from 'jotai/vanilla'
 
 it('only relevant render function called (#156)', async () => {
   const count1Atom = atom(0)
@@ -334,4 +334,15 @@ it('Avoid redundant readAtomState while unmount', () => {
   readAtomStateTestCase(false)
   console.debug('Test case with unmounted cache')
   readAtomStateTestCase(true)
+})
+
+it('store.set clears unmounted cache', () => {
+  const baseAtom = atom(0)
+  const derivedAtom = atom((get) => get(baseAtom) * 2)
+
+  const store = createStore({ unmountedCacheEnabled: true })
+  store.get(derivedAtom)
+  expect(store.get(derivedAtom)).toEqual(0)
+  store.set(baseAtom, 10)
+  expect(store.get(derivedAtom)).toEqual(20)
 })


### PR DESCRIPTION
## Related Issues or Discussions

https://github.com/pmndrs/jotai/discussions/2334

## Summary

This PR is here to showcase the issue with a potential fix, not to be merged.

```
Test case without unmounted cache
Jotai store call counts
-----------------------
| readAtomState | 45
Test case with unmounted cache
Jotai store call counts
-----------------------
| readAtomState | 24
```


## Check List

- [ ] `yarn run prettier` for formatting code and docs
