### PR TITLE
docs: add DevTool's new position prop

### DIFF
--- a/docs/tools/devtools.mdx
+++ b/docs/tools/devtools.mdx
@@ -92,6 +92,9 @@ type DevToolsProps = {
   store?: Store
   // Defaults to light
   theme?: 'dark' | 'light'
+  // Set the position of the trigger button
+  // Defaults to `bottom-left`
+  position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'
   // Custom nonce to allowlist jotai-devtools specific inline styles via CSP
   nonce?: string
   options?: {


### PR DESCRIPTION
## Summary
- Document DevTool's new position prop (https://github.com/jotaijs/jotai-devtools/pull/118)


## Check List

- [x] `yarn run prettier` for formatting code and docs
