### PR TITLE
chore(tests): fix useAtom and useSetAtom type tests

### DIFF
--- a/tests/react/types.test.tsx
+++ b/tests/react/types.test.tsx
@@ -1,7 +1,7 @@
 import { expectType } from 'ts-expect'
 import type { TypeEqual } from 'ts-expect'
 import { it } from 'vitest'
-import { useAtom } from 'jotai/react'
+import { useAtom, useSetAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
 
 it('useAtom should return the correct types', () => {
@@ -42,9 +42,30 @@ it('useAtom should handle inference of atoms (#1831 #1387)', () => {
     return useAtom(fieldAtoms[prop])
   }
   function Component() {
-    expectType<[string, (arg: string) => void]>(useField('username'))
-    expectType<[number, (arg: number) => void]>(useField('age'))
-    expectType<[boolean, (arg: boolean) => void]>(useField('checked'))
+    const [username, setUsername] = useField('username')
+    expectType<TypeEqual<string, typeof username>>(true)
+    expectType<
+      TypeEqual<
+        (arg: string | ((prev: string) => string)) => void,
+        typeof setUsername
+      >
+    >(true)
+    const [age, setAge] = useField('age')
+    expectType<TypeEqual<number, typeof age>>(true)
+    expectType<
+      TypeEqual<
+        (arg: number | ((prev: number) => number)) => void,
+        typeof setAge
+      >
+    >(true)
+    const [checked, setChecked] = useField('checked')
+    expectType<TypeEqual<boolean, typeof checked>>(true)
+    expectType<
+      TypeEqual<
+        (arg: boolean | ((prev: boolean) => boolean)) => void,
+        typeof setChecked
+      >
+    >(true)
   }
   Component
 })
@@ -62,6 +83,41 @@ it('useAtom should handle inference of read-only atoms', () => {
     expectType<[string, never]>(useField('username'))
     expectType<[number, never]>(useField('age'))
     expectType<[boolean, never]>(useField('checked'))
+  }
+  Component
+})
+
+it('useSetAtom should handle inference of atoms', () => {
+  const fieldAtoms = {
+    username: atom(''),
+    age: atom(0),
+    checked: atom(false),
+  }
+  const useSetField = <T extends keyof typeof fieldAtoms>(prop: T) => {
+    return useSetAtom(fieldAtoms[prop])
+  }
+  function Component() {
+    const setUsername = useSetField('username')
+    expectType<
+      TypeEqual<
+        (arg: string | ((prev: string) => string)) => void,
+        typeof setUsername
+      >
+    >(true)
+    const setAge = useSetField('age')
+    expectType<
+      TypeEqual<
+        (arg: number | ((prev: number) => number)) => void,
+        typeof setAge
+      >
+    >(true)
+    const setChecked = useSetField('checked')
+    expectType<
+      TypeEqual<
+        (arg: boolean | ((prev: boolean) => boolean)) => void,
+        typeof setChecked
+      >
+    >(true)
   }
   Component
 })


### PR DESCRIPTION
`TypeEqual` util is required to test them properly.