### PR TITLE
feat(vanilla): customizable atom.unstable_is

### DIFF
--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -40,7 +40,7 @@ type OnMount<Args extends unknown[], Result> = <
 export interface Atom<Value> {
   toString: () => string
   read: Read<Value>
-  is?: (a: Atom<unknown>) => boolean
+  is?: (self: Atom<unknown>, target: Atom<unknown>) => boolean
   debugLabel?: string
   /**
    * To ONLY be used by Jotai libraries to mark atoms as private. Subject to change.

--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -40,7 +40,7 @@ type OnMount<Args extends unknown[], Result> = <
 export interface Atom<Value> {
   toString: () => string
   read: Read<Value>
-  is?(a: Atom<unknown>): boolean
+  unstable_is?(a: Atom<unknown>): boolean
   debugLabel?: string
   /**
    * To ONLY be used by Jotai libraries to mark atoms as private. Subject to change.

--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -40,6 +40,7 @@ type OnMount<Args extends unknown[], Result> = <
 export interface Atom<Value> {
   toString: () => string
   read: Read<Value>
+  is?: (a: Atom<unknown>) => boolean
   debugLabel?: string
   /**
    * To ONLY be used by Jotai libraries to mark atoms as private. Subject to change.

--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -98,25 +98,29 @@ export function atom<Value, Args extends unknown[], Result>(
     config.read = read as Read<Value, SetAtom<Args, Result>>
   } else {
     config.init = read
-    config.read = function (get) {
-      return get(this)
-    }
-    config.write = function (
-      this: PrimitiveAtom<Value>,
-      get: Getter,
-      set: Setter,
-      arg: SetStateAction<Value>,
-    ) {
-      return set(
-        this,
-        typeof arg === 'function'
-          ? (arg as (prev: Value) => Value)(get(this))
-          : arg,
-      )
-    } as unknown as Write<Args, Result>
+    config.read = defaultRead
+    config.write = defaultWrite as unknown as Write<Args, Result>
   }
   if (write) {
     config.write = write
   }
   return config
+}
+
+function defaultRead<Value>(this: Atom<Value>, get: Getter) {
+  return get(this)
+}
+
+function defaultWrite<Value>(
+  this: PrimitiveAtom<Value>,
+  get: Getter,
+  set: Setter,
+  arg: SetStateAction<Value>,
+) {
+  return set(
+    this,
+    typeof arg === 'function'
+      ? (arg as (prev: Value) => Value)(get(this))
+      : arg,
+  )
 }

--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -40,7 +40,7 @@ type OnMount<Args extends unknown[], Result> = <
 export interface Atom<Value> {
   toString: () => string
   read: Read<Value>
-  is?: (self: Atom<unknown>, target: Atom<unknown>) => boolean
+  is?(a: Atom<unknown>): boolean
   debugLabel?: string
   /**
    * To ONLY be used by Jotai libraries to mark atoms as private. Subject to change.

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -9,7 +9,7 @@ type Getter = Parameters<AnyAtom['read']>[0]
 type Setter = Parameters<AnyWritableAtom['write']>[1]
 
 const isSelfAtom = (atom: AnyAtom, a: AnyAtom) =>
-  atom.is ? atom.is(atom, a) : a === atom
+  atom.is ? atom.is(a) : a === atom
 
 const hasInitialValue = <T extends Atom<AnyValue>>(
   atom: T,

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -9,7 +9,7 @@ type Getter = Parameters<AnyAtom['read']>[0]
 type Setter = Parameters<AnyWritableAtom['write']>[1]
 
 const isSelfAtom = (atom: AnyAtom, a: AnyAtom) =>
-  atom.is ? atom.is(a) : a === atom
+  atom.is ? atom.is(atom, a) : a === atom
 
 const hasInitialValue = <T extends Atom<AnyValue>>(
   atom: T,

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -9,7 +9,7 @@ type Getter = Parameters<AnyAtom['read']>[0]
 type Setter = Parameters<AnyWritableAtom['write']>[1]
 
 const defaultAtomIs = function (this: AnyAtom, a: AnyAtom) {
-  return this === a
+  return a === this
 }
 
 const hasInitialValue = <T extends Atom<AnyValue>>(

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -9,7 +9,7 @@ type Getter = Parameters<AnyAtom['read']>[0]
 type Setter = Parameters<AnyWritableAtom['write']>[1]
 
 const isSelfAtom = (atom: AnyAtom, a: AnyAtom) =>
-  atom.is ? atom.is(a) : a === atom
+  atom.unstable_is ? atom.unstable_is(a) : a === atom
 
 const hasInitialValue = <T extends Atom<AnyValue>>(
   atom: T,


### PR DESCRIPTION
supersedes #2353

- introduce `atom.unstable_is`
- make default `read` & `write` functions stable