### PR TITLE
feat(react): add new hook `useAtomValueMemo`

### DIFF
--- a/src/react/utils/useAtomMemo.ts
+++ b/src/react/utils/useAtomMemo.ts
@@ -1,0 +1,64 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Atom } from '../../vanilla.ts'
+import { useStore } from '../Provider.ts'
+
+type Store = ReturnType<typeof useStore>
+
+type Options = {
+  store?: Store
+  delay?: number
+}
+
+export function useAtomValueMemo<Value extends object>(
+  atom: Atom<Value>,
+  options?: Options,
+) {
+  const store = useStore(options)
+  const trackMapRef = useRef<Map<string, Value[keyof Value]> | null>(null)
+  if (!trackMapRef.current) {
+    trackMapRef.current = new Map()
+  }
+  const [, rerender] = useState<number>(0)
+  const delay = options?.delay
+  useEffect(() => {
+    const unsub = store.sub(atom, () => {
+      const trackMap = trackMapRef.current!
+      let changed = false
+      const currentValue = store.get(atom)
+      for (const key of trackMap.keys()) {
+        if (currentValue[key as keyof Value] !== trackMap.get(key)) {
+          changed = true
+          break
+        }
+      }
+      trackMap.clear()
+      if (!changed) {
+        return
+      }
+      if (typeof delay === 'number') {
+        setTimeout(rerender)
+        return
+      }
+      rerender((c) => c + 1)
+    })
+    rerender((c) => c + 1)
+    return unsub
+  }, [store, atom, delay])
+
+  return useMemo(() => {
+    return new Proxy<Value>({} as Value, {
+      get: (_, key: string) => {
+        const value = store.get(atom)
+        if (!(key in value)) {
+          throw new Error(`No key "${key}" in atom`)
+        }
+        const trackSet = trackMapRef.current!
+        const returnValue = value[key as keyof Value]
+        if (!trackSet.has(key)) {
+          trackSet.set(key, returnValue)
+        }
+        return returnValue satisfies Value[keyof Value]
+      },
+    })
+  }, [atom, store])
+}

--- a/tests/react/utils/useAtomValueMemo.test.tsx
+++ b/tests/react/utils/useAtomValueMemo.test.tsx
@@ -1,0 +1,89 @@
+import { StrictMode } from 'react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { expect, it } from 'vitest'
+import { useAtom } from 'jotai/react'
+import { useAtomValueMemo } from 'jotai/react/utils/useAtomMemo'
+import { atom } from 'jotai/vanilla'
+
+it('useAtomValueMemo with object', async () => {
+  const countAtom = atom({
+    count: 0,
+    unused: 0,
+  })
+
+  const Counter = () => {
+    const [{ count }, setCount] = useAtom(countAtom)
+    return (
+      <>
+        <div>atom count: {count}</div>
+        <button
+          onClick={() =>
+            setCount((c) => ({
+              ...c,
+              count: c.count + 1,
+            }))
+          }
+        >
+          dispatch
+        </button>
+      </>
+    )
+  }
+
+  let unusedRenderCount = 0
+  let usedRenderCount = 0
+  const Unused = () => {
+    unusedRenderCount += 1
+    const { unused } = useAtomValueMemo(countAtom)
+    return (
+      <>
+        <div>unused count: {unused}</div>
+      </>
+    )
+  }
+
+  const Used = () => {
+    usedRenderCount += 1
+    const { count } = useAtomValueMemo(countAtom)
+    return (
+      <>
+        <div>used count: {count}</div>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <StrictMode>
+      <Counter />
+      <Unused />
+      <Used />
+    </StrictMode>,
+  )
+
+  await findByText('atom count: 0')
+  fireEvent.click(getByText('dispatch'))
+  await waitFor(() => {
+    getByText('atom count: 1')
+  })
+  await waitFor(() => {
+    getByText('unused count: 0')
+  })
+  await waitFor(() => {
+    getByText('used count: 1')
+  })
+  fireEvent.click(getByText('dispatch'))
+  fireEvent.click(getByText('dispatch'))
+  fireEvent.click(getByText('dispatch'))
+  await waitFor(() => {
+    getByText('atom count: 4')
+  })
+  await waitFor(() => {
+    getByText('unused count: 0')
+  })
+  await waitFor(() => {
+    getByText('used count: 4')
+  })
+  expect(unusedRenderCount).toBeLessThan(usedRenderCount)
+  // on StrictMode, callback inside `setState` is called twice
+  expect(usedRenderCount - unusedRenderCount).toBe(4 * 2)
+})


### PR DESCRIPTION
## Summary

Since some field of an object is never used but will trigger an update. This new hook will improve the performance of rendering the huge object atom.

Only jotai core library can archive this magic because it needs internal `useStore` hook

## Check List

- [x] `yarn run prettier` for formatting code and docs
