### PR TITLE
fix(vanilla): store should notify subscriber if subscribing causes the value to change

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -476,7 +476,7 @@ export const createStore = () => {
   const addAtom = (atom: AnyAtom, initialListener?: () => void): Mounted => {
     let mounted = mountedMap.get(atom)
     if (!mounted) {
-      mounted = mountAtom(atom, initialListener)
+      mounted = mountAtom(atom, undefined, undefined, initialListener)
     }
     return mounted
   }
@@ -610,9 +610,9 @@ export const createStore = () => {
 
   const mountAtom = <Value>(
     atom: Atom<Value>,
-    initialListener?: () => void,
     initialDependent?: AnyAtom,
     onMountQueue?: (() => void)[],
+    initialListener?: () => void,
   ): Mounted => {
     const queue = onMountQueue || []
     // mount dependencies before mounting self
@@ -622,7 +622,7 @@ export const createStore = () => {
         aMounted.t.add(atom) // add dependent
       } else {
         if (a !== atom) {
-          mountAtom(a, undefined, atom, queue)
+          mountAtom(a, atom, queue)
         }
       }
     })
@@ -717,7 +717,7 @@ export const createStore = () => {
         // we mount dependencies only when atom is already mounted
         // Note: we should revisit this when you find other issues
         // https://github.com/pmndrs/jotai/issues/942
-        mountAtom(a, undefined, atom)
+        mountAtom(a, atom)
       }
     })
     maybeUnmountAtomSet.forEach((a) => {

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -502,3 +502,19 @@ it('should mount once with atom creator atom (#2314)', async () => {
   store.sub(atomCreatorAtom, () => {})
   expect(countAtom.onMount).toHaveBeenCalledTimes(1)
 })
+
+it('should notify subscriber if subscribing causes the value to change', async () => {
+  const anAtom = atom(0)
+  anAtom.onMount = (setAtom) => {
+    setAtom(1)
+  }
+  const store = createStore()
+  const subscriberFn = vi.fn((_value: number) => {})
+  expect(store.get(anAtom)).toEqual(0)
+  store.sub(anAtom, () => {
+    subscriberFn(store.get(anAtom))
+  })
+
+  expect(subscriberFn).toHaveBeenCalledOnce()
+  expect(subscriberFn).toHaveBeenCalledWith(1)
+})


### PR DESCRIPTION
## Summary

Not sure if this was the desired behavior, but currently, if we create an atom that changes their value synchronously in `onMount`, and we subscribe to that atom's changes for the first time, the listener does not get executed.

Given the atom:
```ts
const anAtom = atom(0)
anAtom.onMount = (setAtom) => {
  setAtom(1)
}
```

```ts
// hoping to keep `value` in sync with the atom
let value = store.get(anAtom)
store.sub(anAtom, () => {
  // ideally, getting all subsequent changes to the value of `anAtom`.
  value = store.get(anAtom)
})
```

The code above is not a foolproof solution to tracking the atom's value in the described situation. We would have to do:
```ts
store.sub(anAtom, () => {
  value = store.get(anAtom)
})
// place the initial value read here, after subscribing
let value = store.get(anAtom)
```

I found this behavior a bit confusing, but it might be desired. Let me know if this is something you would like to change.

## Check List

- [x] `yarn run prettier` for formatting code and docs
