### PR TITLE
fix(utils/atomWithStorage): defaultStorage with disabled local storage crashes on mount

### DIFF
--- a/src/vanilla/utils/atomWithStorage.ts
+++ b/src/vanilla/utils/atomWithStorage.ts
@@ -105,7 +105,7 @@ export function createJSONStorage<Value>(
     } catch (e) {
       if (import.meta.env?.MODE !== 'production') {
         if (typeof window !== 'undefined') {
-          console.warn(e);
+          console.warn(e)
         }
       }
       return undefined

--- a/src/vanilla/utils/atomWithStorage.ts
+++ b/src/vanilla/utils/atomWithStorage.ts
@@ -99,8 +99,18 @@ export function createJSONStorage<Value>(
   getStringStorage: () =>
     | AsyncStringStorage
     | SyncStringStorage
-    | undefined = () =>
-    typeof window !== 'undefined' ? window.localStorage : undefined,
+    | undefined = () => {
+    try {
+      return window.localStorage
+    } catch (e) {
+      // Window could be undefined or local storage could be disabled
+      if (e instanceof TypeError || e instanceof DOMException) {
+        return undefined
+      }
+
+      throw e
+    }
+  },
   options?: JsonStorageOptions,
 ): AsyncStorage<Value> | SyncStorage<Value> {
   let lastStr: string | undefined

--- a/src/vanilla/utils/atomWithStorage.ts
+++ b/src/vanilla/utils/atomWithStorage.ts
@@ -103,12 +103,12 @@ export function createJSONStorage<Value>(
     try {
       return window.localStorage
     } catch (e) {
-      // Window could be undefined or local storage could be disabled
-      if (e instanceof TypeError || e instanceof DOMException) {
-        return undefined
+      if (import.meta.env?.MODE !== 'production') {
+        if (typeof window !== 'undefined') {
+          console.warn(e);
+        }
       }
-
-      throw e
+      return undefined
     }
   },
   options?: JsonStorageOptions,

--- a/tests/react/vanilla-utils/atomWithStorage.test.tsx
+++ b/tests/react/vanilla-utils/atomWithStorage.test.tsx
@@ -515,7 +515,7 @@ describe('atomWithStorage (with disabled browser storage)', () => {
   })
 
   afterAll(() => {
-    // TS < 4.5 causes type error
+    // TS < 4.5 causes type error without `as any`
     ;(window as any).localStorage = savedLocalStorage
   })
 

--- a/tests/react/vanilla-utils/atomWithStorage.test.tsx
+++ b/tests/react/vanilla-utils/atomWithStorage.test.tsx
@@ -515,7 +515,8 @@ describe('atomWithStorage (with disabled browser storage)', () => {
   })
 
   afterAll(() => {
-    window.localStorage = savedLocalStorage
+    // TS < 4.5 causes type error
+    (window as any).localStorage = savedLocalStorage
   })
 
   it('initial value of atomWithStorage can be used when cookies are disabled', async () => {

--- a/tests/react/vanilla-utils/atomWithStorage.test.tsx
+++ b/tests/react/vanilla-utils/atomWithStorage.test.tsx
@@ -502,6 +502,44 @@ describe('atomWithStorage (with browser storage)', () => {
   })
 })
 
+describe('atomWithStorage (with disabled browser storage)', () => {
+  const savedLocalStorage = window.localStorage
+
+  beforeAll(() => {
+    // Firefox and chromium based browser throw DOMException when cookies are disabled
+    Object.defineProperty(window, 'localStorage', {
+      get() {
+        throw new DOMException('The operation is insecure.')
+      },
+    })
+  })
+
+  afterAll(() => {
+    window.localStorage = savedLocalStorage
+  })
+
+  it('initial value of atomWithStorage can be used when cookies are disabled', async () => {
+    const countAtom = atomWithStorage<number>('counter', 4)
+
+    const Counter = () => {
+      const [value] = useAtom(countAtom)
+      return (
+        <>
+          <div>count: {value}</div>
+        </>
+      )
+    }
+
+    const { findByText } = render(
+      <StrictMode>
+        <Counter />
+      </StrictMode>,
+    )
+
+    await findByText('count: 4')
+  })
+})
+
 describe('atomWithStorage (with non-browser storage)', () => {
   const addEventListener = window.addEventListener
   const mockAddEventListener = vi.fn()

--- a/tests/react/vanilla-utils/atomWithStorage.test.tsx
+++ b/tests/react/vanilla-utils/atomWithStorage.test.tsx
@@ -516,7 +516,7 @@ describe('atomWithStorage (with disabled browser storage)', () => {
 
   afterAll(() => {
     // TS < 4.5 causes type error
-    (window as any).localStorage = savedLocalStorage
+    ;(window as any).localStorage = savedLocalStorage
   })
 
   it('initial value of atomWithStorage can be used when cookies are disabled', async () => {


### PR DESCRIPTION
## Related Issues or Discussions

Fixes downstream issue for https://ui.shadcn.com/
It crashes when cookies are disabled with this exception:
![image](https://github.com/pmndrs/jotai/assets/115920155/0f5c6cc6-8001-4b31-b7d0-f5193be6d5c1)


## Summary
On Firefox accessing the property localStorage of window results in a `DOMException: The operation is insecure.`
This PR will handle this case gracefully and fall back to providing no storage implementation. This should be fine as we cannot store anything in a cookie-free browser.

## Check List

- [x] `yarn run prettier` for formatting code and docs
