### PR TITLE
recipes: fix typo

### DIFF
--- a/docs/recipes/use-reducer-atom.mdx
+++ b/docs/recipes/use-reducer-atom.mdx
@@ -1,5 +1,5 @@
 ---
-title: useReduerAtom
+title: useReducerAtom
 nav: 8.11
 keywords: reducer, hook, useReducerAtom
 ---


### PR DESCRIPTION
## Related Issues or Discussions

## Summary
Just a typo in the recipes title.
useReduerAtom -> useReducerAtom


## Check List

- [ ] `yarn run prettier` for formatting code and docs
