### PR TITLE
Fix document layout flickering.

### DIFF
--- a/website/src/components/code.js
+++ b/website/src/components/code.js
@@ -6,7 +6,7 @@ export const Code = ({ language = 'jsx', children }) => {
   return (
     <Highlight {...defaultProps} language={language} code={code} theme={undefined}>
       {({ className, style, tokens, getLineProps, getTokenProps }) => (
-        <pre className={className} style={style}>
+        <pre className={`${className} notranslate`} style={style}>
           {tokens.map((line, i) => (
             <div {...getLineProps({ line, key: i })}>
               {line.map((token, key) => (

--- a/website/src/components/main.js
+++ b/website/src/components/main.js
@@ -1,6 +1,6 @@
 export const Main = ({ children, ...rest }) => {
   return (
-    <main className="p-6 sm:p-8 lg:mt-8 lg:max-w-5xl lg:flex-shrink xl:p-16" {...rest}>
+    <main className="p-6 sm:p-8 lg:mt-8 lg:max-w-5xl lg:flex-shrink xl:p-16 flex-grow" {...rest}>
       {children}
     </main>
   );

--- a/website/src/components/main.js
+++ b/website/src/components/main.js
@@ -1,6 +1,6 @@
 export const Main = ({ children, ...rest }) => {
   return (
-    <main className="p-6 sm:p-8 lg:mt-8 lg:max-w-5xl lg:flex-shrink xl:p-16 flex-grow" {...rest}>
+    <main className="p-6 sm:p-8 lg:mt-8 lg:max-w-5xl lg:flex-shrink xl:p-16 grow" {...rest}>
       {children}
     </main>
   );

--- a/website/src/components/wrapper.js
+++ b/website/src/components/wrapper.js
@@ -1,7 +1,7 @@
 export const Wrapper = ({ children, ...rest }) => {
   return (
     <div
-      className="relative flex flex-col lg:mx-auto lg:max-w-[1920px] lg:flex-row lg:justify-around"
+      className="relative flex flex-col lg:mx-auto lg:max-w-[1920px] lg:w-full lg:flex-row lg:justify-around"
       {...rest}
     >
       {children}


### PR DESCRIPTION
When the content in the main container is too short, the container will shrink, causing layout flickering.

Setting `flex-grow` on main can solve this problem, always keeping main to fill its parent container.

https://jotai.org/docs/utilities/reducer

https://github.com/pmndrs/jotai/assets/28357731/cc0462e8-f97e-4019-8c0c-ca1c82b41e7c


Adding the notranslate class to the code block component can prevent the code text from being translated by Google.


![image](https://github.com/pmndrs/jotai/assets/28357731/15962285-6883-46e9-98b0-211377a64ab0)
