### PR TITLE
Fix #2581: subscribe method of createJSONStorage should only run in the client

### DIFF
--- a/src/vanilla/utils/atomWithStorage.ts
+++ b/src/vanilla/utils/atomWithStorage.ts
@@ -161,30 +161,34 @@ export function createJSONStorage<Value>(
         callback(newValue)
       })
 
-  let subscriber = getStringStorage()?.subscribe
   if (
-    !subscriber &&
     typeof window !== 'undefined' &&
-    typeof window.addEventListener === 'function' &&
-    window.Storage &&
-    getStringStorage() instanceof window.Storage
+    typeof window.addEventListener === 'function'
   ) {
-    subscriber = (key, callback) => {
-      const storageEventCallback = (e: StorageEvent) => {
-        if (e.storageArea === getStringStorage() && e.key === key) {
-          callback(e.newValue)
+    let subscriber = getStringStorage()?.subscribe
+    if (
+      !subscriber &&
+      window.Storage &&
+      getStringStorage() instanceof window.Storage
+    ) {
+      subscriber = (key, callback) => {
+        const storageEventCallback = (e: StorageEvent) => {
+          if (e.storageArea === getStringStorage() && e.key === key) {
+            callback(e.newValue)
+          }
+        }
+        window.addEventListener('storage', storageEventCallback)
+        return () => {
+          window.removeEventListener('storage', storageEventCallback)
         }
       }
-      window.addEventListener('storage', storageEventCallback)
-      return () => {
-        window.removeEventListener('storage', storageEventCallback)
-      }
+    }
+
+    if (subscriber) {
+      storage.subscribe = createHandleSubscribe(subscriber)
     }
   }
 
-  if (subscriber) {
-    storage.subscribe = createHandleSubscribe(subscriber)
-  }
   return storage
 }
 


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #2581

## Summary

Fixes some issues created by previous PR (#2539) subscribe method of createJSONStorage should only run in the client


## Check List

- [x] `pnpm run prettier` for formatting code and docs
