### PR TITLE
chore(tests): add test for useAtom types

### DIFF
--- a/tests/react/types.test.tsx
+++ b/tests/react/types.test.tsx
@@ -38,7 +38,6 @@ it('useAtom should handle inference of atoms (#1831 #1387)', () => {
     age: atom(0),
     checked: atom(false),
   }
-
   const useField = <T extends keyof typeof fieldAtoms>(prop: T) => {
     return useAtom(fieldAtoms[prop])
   }
@@ -46,6 +45,23 @@ it('useAtom should handle inference of atoms (#1831 #1387)', () => {
     expectType<[string, (arg: string) => void]>(useField('username'))
     expectType<[number, (arg: number) => void]>(useField('age'))
     expectType<[boolean, (arg: boolean) => void]>(useField('checked'))
+  }
+  Component
+})
+
+it('useAtom should handle inference of read-only atoms', () => {
+  const fieldAtoms = {
+    username: atom(() => ''),
+    age: atom(() => 0),
+    checked: atom(() => false),
+  }
+  const useField = <T extends keyof typeof fieldAtoms>(prop: T) => {
+    return useAtom(fieldAtoms[prop])
+  }
+  function Component() {
+    expectType<[string, never]>(useField('username'))
+    expectType<[number, never]>(useField('age'))
+    expectType<[boolean, never]>(useField('checked'))
   }
   Component
 })


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #2499

## Summary

We had test for primitive atoms, but test for read-only atoms were missing.

## Check List

- [x] `yarn run prettier` for formatting code and docs
