### PR TITLE
fix(utils): make 'atomWithStorage' behave as expected when store changes.

### DIFF
--- a/tests/vanilla/utils/atomWithStorage.test.ts
+++ b/tests/vanilla/utils/atomWithStorage.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { createStore } from 'jotai/vanilla'
+import { atomWithStorage, createJSONStorage } from 'jotai/vanilla/utils'
+
+const testStringStorage = (() => {
+  const map = new Map<string, string>()
+
+  return {
+    getItem(key: string) {
+      return map.get(key) ?? null
+    },
+
+    removeItem(key: string) {
+      map.delete(key)
+    },
+
+    setItem(key: string, newValue: string) {
+      map.set(key, newValue)
+    },
+  }
+})()
+
+const testStorage = createJSONStorage(() => testStringStorage)
+
+describe('atomWithStorage', () => {
+  it('given getOnInit is true, initial value should be calculated on the first get (per store)', () => {
+    const storeKey = 'a-key' as const
+    const storeAlpha = createStore()
+    const storeBeta = createStore()
+    let store = storeAlpha
+
+    // providing an initial value in the storage
+    testStorage.setItem(storeKey, 'initial')
+
+    const anAtom = atomWithStorage(storeKey, null, testStorage, {
+      getOnInit: true,
+    })
+
+    expect(store.get(anAtom)).toEqual('initial')
+
+    store.set(anAtom, 'next-value')
+
+    expect(store.get(anAtom)).toEqual('next-value')
+
+    // changing store, often used when logging out of the app to reset the state.
+    store = storeBeta
+
+    expect(store.get(anAtom)).toEqual('next-value')
+  })
+})


### PR DESCRIPTION
## Summary

We recreate the store that is provided to the React component tree when logging out of the app to clear cache. When using `atomWithStorage` (with `getOnInit=true`), recreating the store causes the atom to revert to its initial value, bound at atom creation.

```ts
// the current value of `localStorage.getItem('app-theme')` gets bound, e.g. { primaryColor: 'blue' }.
const storedThemeAtom = atomWIthStorage('app-theme', null, undefined, { getOnInit: true });

// updating the value of the atom, therefore updating the storage
setAnAtom({ primaryColor: 'red' });

// recreating the store
// ...
///

// `storedThemeAtom` now holds the same value as when the app initialized, therefore being desynced from the Storage.
```

I am not sure whether this was the desired behavior, or if the `getOnInit=true` is just supposed to retrieve the data sooner, but still be synced with the inherent Storage when it is possible.

## Fixes
- The base atom within `atomWithStorage` is wrapped within an atom, meaning the initial value is part of the store, not the atom definition.

## Check List

- [x] `yarn run prettier` for formatting code and docs
