### PR TITLE
chore: onUpdate

### DIFF
--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -37,6 +37,8 @@ type OnMount<Args extends unknown[], Result> = <
   setAtom: S,
 ) => OnUnmount | void
 
+type OnUpdate<Args extends unknown[]> = (get: Getter, ...args: Args) => void
+
 export interface Atom<Value> {
   toString: () => string
   read: Read<Value>
@@ -54,6 +56,7 @@ export interface WritableAtom<Value, Args extends unknown[], Result>
   read: Read<Value, SetAtom<Args, Result>>
   write: Write<Args, Result>
   onMount?: OnMount<Args, Result>
+  onUpdate?: OnUpdate<Args>
 }
 
 type SetStateAction<Value> = Value | ((prev: Value) => Value)

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -575,6 +575,7 @@ export const createStore = () => {
       }
       return r as R
     }
+    atom.onUpdate?.(getter, ...args)
     const result = atom.write(getter, setter, ...args)
     isSync = false
     return result


### PR DESCRIPTION
## Summary
We have a requirement where certain actions are triggered when the state of an atom changes. Therefore, we added onUpdate, corresponding to onMount.


## Check List

- [x] `yarn run prettier` for formatting code and docs
