### PR TITLE
feat(vanilla): Add a hack for jotai-scope

### DIFF
--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -103,11 +103,7 @@ export function atom<Value, Args extends unknown[], Result>(
   } else {
     config.init = read
     config.read = (get) => get(config)
-    config.write = ((
-      get: Getter,
-      set: Setter,
-      arg: SetStateAction<Value>,
-    ) => {
+    config.write = ((get: Getter, set: Setter, arg: SetStateAction<Value>) => {
       return set(
         config as unknown as PrimitiveAtom<Value>,
         typeof arg === 'function'

--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -97,22 +97,19 @@ export function atom<Value, Args extends unknown[], Result>(
     config.read = read as Read<Value, SetAtom<Args, Result>>
   } else {
     config.init = read
-    config.read = function (get) {
-      return get(this)
-    }
-    config.write = function (
-      this: PrimitiveAtom<Value>,
+    config.read = (get) => get(config)
+    config.write = ((
       get: Getter,
       set: Setter,
       arg: SetStateAction<Value>,
-    ) {
+    ) => {
       return set(
-        this,
+        config as unknown as PrimitiveAtom<Value>,
         typeof arg === 'function'
-          ? (arg as (prev: Value) => Value)(get(this))
+          ? (arg as (prev: Value) => Value)(get(config))
           : arg,
       )
-    } as unknown as Write<Args, Result>
+    }) as unknown as Write<Args, Result>
   }
   if (write) {
     config.write = write

--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -46,6 +46,11 @@ export interface Atom<Value> {
    * @private
    */
   debugPrivate?: boolean
+  /**
+   * @internal
+   * Original atom of a scoped atom. For package `jotai-scope` ONLY.
+   */
+  scopedOriginal?: Atom<Value>
 }
 
 export interface WritableAtom<Value, Args extends unknown[], Result>

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -102,6 +102,14 @@ const returnAtomValue = <Value>(atomState: AtomState<Value>): Value => {
   return atomState.v
 }
 
+/**
+ * @returns Original atom if anAtom is a scoped atom in `jotai-scope`. Otherwise it
+ * returns anAtom itself.
+ */
+const getScopedOriginal = (anAtom: AnyAtom): AnyAtom => {
+  return anAtom.scopedOriginal ?? anAtom;
+}
+
 type Listeners = Set<() => void>
 type Dependents = Set<AnyAtom>
 
@@ -524,7 +532,7 @@ export const createStore = () => {
       ...args: As
     ) => {
       let r: R | undefined
-      if ((a as AnyWritableAtom) === atom) {
+      if (getScopedOriginal(a) === getScopedOriginal(atom)) {
         if (!hasInitialValue(a)) {
           // NOTE technically possible but restricted as it may cause bugs
           throw new Error('atom not writable')

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -107,7 +107,7 @@ const returnAtomValue = <Value>(atomState: AtomState<Value>): Value => {
  * returns anAtom itself.
  */
 const getScopedOriginal = (anAtom: AnyAtom): AnyAtom => {
-  return anAtom.scopedOriginal ?? anAtom;
+  return anAtom.scopedOriginal ?? anAtom
 }
 
 type Listeners = Set<() => void>

--- a/src/vanilla/utils/freezeAtom.ts
+++ b/src/vanilla/utils/freezeAtom.ts
@@ -34,9 +34,7 @@ export function freezeAtomCreator<
   return ((...params: any[]) => {
     const anAtom = createAtom(...params)
     const origRead = anAtom.read
-    anAtom.read = function (get, options) {
-      return deepFreeze(origRead.call(this, get, options))
-    }
+    anAtom.read = (get, options) => deepFreeze(origRead(get, options))
     return anAtom
   }) as CreateAtom
 }

--- a/src/vanilla/utils/unwrap.ts
+++ b/src/vanilla/utils/unwrap.ts
@@ -101,8 +101,7 @@ export function unwrap<Value, Args extends unknown[], Result, PendingValue>(
           }
           return state.v
         },
-        (_get, set, ...args) =>
-          set(anAtom as WritableAtom<Value, unknown[], unknown>, ...args),
+        (anAtom as WritableAtom<Value, unknown[], unknown>).write
       )
     },
     anAtom,

--- a/src/vanilla/utils/unwrap.ts
+++ b/src/vanilla/utils/unwrap.ts
@@ -101,7 +101,7 @@ export function unwrap<Value, Args extends unknown[], Result, PendingValue>(
           }
           return state.v
         },
-        (anAtom as WritableAtom<Value, unknown[], unknown>).write
+        (anAtom as WritableAtom<Value, unknown[], unknown>).write,
       )
     },
     anAtom,


### PR DESCRIPTION
Reverts #2186
Add a property `scopedOriginal` and add a intercepted function to ensure copy of scoped atoms can directly set itself without calling its write function again. Now all the write function in jotai-scope get executed **exactly once**.
Related to https://github.com/jotaijs/jotai-scope/pull/20