### PR TITLE
refactor atomWithLazy

### DIFF
--- a/src/vanilla/utils/atomWithLazy.ts
+++ b/src/vanilla/utils/atomWithLazy.ts
@@ -3,10 +3,12 @@ import { PrimitiveAtom, atom } from '../../vanilla.ts'
 export function atomWithLazy<Value>(
   makeInitial: () => Value,
 ): PrimitiveAtom<Value> {
-  return {
-    ...atom(undefined as unknown as Value),
-    get init() {
+  const a = atom(undefined as unknown as Value)
+  delete (a as { init?: Value }).init
+  Object.defineProperty(a, 'init', {
+    get() {
       return makeInitial()
     },
-  }
+  })
+  return a
 }


### PR DESCRIPTION
based on #2465 

While woking on #2479 and enabling CJS tests, I noticed that with the current transpilation target, it expands `{...}` and makes the test to fail. So, let's refactor it to be compatible with transpiration.