### PR TITLE
feat(store2): add dev4_get_mounted_atoms

### DIFF
--- a/src/vanilla/store2.ts
+++ b/src/vanilla/store2.ts
@@ -243,7 +243,7 @@ const flushPending = (pending: Pending) => {
 // for debugging purpose only
 type DevStoreRev4 = {
   dev4_get_internal_weak_map: () => WeakMap<AnyAtom, AtomState>
-  dev4_get_mounted_atoms: () => IterableIterator<AnyAtom>
+  dev4_get_mounted_atoms: () => Set<AnyAtom>
   dev4_restore_atoms: (values: Iterable<readonly [AnyAtom, AnyValue]>) => void
 }
 
@@ -688,7 +688,7 @@ export const createStore = (): Store => {
       sub: subscribeAtom,
       // store dev methods (these are tentative and subject to change without notice)
       dev4_get_internal_weak_map: () => atomStateMap,
-      dev4_get_mounted_atoms: () => debugMountedAtoms.values(),
+      dev4_get_mounted_atoms: () => debugMountedAtoms,
       dev4_restore_atoms: (values) => {
         const pending = createPending()
         for (const [atom, value] of values) {


### PR DESCRIPTION
## Summary
- Adds `dev4_get_mounted_atoms` to return Iterable list of mounted atoms


## Check List

- [x] `pnpm run prettier` for formatting code and docs
