### PR TITLE
fix: atoms should not remount on recalculations (with async dependencies)

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -195,8 +195,11 @@ export const createStore = () => {
     atom: Atom<Value>,
     nextAtomState: AtomState<Value>,
     nextDependencies: NextDependencies,
+    keepPreviousDependencies?: boolean,
   ): void => {
-    const dependencies: Dependencies = new Map()
+    const dependencies: Dependencies = new Map(
+      keepPreviousDependencies ? nextAtomState.d : null,
+    )
     let changed = false
     nextDependencies.forEach((aState, a) => {
       if (!aState && a === atom) {
@@ -220,6 +223,7 @@ export const createStore = () => {
     atom: Atom<Value>,
     value: Value,
     nextDependencies?: NextDependencies,
+    keepPreviousDependencies?: boolean,
   ): AtomState<Value> => {
     const prevAtomState = getAtomState(atom)
     const nextAtomState: AtomState<Value> = {
@@ -227,7 +231,12 @@ export const createStore = () => {
       v: value,
     }
     if (nextDependencies) {
-      updateDependencies(atom, nextAtomState, nextDependencies)
+      updateDependencies(
+        atom,
+        nextAtomState,
+        nextDependencies,
+        keepPreviousDependencies,
+      )
     }
     if (
       isEqualAtomValue(prevAtomState, nextAtomState) &&
@@ -320,7 +329,7 @@ export const createStore = () => {
         }
         abortPromise?.()
       })
-      return setAtomValue(atom, promise as Value, nextDependencies)
+      return setAtomValue(atom, promise as Value, nextDependencies, true)
     }
     return setAtomValue(atom, valueOrPromise, nextDependencies)
   }

--- a/tests/react/async.test.tsx
+++ b/tests/react/async.test.tsx
@@ -70,6 +70,8 @@ it('does not show async stale result', async () => {
   await findByText('loading')
   resolve1()
   resolve2()
+  await Promise.resolve()
+  resolve2()
   await waitFor(() => {
     getByText('count: 2')
     getByText('delayedCount: 2')


### PR DESCRIPTION
## Related Issues or Discussions
https://github.com/pmndrs/jotai/issues/2348

## Summary
Atoms having an onMount function will remount on another atom recalculation.

Please see the following example below:
countAtom will remount when anotherAtom is incremented.
```ts
const countAtom = atom(0)
countAtom.onMount = () => {}
const anotherAtom = atom(0)
  const derivedAtom = atom((get) => {
    void get(countAtom)
  })
const effectAtom = atom((get) => {
  return Promise.resolve().then(() => {
    get(derivedAtom)
    get(anotherAtom)
  })
})
```

Expected behavior is that countAtom should not remount when anotherAtom increments.


## Check List

- [o] `yarn run prettier` for formatting code and docs
