### PR TITLE
build: change rollup target to ES2018

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,10 +33,11 @@ function getBabelOptions(targets) {
   }
 }
 
-function getEsbuild(target, env = 'development') {
+function getEsbuild(env = 'development') {
   return esbuild({
     minify: env === 'production',
-    target,
+    target: 'es2018',
+    supported: { 'import-meta': true },
     tsconfig: path.resolve('./tsconfig.json'),
   })
 }
@@ -78,7 +79,7 @@ function createESMConfig(input, output, clientOnly) {
         delimiters: ['\\b', '\\b(?!(\\.|/))'],
         preventAssignment: true,
       }),
-      getEsbuild('node12'),
+      getEsbuild(),
       banner2(() => clientOnly && cscComment),
     ],
   }
@@ -157,7 +158,7 @@ function createSystemConfig(input, output, env, clientOnly) {
         delimiters: ['\\b', '\\b(?!(\\.|/))'],
         preventAssignment: true,
       }),
-      getEsbuild('node12', env),
+      getEsbuild(env),
       banner2(() => clientOnly && cscComment),
     ],
   }


### PR DESCRIPTION
## Related Issues or Discussions

https://github.com/pmndrs/jotai/issues/48

## Summary

Jotai causes a very hard to debug syntax error in browsers that don't support ES2019. I tracked down the issue to the two `catch` blocks that use [Optional catch Binding](https://www.javascripttutorial.net/es-next/optional-catch-binding). Optional catch Binding was introduced in ES2019 and is not supported in Chrome 65 and older. This PR fixes that.

Browser support: https://caniuse.com/mdn-javascript_statements_try_catch_optional_catch_binding

## Check List

- [ ] `yarn run prettier` for formatting code and docs
