### PR TITLE
Update atom-with-toggle-and-storage.mdx

### DIFF
--- a/docs/recipes/atom-with-toggle-and-storage.mdx
+++ b/docs/recipes/atom-with-toggle-and-storage.mdx
@@ -16,17 +16,17 @@ export function atomWithToggleAndStorage(
   key: string,
   initialValue?: boolean,
   storage?: any,
-): WritableAtom<boolean, boolean | undefined> {
+): WritableAtom<boolean, [boolean?], void> {
   const anAtom = atomWithStorage(key, initialValue, storage)
   const derivedAtom = atom(
     (get) => get(anAtom),
     (get, set, nextValue?: boolean) => {
       const update = nextValue ?? !get(anAtom)
-      set(anAtom, update)
+      void set(anAtom, update)
     },
   )
 
-  return derivedAtom
+  return derivedAtom as WritableAtom<boolean, [boolean?], void>
 }
 ```
 


### PR DESCRIPTION
Updating recipe example with Typescript error fixes

## Related Issues or Discussions

Fixes # Recipe doc for atom-with-toggle-and-storage

## Summary
Fixed the Typescript issues as per the new Jotai API. Also added void before set(anAtom, update) to ignore the promise as per typescript no floating promises rule. Can this be made better?


## Check List

- [ ] `yarn run prettier` for formatting code and docs
