### PR TITLE
fix: export SetAtom type

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -1,4 +1,4 @@
 export { Provider, useStore } from './react/Provider.ts'
 export { useAtomValue } from './react/useAtomValue.ts'
 export { useSetAtom } from './react/useSetAtom.ts'
-export { useAtom } from './react/useAtom.ts'
+export { useAtom, SetAtom } from './react/useAtom.ts'

--- a/src/react/useAtom.ts
+++ b/src/react/useAtom.ts
@@ -10,7 +10,7 @@ import type {
 import { useAtomValue } from './useAtomValue.ts'
 import { useSetAtom } from './useSetAtom.ts'
 
-type SetAtom<Args extends unknown[], Result> = (...args: Args) => Result
+export type SetAtom<Args extends unknown[], Result> = (...args: Args) => Result
 
 type Options = Parameters<typeof useAtomValue>[1]
 


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #

## Summary
When an attempt is made to use `SetAtom` type, TypeScript reports the following error:

```
Cannot find name 'SetAtom'.ts(2304)
type SetAtom = /*unresolved*/ any
```

Sample Code: 

```
import { SetStateAction, atom, useAtom } from 'jotai';

type ModalType = 'Home' | 'Status' | '';

interface UseModal {
  showModal: ModalType;
  setShowModal: SetAtom<[SetStateAction<ModalType>], void>;
}


const useModal = (): UseModal => {
  const [showModal, setShowModal] = useAtom(modalAtom);

  return { showModal, setShowModal };
};

export default useModal;
```

The solution to this problem was to create the following type.

```
type SetAtom<Args extends any[], Result> = (...args: Args) => Result;
```

So the code becomes.

```
import { SetStateAction, atom, useAtom } from 'jotai';

type ModalType = 'Home' | 'Status' | '';
type SetAtom<Args extends any[], Result> = (...args: Args) => Result;

interface UseModal {
  showModal: ModalType;
  setShowModal: SetAtom<[SetStateAction<ModalType>], void>;
}


const useModal = (): UseModal => {
  const [showModal, setShowModal] = useAtom(modalAtom);

  return { showModal, setShowModal };
};

export default useModal;
```

To fix this, I just exported the `SetAtom` type.

## Check List
- [x] `yarn run prettier` for formatting code and docs
