### PR TITLE
refactor: avoid extra rerender

### DIFF
--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -94,7 +94,6 @@ export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
       }
       rerender()
     })
-    rerender()
     return unsub
   }, [store, atom, delay])
 


### PR DESCRIPTION
## Summary
useAtomValue called rerender inside useEffect, which led to an additional render, and this PR optimized that performance issue.


## Check List

- [x] `yarn run prettier` for formatting code and docs
