### PR TITLE
docs: using createStore to interact with atoms outside React 

### DIFF
--- a/docs/guides/using-store-outside-react.mdx
+++ b/docs/guides/using-store-outside-react.mdx
@@ -11,8 +11,7 @@ to interact with the world outside React.
 
 ## createStore
 
-[`createStore`](../core/store) provides a store interface that can be used to store your atoms. Using the store, you can access and mutate the state of your stored atoms from outside React.
-
+[`createStore`](../core/store.mdx#createstore) provides a store interface that can be used to store your atoms. Using the store, you can access and mutate the state of your stored atoms from outside React.
 
 ```jsx
 import { atom, useAtomValue, createStore, Provider } from "jotai";
@@ -20,11 +19,11 @@ import { atom, useAtomValue, createStore, Provider } from "jotai";
 const timeAtom = atom(0);
 const store = createStore();
 
-store.set(timeAtom, store.get(timeAtom) + 1); // Update atom's value
-store.get(timeAtom); // Read atom's value
+store.set(timeAtom, (prev) => prev + 1); // Update atom's value
+store.get(timeAtom) // Read atom's value
 
 function Component() {
-  const time = useAtomValue(timeAtom); // Inside React
+  const time = useAtomValue(timeAtom) // Inside React
   return (
     <div className="App">
       <h1>{time}</h1>

--- a/docs/guides/using-store-outside-react.mdx
+++ b/docs/guides/using-store-outside-react.mdx
@@ -14,12 +14,12 @@ to interact with the world outside React.
 [`createStore`](../core/store.mdx#createstore) provides a store interface that can be used to store your atoms. Using the store, you can access and mutate the state of your stored atoms from outside React.
 
 ```jsx
-import { atom, useAtomValue, createStore, Provider } from "jotai";
+import { atom, useAtomValue, createStore, Provider } from 'jotai'
 
-const timeAtom = atom(0);
-const store = createStore();
+const timeAtom = atom(0)
+const store = createStore()
 
-store.set(timeAtom, (prev) => prev + 1); // Update atom's value
+store.set(timeAtom, (prev) => prev + 1) // Update atom's value
 store.get(timeAtom) // Read atom's value
 
 function Component() {
@@ -28,7 +28,7 @@ function Component() {
     <div className="App">
       <h1>{time}</h1>
     </div>
-  );
+  )
 }
 
 export default function App() {
@@ -36,7 +36,7 @@ export default function App() {
     <Provider store={store}>
       <Component />
     </Provider>
-  );
+  )
 }
 ```
 

--- a/docs/guides/using-store-outside-react.mdx
+++ b/docs/guides/using-store-outside-react.mdx
@@ -1,0 +1,46 @@
+---
+title: Using store outside React
+description: Using store outside React
+nav: 4.98
+keywords: state, outside, react
+published: false
+---
+
+Jotai's state resides in React, but sometimes it would be nice
+to interact with the world outside React.
+
+## createStore
+
+[`createStore`](../core/store) provides a store interface that can be used to store your atoms. Using the store, you can access and mutate the state of your stored atoms from outside React.
+
+
+```jsx
+import { atom, useAtomValue, createStore, Provider } from "jotai";
+
+const timeAtom = atom(0);
+const store = createStore();
+
+store.set(timeAtom, store.get(timeAtom) + 1); // Update atom's value
+store.get(timeAtom); // Read atom's value
+
+function Component() {
+  const time = useAtomValue(timeAtom); // Inside React
+  return (
+    <div className="App">
+      <h1>{time}</h1>
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <Provider store={store}>
+      <Component />
+    </Provider>
+  );
+}
+```
+
+### Examples
+
+<CodeSandbox id="2jvynm" />


### PR DESCRIPTION
## Related Issues or Discussions

- #263

## Summary

Added docs to explain how to interact with atoms outside React

This Codesandbox is used in the example: https://codesandbox.io/p/sandbox/practical-bardeen-2jvynm?file=%2Fsrc%2FApp.tsx%3A16%2C5

## Check List

- [x] `yarn run prettier` for formatting code and docs
