### PR TITLE
fix(vanilla): store should flush pending write triggered asynchronously and indirectly

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -560,7 +560,6 @@ export const createStore = () => {
     atom: WritableAtom<Value, Args, Result>,
     ...args: Args
   ): Result => {
-    let isSync = true
     const getter: Getter = <V>(a: Atom<V>) => returnAtomValue(readAtomState(a))
     const setter: Setter = <V, As extends unknown[], R>(
       a: WritableAtom<V, As, R>,
@@ -580,7 +579,7 @@ export const createStore = () => {
       } else {
         r = writeAtomState(a as AnyWritableAtom, ...args) as R
       }
-      if (!isSync) {
+      if (pendingStack.length === 0) {
         const flushed = flushPending([a])
         if (import.meta.env?.MODE !== 'production') {
           storeListenersRev2.forEach((l) =>
@@ -591,7 +590,6 @@ export const createStore = () => {
       return r as R
     }
     const result = atom.write(getter, setter, ...args)
-    isSync = false
     return result
   }
 

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -503,7 +503,7 @@ it('should mount once with atom creator atom (#2314)', async () => {
   expect(countAtom.onMount).toHaveBeenCalledTimes(1)
 })
 
-it('should flush pending write triggered asynchronously and indirectly', async () => {
+it('should flush pending write triggered asynchronously and indirectly (#2451)', async () => {
   const store = createStore()
   const anAtom = atom('initial')
 

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -502,3 +502,29 @@ it('should mount once with atom creator atom (#2314)', async () => {
   store.sub(atomCreatorAtom, () => {})
   expect(countAtom.onMount).toHaveBeenCalledTimes(1)
 })
+
+it('should flush pending write triggered asynchronously and indirectly', async () => {
+  const store = createStore()
+  const anAtom = atom('initial')
+
+  const callbackFn = vi.fn((_value: string) => {})
+  const unsub = store.sub(anAtom, () => {
+    callbackFn(store.get(anAtom))
+  })
+
+  const actionAtom = atom(null, async (_get, set) => {
+    await Promise.resolve() // waiting a microtask
+    set(indirectSetAtom)
+  })
+
+  const indirectSetAtom = atom(null, (_get, set) => {
+    set(anAtom, 'next')
+  })
+
+  // executing the chain reaction
+  await store.set(actionAtom)
+
+  expect(callbackFn).toHaveBeenCalledOnce()
+  expect(callbackFn).toHaveBeenCalledWith('next')
+  unsub()
+})


### PR DESCRIPTION
## Related Issues or Discussions

Sorry for the onslaught of PRs, I believe this one to be an actual fix to a regression caused by the #2396 refactor

## Summary

For this bug to occur a few things have to happen:
1. An atom that we wish to update indirectly, e.g.
```ts
const emailAtom = atom('user@example.com')
```
2. An atom that simply writes to the atom above in its write function, e.g.:
```ts
const updateEmailAtom = atom(null, (_get, set, value: string) => set(emailAtom, value.trim()))
```
3. An atom that executes the above atom asynchronously, e.g.:
```ts
const initializeAndVerifyAtom = atom(null, async (_get, set, fields: FormFields) => {
  const email = fields.email
  await verifyEmail(email)
  
  // this write is no longer sync, so should be flushed immediately, but the
  // actual atom that will get set (emailAtom) thinks it is being set synchronously,
  // so it just adds itself to the non-existent top of `pendingStack`.
  set(updateEmailAtom, email)
})
```

Instead of tracking `isSync` in `writeAtomState`, we can use the length of `pendingStack` to determine if the atom we are currently updating will get flushed in a batch, or do we have to handle the flushing immediately.

## Check List

- [x] `yarn run prettier` for formatting code and docs
