### PR TITLE
docs: migrate Codesandbox embeds in Next.js page to Stackblitz

### DIFF
--- a/docs/guides/nextjs.mdx
+++ b/docs/guides/nextjs.mdx
@@ -80,11 +80,11 @@ Jotai provides SWC plugins for better DX while developing with Next.js. [Find mo
 
 #### Clock
 
-<CodeSandbox id="snu7n" />
+<Stackblitz id="stackblitz-starters-nsugnt" file="store%2Findex.ts,components%2FClock.tsx" />
 
 #### HN Posts
 
-<CodeSandbox id="819n4" />
+<Stackblitz id="stackblitz-starters-cnz9lg" file="store%2Findex.ts,pages%2F_app.tsx,pages%2Findex.tsx" />
 
 #### Next.js repo
 

--- a/docs/guides/nextjs.mdx
+++ b/docs/guides/nextjs.mdx
@@ -80,11 +80,17 @@ Jotai provides SWC plugins for better DX while developing with Next.js. [Find mo
 
 #### Clock
 
-<Stackblitz id="stackblitz-starters-nsugnt" file="store%2Findex.ts,components%2FClock.tsx" />
+<Stackblitz
+  id="stackblitz-starters-nsugnt"
+  file="store%2Findex.ts,components%2FClock.tsx"
+/>
 
 #### HN Posts
 
-<Stackblitz id="stackblitz-starters-cnz9lg" file="store%2Findex.ts,pages%2F_app.tsx,pages%2Findex.tsx" />
+<Stackblitz
+  id="stackblitz-starters-cnz9lg"
+  file="store%2Findex.ts,pages%2F_app.tsx,pages%2Findex.tsx"
+/>
 
 #### Next.js repo
 


### PR DESCRIPTION
## Summary

Migrate Codesandbox demo embeds in Next.js page to Stackblitz

- Clock demo: https://stackblitz.com/edit/stackblitz-starters-nsugnt
- HN demo: https://stackblitz.com/edit/stackblitz-starters-cnz9lg

## Check List

- [x] `yarn run prettier` for formatting code and docs
