### PR TITLE
Improve performance of recomputeDependents

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -500,7 +500,7 @@ export const createStore = () => {
       }
       markedAtoms.add(n)
       for (const m of getDependents(n)) {
-        if (!isSelfAtom(n, m)) {
+        if (n !== m) {
           visit(m)
         }
       }

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -517,8 +517,8 @@ export const createStore = () => {
     // Step 2: use the topsorted atom list to recompute all affected atoms
     // Track what's changed, so that we can short circuit when possible
     const changedAtoms = new Set<AnyAtom>([atom])
-    for (let i = topsortedAtoms.length; i > 0; i--) {
-      const a = topsortedAtoms[i - 1]!
+    for (let i = topsortedAtoms.length - 1; i >= 0; --i) {
+      const a = topsortedAtoms[i]!
       const prevAtomState = getAtomState(a)
       if (!prevAtomState) {
         continue

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -506,7 +506,7 @@ export const createStore = () => {
     // Step 2: traverse the dependency graph to build the topsorted atom list
     // We don't bother to check for cycles, which simplifies the algorithm.
     const topsortedAtoms = new Array<AnyAtom>(allAtomsInDependencyGraph.length)
-    let topsortedAtomsIndex = 0
+    let topsortedAtomsIndex = allAtomsInDependencyGraph.length
     const markedAtoms = new Set<AnyAtom>()
     const visit = (n: AnyAtom) => {
       if (markedAtoms.has(n)) {
@@ -518,10 +518,9 @@ export const createStore = () => {
           visit(m)
         }
       }
-      // The algorithm calls for pushing onto the front of the list. For
-      // simplicity, we simply append items in order, and will iterate
-      // in reverse order later.
-      topsortedAtoms[topsortedAtomsIndex++] = n
+      // The algorithm calls for pushing onto the front of the list, so we fill
+      // the array in reverse order.
+      topsortedAtoms[--topsortedAtomsIndex] = n
     }
     while (allAtomsInDependencyGraph.length) {
       visit(allAtomsInDependencyGraph.pop()!)
@@ -530,8 +529,7 @@ export const createStore = () => {
     // Step 3: use the topsorted atom list to recompute all affected atoms
     // Track what's changed, so that we can short circuit when possible
     const changedAtoms = new Set<AnyAtom>([atom])
-    for (let i = topsortedAtoms.length; i > 0; i--) {
-      const a = topsortedAtoms[i - 1]!
+    for (const a of topsortedAtoms) {
       const prevAtomState = getAtomState(a)
       let hasChangedDeps = false
       for (const dep of prevAtomState?.d.keys() || []) {

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -500,6 +500,7 @@ export const createStore = () => {
       }
       markedAtoms.add(n)
       for (const m of getDependents(n)) {
+        // we shouldn't use isSelfAtom here.
         if (n !== m) {
           visit(m)
         }

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -531,8 +531,11 @@ export const createStore = () => {
     const changedAtoms = new Set<AnyAtom>([atom])
     for (const a of topsortedAtoms) {
       const prevAtomState = getAtomState(a)
+      if (!prevAtomState) {
+        continue
+      }
       let hasChangedDeps = false
-      for (const dep of prevAtomState?.d.keys() || []) {
+      for (const dep of prevAtomState.d.keys()) {
         if (dep !== a && changedAtoms.has(dep)) {
           hasChangedDeps = true
           break

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -500,7 +500,7 @@ export const createStore = () => {
       }
       markedAtoms.add(n)
       for (const m of getDependents(n)) {
-        if (n !== m) {
+        if (!isSelfAtom(n, m)) {
           visit(m)
         }
       }

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -476,14 +476,14 @@ export const createStore = () => {
   }
 
   const recomputeDependents = (atom: AnyAtom): void => {
-    const getDependents = (a: AnyAtom): Dependents => {
+    const getDependents = (a: AnyAtom): Array<AnyAtom> => {
       const dependents = new Set(mountedMap.get(a)?.t)
       pendingMap.forEach((_, pendingAtom) => {
         if (getAtomState(pendingAtom)?.d.has(a)) {
           dependents.add(pendingAtom)
         }
       })
-      return dependents
+      return Array.from(dependents)
     }
 
     // This is a topological sort via depth-first search, slightly modified from

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -476,6 +476,10 @@ export const createStore = () => {
   }
 
   const recomputeDependents = (atom: AnyAtom): void => {
+    // Returns an array rather than a set to work around an issue with
+    // transpilation for older environments. Otherwise, Array.prototype.push
+    // below will fail due to the transpiled set iterator implementation.
+    // https://github.com/pmndrs/jotai/discussions/2368#discussioncomment-8274991
     const getDependents = (a: AnyAtom): Array<AnyAtom> => {
       const dependents = new Set(mountedMap.get(a)?.t)
       pendingMap.forEach((_, pendingAtom) => {

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -442,11 +442,8 @@ export const createStore = () => {
     }
     try {
       const valueOrPromise = atom.read(getter, options as any)
-      return setAtomValueOrPromise(
-        atom,
-        valueOrPromise,
-        nextDependencies,
-        () => controller?.abort(),
+      return setAtomValueOrPromise(atom, valueOrPromise, nextDependencies, () =>
+        controller?.abort(),
       )
     } catch (error) {
       return setAtomError(atom, error, nextDependencies)

--- a/src/vanilla/typeUtils.ts
+++ b/src/vanilla/typeUtils.ts
@@ -5,24 +5,13 @@ export type Setter = Parameters<
   WritableAtom<unknown, unknown[], unknown>['write']
 >[1]
 
-export type ExtractAtomValue<AtomType> = AtomType extends Atom<infer Value>
-  ? Value
-  : never
+export type ExtractAtomValue<AtomType> =
+  AtomType extends Atom<infer Value> ? Value : never
 
-export type ExtractAtomArgs<AtomType> = AtomType extends WritableAtom<
-  any,
-  infer Args,
-  any
->
-  ? Args
-  : never
+export type ExtractAtomArgs<AtomType> =
+  AtomType extends WritableAtom<any, infer Args, any> ? Args : never
 
-export type ExtractAtomResult<AtomType> = AtomType extends WritableAtom<
-  any,
-  any[],
-  infer Result
->
-  ? Result
-  : never
+export type ExtractAtomResult<AtomType> =
+  AtomType extends WritableAtom<any, any[], infer Result> ? Result : never
 
 export type SetStateAction<Value> = ExtractAtomArgs<PrimitiveAtom<Value>>[0]

--- a/src/vanilla/typeUtils.ts
+++ b/src/vanilla/typeUtils.ts
@@ -5,13 +5,24 @@ export type Setter = Parameters<
   WritableAtom<unknown, unknown[], unknown>['write']
 >[1]
 
-export type ExtractAtomValue<AtomType> =
-  AtomType extends Atom<infer Value> ? Value : never
+export type ExtractAtomValue<AtomType> = AtomType extends Atom<infer Value>
+  ? Value
+  : never
 
-export type ExtractAtomArgs<AtomType> =
-  AtomType extends WritableAtom<any, infer Args, any> ? Args : never
+export type ExtractAtomArgs<AtomType> = AtomType extends WritableAtom<
+  any,
+  infer Args,
+  any
+>
+  ? Args
+  : never
 
-export type ExtractAtomResult<AtomType> =
-  AtomType extends WritableAtom<any, any[], infer Result> ? Result : never
+export type ExtractAtomResult<AtomType> = AtomType extends WritableAtom<
+  any,
+  any[],
+  infer Result
+>
+  ? Result
+  : never
 
 export type SetStateAction<Value> = ExtractAtomArgs<PrimitiveAtom<Value>>[0]


### PR DESCRIPTION
## Related Issues or Discussions

N/A

## Summary

Hi. I've been working with @edkimmel on performance improvements to our app. It's a React Native ecommerce app that heavily relies on Jotai for managing most state and data. A hotspot that stood out recently was `recomputeDependents`—that's how Eddie identified the Hermes memory leak (https://github.com/pmndrs/jotai/discussions/2355) as a source of our problems.

Even with Eddie's workaround in place for that memory leak, we still found that `recomputeDependents` was very slow for us, so we took a closer look at what `recomputeDependents` is doing. It's something like this:

* loop1 is `O(n*m)` where `n` is the number of atoms and `m` is the number of dependency edges.
* loop2 is `O(n*n*m)` because it does the same thing as loop1 but also iterates over the `dependencyMap` for each iteration where the atom is unchanged (that is, roughly `n*m` times).

This can be improved by doing a topological sort of the atom dependency graph, which is `O(n)`. This PR changes the `recomputeDependents` implementation to do that topsort. All existing tests pass.

I ran through a test case for our app that represents a common customer flow. The total accumulated time in `recomputeDependents` is as follows:

| Platform | Time before | Time after | Percent improvement |
| --- | --- | --- | --- |
| Web/Chrome | 1,483ms | 295ms | 80% |
| iOS React Native (Hermes) | 3,581ms | 367ms | 90% | 
| Android React Native (Hermes) | 4,137ms | 402ms | 90% | 

Thanks again for all of your work on Jotai, we're big fans!

## Check List

- [x] `yarn run prettier` for formatting code and docs
