### PR TITLE
docs: fix atomWithListeners example

### DIFF
--- a/docs/recipes/atom-with-listeners.mdx
+++ b/docs/recipes/atom-with-listeners.mdx
@@ -26,7 +26,7 @@ type Callback<Value> = (
 
 export function atomWithListeners<Value>(initialValue: Value) {
   const baseAtom = atom(initialValue)
-  const listenersAtom = atom(<Callback<Value>[]>[])
+  const listenersAtom = atom<Callback<Value>[]>([])
   const anAtom = atom(
     (get) => get(baseAtom),
     (get, set, arg: SetStateAction<Value>) => {


### PR DESCRIPTION
fixed a typescript type error

- [x] `yarn run prettier` for formatting code and docs
