### PR TITLE
Docs: stackblitz migration

### DIFF
--- a/docs/utilities/ssr.mdx
+++ b/docs/utilities/ssr.mdx
@@ -88,8 +88,8 @@ useHydrateAtoms([
 ] as const)
 ```
 
-### Codesandbox
+### Demo
 
-<Stackblitz id="stackblitz-starters-nsugnt" file="pages%2Fssr.tsx" />
+<Stackblitz id="stackblitz-starters-b7cvxi" file="pages%2Findex.tsx" />
 
 There's more examples in the [Next.js section](../guides/nextjs.mdx).

--- a/docs/utilities/ssr.mdx
+++ b/docs/utilities/ssr.mdx
@@ -90,6 +90,6 @@ useHydrateAtoms([
 
 ### Codesandbox
 
-<CodeSandbox id="snu7n" />
+<Stackblitz id="stackblitz-starters-nsugnt" file="pages%2Fssr.tsx" />
 
 There's more examples in the [Next.js section](../guides/nextjs.mdx).

--- a/website/src/components/stackblitz.js
+++ b/website/src/components/stackblitz.js
@@ -1,6 +1,6 @@
 export const Stackblitz = ({ id, file }) => {
   return (
-    <div className="mb-8 overflow-hidden rounded-md border-b border-gray-200 shadow-lg dark:!shadow-none sm:rounded-lg">
+    <div className="mb-8 mt-4 overflow-hidden rounded-md border-b border-gray-200 shadow-lg dark:!shadow-none sm:rounded-lg">
       <iframe
         title={id}
         className="h-[400px] w-full"


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #2516 

## Summary

As per #2516, here's my first PR to migrate Codesandbox examples to Stackblitz. (This is my personal Github acc). While copying this particular SSR example, I found it quite irrelevant and failed to demonstrate the [`useHydrateAtoms`](https://jotai.org/docs/utilities/ssr#usehydrateatoms) which the example is placed at. Can I make change to the example to make it relevant and useful?

## Check List

- [x] `yarn run prettier` for formatting code and docs
