### PR TITLE
remove unnacessary any type

### DIFF
--- a/src/vanilla/store2.ts
+++ b/src/vanilla/store2.ts
@@ -608,7 +608,7 @@ export const createStore = (): Store => {
       // store dev methods (these are tentative and subject to change without notice)
       dev4_get_internal_weak_map: () => atomStateMap,
       dev4_override_method: (key, fn) => {
-        ;(store as any)[key] = fn
+        store[key] = fn
       },
     }
     return store


### PR DESCRIPTION
## Summary

`key: K extends keyof PrdStore` and there is no problem with the type.

So `any` seems unnecessary.

## Check List

- [x] `yarn run prettier` for formatting code and docs
