### PR TITLE
Revert "fix(vanilla): fix unexpected cache in jotai-scope (#2371)"

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -411,8 +411,7 @@ export const createStore = (): Store => {
       // If all dependencies haven't changed, we can use the cache.
       if (
         Array.from(atomState.d).every(([a, s]) => {
-          // we shouldn't use isSelfAtom. https://github.com/pmndrs/jotai/pull/2371
-          if (a === atom) {
+          if (isSelfAtom(atom, a)) {
             return true
           }
           const aState = readAtomState(a, force)


### PR DESCRIPTION
This reverts commit fdc2324f19d15827fcb2419279b6481f3fc5e9c0 #2371.

jotai-scope has got a new impl, so this might be correct, or not?