### PR TITLE
fix(types): useAtom with one type argument for primitive atoms

### DIFF
--- a/src/react/useAtom.ts
+++ b/src/react/useAtom.ts
@@ -3,6 +3,8 @@ import type {
   ExtractAtomArgs,
   ExtractAtomResult,
   ExtractAtomValue,
+  PrimitiveAtom,
+  SetStateAction,
   WritableAtom,
 } from '../vanilla.ts'
 import { useAtomValue } from './useAtomValue.ts'
@@ -16,6 +18,11 @@ export function useAtom<Value, Args extends unknown[], Result>(
   atom: WritableAtom<Value, Args, Result>,
   options?: Options,
 ): [Awaited<Value>, SetAtom<Args, Result>]
+
+export function useAtom<Value>(
+  atom: PrimitiveAtom<Value>,
+  options?: Options,
+): [Awaited<Value>, SetAtom<[SetStateAction<Value>], void>]
 
 export function useAtom<Value>(
   atom: Atom<Value>,

--- a/tests/react/types.test.tsx
+++ b/tests/react/types.test.tsx
@@ -1,4 +1,5 @@
 import { expectType } from 'ts-expect'
+import type { TypeEqual } from 'ts-expect'
 import { it } from 'vitest'
 import { useAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -45,6 +46,21 @@ it('useAtom should handle inference of atoms (#1831 #1387)', () => {
     expectType<[string, (arg: string) => void]>(useField('username'))
     expectType<[number, (arg: number) => void]>(useField('age'))
     expectType<[boolean, (arg: boolean) => void]>(useField('checked'))
+  }
+  Component
+})
+
+it('useAtom should handle primitive atom with one type argeument', () => {
+  const countAtom = atom(0)
+  function Component() {
+    const [count, setCount] = useAtom<number>(countAtom)
+    expectType<TypeEqual<typeof count, number>>(true)
+    expectType<
+      TypeEqual<
+        typeof setCount,
+        (arg: number | ((prev: number) => number)) => void
+      >
+    >(true)
   }
   Component
 })


### PR DESCRIPTION
This has been asked several times. Hope this doesn't break some usages.