### PR TITLE
[WIP] fix(core): expose unstable_resolve instead of unstable_is

### DIFF
--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -40,7 +40,6 @@ type OnMount<Args extends unknown[], Result> = <
 export interface Atom<Value> {
   toString: () => string
   read: Read<Value>
-  unstable_is?(a: Atom<unknown>): boolean
   debugLabel?: string
   /**
    * To ONLY be used by Jotai libraries to mark atoms as private. Subject to change.

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -148,6 +148,7 @@ type PrdStore = {
   ) => Result
   sub: (atom: AnyAtom, listener: () => void) => () => void
   unstable_resolve?: <A extends Atom<unknown>>(atom: A) => A
+  unstable_derive: () => Store
 }
 type Store = PrdStore & Partial<DevStoreRev2>
 
@@ -181,668 +182,677 @@ export const createStore = (): Store => {
     devListenersRev2 = new Set()
     mountedAtoms = new Set()
   }
+  const buildStore = (): Store => {
+    const resolveAtom = <A extends Atom<unknown>>(atom: A): A => {
+      return store.unstable_resolve?.(atom) ?? atom
+    }
 
-  const resolveAtom = <A extends Atom<unknown>>(atom: A): A => {
-    return store.unstable_resolve?.(atom) ?? atom
-  }
+    const getAtomState = <Value>(atom: Atom<Value>) =>
+      atomStateMap.get(atom) as AtomState<Value> | undefined
 
-  const getAtomState = <Value>(atom: Atom<Value>) =>
-    atomStateMap.get(atom) as AtomState<Value> | undefined
+    const addPendingDependent = (atom: AnyAtom, atomState: AtomState) => {
+      atomState.d.forEach((_, a) => {
+        if (!pendingMap.has(a)) {
+          const aState = getAtomState(a)
+          pendingMap.set(a, [aState, new Set()])
+          if (aState) {
+            addPendingDependent(a, aState)
+          }
+        }
+        pendingMap.get(a)![1].add(atom)
+      })
+    }
 
-  const addPendingDependent = (atom: AnyAtom, atomState: AtomState) => {
-    atomState.d.forEach((_, a) => {
-      if (!pendingMap.has(a)) {
-        const aState = getAtomState(a)
-        pendingMap.set(a, [aState, new Set()])
-        if (aState) {
-          addPendingDependent(a, aState)
+    const setAtomState = <Value>(
+      atom: Atom<Value>,
+      atomState: AtomState<Value>,
+    ): void => {
+      if (import.meta.env?.MODE !== 'production') {
+        Object.freeze(atomState)
+      }
+      const prevAtomState = getAtomState(atom)
+      atomStateMap.set(atom, atomState)
+      pendingStack[pendingStack.length - 1]?.add(atom)
+      if (!pendingMap.has(atom)) {
+        pendingMap.set(atom, [prevAtomState, new Set()])
+        addPendingDependent(atom, atomState)
+      }
+      if (hasPromiseAtomValue(prevAtomState)) {
+        const next =
+          'v' in atomState
+            ? atomState.v instanceof Promise
+              ? atomState.v
+              : Promise.resolve(atomState.v)
+            : Promise.reject(atomState.e)
+        if (prevAtomState.v !== next) {
+          cancelPromise(prevAtomState.v, next)
         }
       }
-      pendingMap.get(a)![1].add(atom)
-    })
-  }
+    }
 
-  const setAtomState = <Value>(
-    atom: Atom<Value>,
-    atomState: AtomState<Value>,
-  ): void => {
-    if (import.meta.env?.MODE !== 'production') {
-      Object.freeze(atomState)
-    }
-    const prevAtomState = getAtomState(atom)
-    atomStateMap.set(atom, atomState)
-    pendingStack[pendingStack.length - 1]?.add(atom)
-    if (!pendingMap.has(atom)) {
-      pendingMap.set(atom, [prevAtomState, new Set()])
-      addPendingDependent(atom, atomState)
-    }
-    if (hasPromiseAtomValue(prevAtomState)) {
-      const next =
-        'v' in atomState
-          ? atomState.v instanceof Promise
-            ? atomState.v
-            : Promise.resolve(atomState.v)
-          : Promise.reject(atomState.e)
-      if (prevAtomState.v !== next) {
-        cancelPromise(prevAtomState.v, next)
-      }
-    }
-  }
-
-  const updateDependencies = <Value>(
-    atom: Atom<Value>,
-    nextAtomState: AtomState<Value>,
-    nextDependencies: NextDependencies,
-    keepPreviousDependencies?: boolean,
-  ): void => {
-    const dependencies: Dependencies = new Map(
-      keepPreviousDependencies ? nextAtomState.d : null,
-    )
-    let changed = false
-    nextDependencies.forEach((aState, a) => {
-      if (!aState && a === atom) {
-        aState = nextAtomState
-      }
-      if (aState) {
-        dependencies.set(a, aState)
-        if (nextAtomState.d.get(a) !== aState) {
-          changed = true
-        }
-      } else if (import.meta.env?.MODE !== 'production') {
-        console.warn('[Bug] atom state not found')
-      }
-    })
-    if (changed || nextAtomState.d.size !== dependencies.size) {
-      nextAtomState.d = dependencies
-    }
-  }
-
-  const setAtomValue = <Value>(
-    atom: Atom<Value>,
-    value: Value,
-    nextDependencies?: NextDependencies,
-    keepPreviousDependencies?: boolean,
-  ): AtomState<Value> => {
-    const prevAtomState = getAtomState(atom)
-    const nextAtomState: AtomState<Value> = {
-      d: prevAtomState?.d || new Map(),
-      v: value,
-    }
-    if (nextDependencies) {
-      updateDependencies(
-        atom,
-        nextAtomState,
-        nextDependencies,
-        keepPreviousDependencies,
+    const updateDependencies = <Value>(
+      atom: Atom<Value>,
+      nextAtomState: AtomState<Value>,
+      nextDependencies: NextDependencies,
+      keepPreviousDependencies?: boolean,
+    ): void => {
+      const dependencies: Dependencies = new Map(
+        keepPreviousDependencies ? nextAtomState.d : null,
       )
+      let changed = false
+      nextDependencies.forEach((aState, a) => {
+        if (!aState && a === atom) {
+          aState = nextAtomState
+        }
+        if (aState) {
+          dependencies.set(a, aState)
+          if (nextAtomState.d.get(a) !== aState) {
+            changed = true
+          }
+        } else if (import.meta.env?.MODE !== 'production') {
+          console.warn('[Bug] atom state not found')
+        }
+      })
+      if (changed || nextAtomState.d.size !== dependencies.size) {
+        nextAtomState.d = dependencies
+      }
     }
-    if (
-      isEqualAtomValue(prevAtomState, nextAtomState) &&
-      prevAtomState.d === nextAtomState.d
-    ) {
-      // bail out
-      return prevAtomState
-    }
-    if (
-      hasPromiseAtomValue(prevAtomState) &&
-      hasPromiseAtomValue(nextAtomState) &&
-      isEqualPromiseAtomValue(prevAtomState, nextAtomState)
-    ) {
-      if (prevAtomState.d === nextAtomState.d) {
+
+    const setAtomValue = <Value>(
+      atom: Atom<Value>,
+      value: Value,
+      nextDependencies?: NextDependencies,
+      keepPreviousDependencies?: boolean,
+    ): AtomState<Value> => {
+      const prevAtomState = getAtomState(atom)
+      const nextAtomState: AtomState<Value> = {
+        d: prevAtomState?.d || new Map(),
+        v: value,
+      }
+      if (nextDependencies) {
+        updateDependencies(
+          atom,
+          nextAtomState,
+          nextDependencies,
+          keepPreviousDependencies,
+        )
+      }
+      if (
+        isEqualAtomValue(prevAtomState, nextAtomState) &&
+        prevAtomState.d === nextAtomState.d
+      ) {
         // bail out
         return prevAtomState
-      } else {
-        // restore the wrapped promise
-        nextAtomState.v = prevAtomState.v
+      }
+      if (
+        hasPromiseAtomValue(prevAtomState) &&
+        hasPromiseAtomValue(nextAtomState) &&
+        isEqualPromiseAtomValue(prevAtomState, nextAtomState)
+      ) {
+        if (prevAtomState.d === nextAtomState.d) {
+          // bail out
+          return prevAtomState
+        } else {
+          // restore the wrapped promise
+          nextAtomState.v = prevAtomState.v
+        }
+      }
+      setAtomState(atom, nextAtomState)
+      return nextAtomState
+    }
+
+    const setAtomValueOrPromise = <Value>(
+      atom: Atom<Value>,
+      valueOrPromise: Value,
+      nextDependencies?: NextDependencies,
+      abortPromise?: () => void,
+    ): AtomState<Value> => {
+      if (isPromiseLike(valueOrPromise)) {
+        let continuePromise: (next: Promise<Awaited<Value>>) => void
+        const updatePromiseDependencies = () => {
+          const prevAtomState = getAtomState(atom)
+          if (
+            !hasPromiseAtomValue(prevAtomState) ||
+            prevAtomState.v !== promise
+          ) {
+            // not the latest promise
+            return
+          }
+          // update dependencies, that could have changed
+          const nextAtomState = setAtomValue(
+            atom,
+            promise as Value,
+            nextDependencies,
+          )
+          if (mountedMap.has(atom) && prevAtomState.d !== nextAtomState.d) {
+            mountDependencies(atom, nextAtomState, prevAtomState.d)
+          }
+        }
+        const promise: Promise<Awaited<Value>> & PromiseMeta<Awaited<Value>> =
+          new Promise((resolve, reject) => {
+            let settled = false
+            valueOrPromise.then(
+              (v) => {
+                if (!settled) {
+                  settled = true
+                  resolvePromise(promise, v)
+                  resolve(v as Awaited<Value>)
+                  updatePromiseDependencies()
+                }
+              },
+              (e) => {
+                if (!settled) {
+                  settled = true
+                  rejectPromise(promise, e)
+                  reject(e)
+                  updatePromiseDependencies()
+                }
+              },
+            )
+            continuePromise = (next) => {
+              if (!settled) {
+                settled = true
+                next.then(
+                  (v) => resolvePromise(promise, v),
+                  (e) => rejectPromise(promise, e),
+                )
+                resolve(next)
+              }
+            }
+          })
+        promise.orig = valueOrPromise as PromiseLike<Awaited<Value>>
+        promise.status = 'pending'
+        registerCancelPromise(promise, (next) => {
+          if (next) {
+            continuePromise(next as Promise<Awaited<Value>>)
+          }
+          abortPromise?.()
+        })
+        return setAtomValue(atom, promise as Value, nextDependencies, true)
+      }
+      return setAtomValue(atom, valueOrPromise, nextDependencies)
+    }
+
+    const setAtomError = <Value>(
+      atom: Atom<Value>,
+      error: AnyError,
+      nextDependencies?: NextDependencies,
+    ): AtomState<Value> => {
+      const prevAtomState = getAtomState(atom)
+      const nextAtomState: AtomState<Value> = {
+        d: prevAtomState?.d || new Map(),
+        e: error,
+      }
+      if (nextDependencies) {
+        updateDependencies(atom, nextAtomState, nextDependencies)
+      }
+      if (
+        isEqualAtomError(prevAtomState, nextAtomState) &&
+        prevAtomState.d === nextAtomState.d
+      ) {
+        // bail out
+        return prevAtomState
+      }
+      setAtomState(atom, nextAtomState)
+      return nextAtomState
+    }
+
+    const readAtomState = <Value>(
+      atom: Atom<Value>,
+      force?: (a: AnyAtom) => boolean,
+    ): AtomState<Value> => {
+      // See if we can skip recomputing this atom.
+      const atomState = getAtomState(atom)
+      if (!force?.(atom) && atomState) {
+        // If the atom is mounted, we can use the cache.
+        // because it should have been updated by dependencies.
+        if (mountedMap.has(atom)) {
+          return atomState
+        }
+        // Otherwise, check if the dependencies have changed.
+        // If all dependencies haven't changed, we can use the cache.
+        if (
+          Array.from(atomState.d).every(([a, s]) => {
+            if (a === atom) {
+              return true
+            }
+            const aState = readAtomState(a, force)
+            // Check if the atom state is unchanged, or
+            // check the atom value in case only dependencies are changed
+            return aState === s || isEqualAtomValue(aState, s)
+          })
+        ) {
+          return atomState
+        }
+      }
+      // Compute a new state for this atom.
+      const nextDependencies: NextDependencies = new Map()
+      let isSync = true
+      const getter: Getter = <V>(a: Atom<V>) => {
+        const resolvedA = resolveAtom(a)
+        if (resolvedA === (atom as AnyAtom)) {
+          const aState = getAtomState(resolvedA)
+          if (aState) {
+            nextDependencies.set(resolvedA, aState)
+            return returnAtomValue(aState)
+          }
+          if (hasInitialValue(resolvedA)) {
+            nextDependencies.set(resolvedA, undefined)
+            return resolvedA.init
+          }
+          // NOTE invalid derived atoms can reach here
+          throw new Error('no atom init')
+        }
+        // resolvedA !== atom
+        const aState = readAtomState(resolvedA, force)
+        nextDependencies.set(resolvedA, aState)
+        return returnAtomValue(aState)
+      }
+      let controller: AbortController | undefined
+      let setSelf: ((...args: unknown[]) => unknown) | undefined
+      const options = {
+        get signal() {
+          if (!controller) {
+            controller = new AbortController()
+          }
+          return controller.signal
+        },
+        get setSelf() {
+          if (
+            import.meta.env?.MODE !== 'production' &&
+            !isActuallyWritableAtom(atom)
+          ) {
+            console.warn('setSelf function cannot be used with read-only atom')
+          }
+          if (!setSelf && isActuallyWritableAtom(atom)) {
+            setSelf = (...args) => {
+              if (import.meta.env?.MODE !== 'production' && isSync) {
+                console.warn('setSelf function cannot be called in sync')
+              }
+              if (!isSync) {
+                return writeAtom(atom, ...args)
+              }
+            }
+          }
+          return setSelf
+        },
+      }
+      try {
+        const valueOrPromise = atom.read(getter, options as never)
+        return setAtomValueOrPromise(
+          atom,
+          valueOrPromise,
+          nextDependencies,
+          () => controller?.abort(),
+        )
+      } catch (error) {
+        return setAtomError(atom, error, nextDependencies)
+      } finally {
+        isSync = false
       }
     }
-    setAtomState(atom, nextAtomState)
-    return nextAtomState
-  }
 
-  const setAtomValueOrPromise = <Value>(
-    atom: Atom<Value>,
-    valueOrPromise: Value,
-    nextDependencies?: NextDependencies,
-    abortPromise?: () => void,
-  ): AtomState<Value> => {
-    if (isPromiseLike(valueOrPromise)) {
-      let continuePromise: (next: Promise<Awaited<Value>>) => void
-      const updatePromiseDependencies = () => {
-        const prevAtomState = getAtomState(atom)
-        if (
-          !hasPromiseAtomValue(prevAtomState) ||
-          prevAtomState.v !== promise
-        ) {
-          // not the latest promise
+    const readAtom = <Value>(atom: Atom<Value>): Value =>
+      returnAtomValue(readAtomState(resolveAtom(atom)))
+
+    const recomputeDependents = (atom: AnyAtom): void => {
+      const getDependents = (a: AnyAtom): Dependents => {
+        const dependents = new Set(mountedMap.get(a)?.t)
+        pendingMap.get(a)?.[1].forEach((dependent) => {
+          dependents.add(dependent)
+        })
+        return dependents
+      }
+
+      // This is a topological sort via depth-first search, slightly modified from
+      // what's described here for simplicity and performance reasons:
+      // https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search
+
+      // Step 1: traverse the dependency graph to build the topsorted atom list
+      // We don't bother to check for cycles, which simplifies the algorithm.
+      const topsortedAtoms = new Array<AnyAtom>()
+      const markedAtoms = new Set<AnyAtom>()
+      const visit = (n: AnyAtom) => {
+        if (markedAtoms.has(n)) {
           return
         }
-        // update dependencies, that could have changed
-        const nextAtomState = setAtomValue(
-          atom,
-          promise as Value,
-          nextDependencies,
-        )
-        if (mountedMap.has(atom) && prevAtomState.d !== nextAtomState.d) {
-          mountDependencies(atom, nextAtomState, prevAtomState.d)
-        }
-      }
-      const promise: Promise<Awaited<Value>> & PromiseMeta<Awaited<Value>> =
-        new Promise((resolve, reject) => {
-          let settled = false
-          valueOrPromise.then(
-            (v) => {
-              if (!settled) {
-                settled = true
-                resolvePromise(promise, v)
-                resolve(v as Awaited<Value>)
-                updatePromiseDependencies()
-              }
-            },
-            (e) => {
-              if (!settled) {
-                settled = true
-                rejectPromise(promise, e)
-                reject(e)
-                updatePromiseDependencies()
-              }
-            },
-          )
-          continuePromise = (next) => {
-            if (!settled) {
-              settled = true
-              next.then(
-                (v) => resolvePromise(promise, v),
-                (e) => rejectPromise(promise, e),
-              )
-              resolve(next)
-            }
-          }
-        })
-      promise.orig = valueOrPromise as PromiseLike<Awaited<Value>>
-      promise.status = 'pending'
-      registerCancelPromise(promise, (next) => {
-        if (next) {
-          continuePromise(next as Promise<Awaited<Value>>)
-        }
-        abortPromise?.()
-      })
-      return setAtomValue(atom, promise as Value, nextDependencies, true)
-    }
-    return setAtomValue(atom, valueOrPromise, nextDependencies)
-  }
-
-  const setAtomError = <Value>(
-    atom: Atom<Value>,
-    error: AnyError,
-    nextDependencies?: NextDependencies,
-  ): AtomState<Value> => {
-    const prevAtomState = getAtomState(atom)
-    const nextAtomState: AtomState<Value> = {
-      d: prevAtomState?.d || new Map(),
-      e: error,
-    }
-    if (nextDependencies) {
-      updateDependencies(atom, nextAtomState, nextDependencies)
-    }
-    if (
-      isEqualAtomError(prevAtomState, nextAtomState) &&
-      prevAtomState.d === nextAtomState.d
-    ) {
-      // bail out
-      return prevAtomState
-    }
-    setAtomState(atom, nextAtomState)
-    return nextAtomState
-  }
-
-  const readAtomState = <Value>(
-    atom: Atom<Value>,
-    force?: (a: AnyAtom) => boolean,
-  ): AtomState<Value> => {
-    // See if we can skip recomputing this atom.
-    const atomState = getAtomState(atom)
-    if (!force?.(atom) && atomState) {
-      // If the atom is mounted, we can use the cache.
-      // because it should have been updated by dependencies.
-      if (mountedMap.has(atom)) {
-        return atomState
-      }
-      // Otherwise, check if the dependencies have changed.
-      // If all dependencies haven't changed, we can use the cache.
-      if (
-        Array.from(atomState.d).every(([a, s]) => {
-          if (a === atom) {
-            return true
-          }
-          const aState = readAtomState(a, force)
-          // Check if the atom state is unchanged, or
-          // check the atom value in case only dependencies are changed
-          return aState === s || isEqualAtomValue(aState, s)
-        })
-      ) {
-        return atomState
-      }
-    }
-    // Compute a new state for this atom.
-    const nextDependencies: NextDependencies = new Map()
-    let isSync = true
-    const getter: Getter = <V>(a: Atom<V>) => {
-      const resolvedA = resolveAtom(a)
-      if (resolvedA === (atom as AnyAtom)) {
-        const aState = getAtomState(resolvedA)
-        if (aState) {
-          nextDependencies.set(resolvedA, aState)
-          return returnAtomValue(aState)
-        }
-        if (hasInitialValue(resolvedA)) {
-          nextDependencies.set(resolvedA, undefined)
-          return resolvedA.init
-        }
-        // NOTE invalid derived atoms can reach here
-        throw new Error('no atom init')
-      }
-      // resolvedA !== atom
-      const aState = readAtomState(resolvedA, force)
-      nextDependencies.set(resolvedA, aState)
-      return returnAtomValue(aState)
-    }
-    let controller: AbortController | undefined
-    let setSelf: ((...args: unknown[]) => unknown) | undefined
-    const options = {
-      get signal() {
-        if (!controller) {
-          controller = new AbortController()
-        }
-        return controller.signal
-      },
-      get setSelf() {
-        if (
-          import.meta.env?.MODE !== 'production' &&
-          !isActuallyWritableAtom(atom)
-        ) {
-          console.warn('setSelf function cannot be used with read-only atom')
-        }
-        if (!setSelf && isActuallyWritableAtom(atom)) {
-          setSelf = (...args) => {
-            if (import.meta.env?.MODE !== 'production' && isSync) {
-              console.warn('setSelf function cannot be called in sync')
-            }
-            if (!isSync) {
-              return writeAtom(atom, ...args)
-            }
+        markedAtoms.add(n)
+        for (const m of getDependents(n)) {
+          if (n !== m) {
+            visit(m)
           }
         }
-        return setSelf
-      },
-    }
-    try {
-      const valueOrPromise = atom.read(getter, options as never)
-      return setAtomValueOrPromise(atom, valueOrPromise, nextDependencies, () =>
-        controller?.abort(),
-      )
-    } catch (error) {
-      return setAtomError(atom, error, nextDependencies)
-    } finally {
-      isSync = false
-    }
-  }
-
-  const readAtom = <Value>(atom: Atom<Value>): Value =>
-    returnAtomValue(readAtomState(resolveAtom(atom)))
-
-  const recomputeDependents = (atom: AnyAtom): void => {
-    const getDependents = (a: AnyAtom): Dependents => {
-      const dependents = new Set(mountedMap.get(a)?.t)
-      pendingMap.get(a)?.[1].forEach((dependent) => {
-        dependents.add(dependent)
-      })
-      return dependents
-    }
-
-    // This is a topological sort via depth-first search, slightly modified from
-    // what's described here for simplicity and performance reasons:
-    // https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search
-
-    // Step 1: traverse the dependency graph to build the topsorted atom list
-    // We don't bother to check for cycles, which simplifies the algorithm.
-    const topsortedAtoms = new Array<AnyAtom>()
-    const markedAtoms = new Set<AnyAtom>()
-    const visit = (n: AnyAtom) => {
-      if (markedAtoms.has(n)) {
-        return
+        // The algorithm calls for pushing onto the front of the list. For
+        // performance, we will simply push onto the end, and then will iterate in
+        // reverse order later.
+        topsortedAtoms.push(n)
       }
-      markedAtoms.add(n)
-      for (const m of getDependents(n)) {
-        if (n !== m) {
-          visit(m)
+
+      // Visit the root atom. This is the only atom in the dependency graph
+      // without incoming edges, which is one reason we can simplify the algorithm
+      visit(atom)
+
+      // Step 2: use the topsorted atom list to recompute all affected atoms
+      // Track what's changed, so that we can short circuit when possible
+      const changedAtoms = new Set<AnyAtom>([atom])
+      const isMarked = (a: AnyAtom) => markedAtoms.has(a)
+      for (let i = topsortedAtoms.length - 1; i >= 0; --i) {
+        const a = topsortedAtoms[i]!
+        const prevAtomState = getAtomState(a)
+        if (!prevAtomState) {
+          continue
         }
-      }
-      // The algorithm calls for pushing onto the front of the list. For
-      // performance, we will simply push onto the end, and then will iterate in
-      // reverse order later.
-      topsortedAtoms.push(n)
-    }
-
-    // Visit the root atom. This is the only atom in the dependency graph
-    // without incoming edges, which is one reason we can simplify the algorithm
-    visit(atom)
-
-    // Step 2: use the topsorted atom list to recompute all affected atoms
-    // Track what's changed, so that we can short circuit when possible
-    const changedAtoms = new Set<AnyAtom>([atom])
-    const isMarked = (a: AnyAtom) => markedAtoms.has(a)
-    for (let i = topsortedAtoms.length - 1; i >= 0; --i) {
-      const a = topsortedAtoms[i]!
-      const prevAtomState = getAtomState(a)
-      if (!prevAtomState) {
-        continue
-      }
-      let hasChangedDeps = false
-      for (const dep of prevAtomState.d.keys()) {
-        if (dep !== a && changedAtoms.has(dep)) {
-          hasChangedDeps = true
-          break
-        }
-      }
-      if (hasChangedDeps) {
-        const nextAtomState = readAtomState(a, isMarked)
-        addPendingDependent(a, nextAtomState)
-        if (!isEqualAtomValue(prevAtomState, nextAtomState)) {
-          changedAtoms.add(a)
-        }
-      }
-      markedAtoms.delete(a)
-    }
-  }
-
-  const writeAtomState = <Value, Args extends unknown[], Result>(
-    atom: WritableAtom<Value, Args, Result>,
-    ...args: Args
-  ): Result => {
-    const getter: Getter = <V>(a: Atom<V>) =>
-      returnAtomValue(readAtomState(resolveAtom(a)))
-    const setter: Setter = <V, As extends unknown[], R>(
-      a: WritableAtom<V, As, R>,
-      ...args: As
-    ) => {
-      const resolvedA = resolveAtom(a)
-      const isSync = pendingStack.length > 0
-      if (!isSync) {
-        pendingStack.push(new Set([resolvedA]))
-      }
-      let r: R | undefined
-      if (resolvedA === (atom as AnyAtom)) {
-        if (!hasInitialValue(resolvedA)) {
-          // NOTE technically possible but restricted as it may cause bugs
-          throw new Error('atom not writable')
-        }
-        const prevAtomState = getAtomState(resolvedA)
-        const nextAtomState = setAtomValueOrPromise(resolvedA, args[0] as V)
-        if (!isEqualAtomValue(prevAtomState, nextAtomState)) {
-          recomputeDependents(resolvedA)
-        }
-      } else {
-        r = writeAtomState(resolvedA as AnyWritableAtom, ...args) as R
-      }
-      if (!isSync) {
-        const flushed = flushPending(pendingStack.pop()!)
-        if (import.meta.env?.MODE !== 'production') {
-          devListenersRev2.forEach((l) =>
-            l({ type: 'async-write', flushed: flushed! }),
-          )
-        }
-      }
-      return r as R
-    }
-    const result = atom.write(getter, setter, ...args)
-    return result
-  }
-
-  const writeAtom = <Value, Args extends unknown[], Result>(
-    atom: WritableAtom<Value, Args, Result>,
-    ...args: Args
-  ): Result => {
-    const resolvedAtom = resolveAtom(atom)
-    pendingStack.push(new Set([resolvedAtom]))
-    const result = writeAtomState(resolvedAtom, ...args)
-
-    const flushed = flushPending(pendingStack.pop()!)
-    if (import.meta.env?.MODE !== 'production') {
-      devListenersRev2.forEach((l) => l({ type: 'write', flushed: flushed! }))
-    }
-    return result
-  }
-
-  const mountAtom = <Value>(
-    atom: Atom<Value>,
-    initialDependent?: AnyAtom,
-    onMountQueue?: (() => void)[],
-  ): Mounted => {
-    const existingMount = mountedMap.get(atom)
-    if (existingMount) {
-      if (initialDependent) {
-        existingMount.t.add(initialDependent)
-      }
-      return existingMount
-    }
-
-    const queue = onMountQueue || []
-    // mount dependencies before mounting self
-    getAtomState(atom)?.d.forEach((_, a) => {
-      if (a !== atom) {
-        mountAtom(a, atom, queue)
-      }
-    })
-    // recompute atom state
-    readAtomState(atom)
-    // mount self
-    const mounted: Mounted = {
-      t: new Set(initialDependent && [initialDependent]),
-      l: new Set(),
-    }
-    mountedMap.set(atom, mounted)
-    if (import.meta.env?.MODE !== 'production') {
-      mountedAtoms.add(atom)
-    }
-    // onMount
-    if (isActuallyWritableAtom(atom) && atom.onMount) {
-      const { onMount } = atom
-      queue.push(() => {
-        const onUnmount = onMount((...args) => writeAtom(atom, ...args))
-        if (onUnmount) {
-          mounted.u = onUnmount
-        }
-      })
-    }
-    if (!onMountQueue) {
-      queue.forEach((f) => f())
-    }
-    return mounted
-  }
-
-  // FIXME doesn't work with mutually dependent atoms
-  const canUnmountAtom = (atom: AnyAtom, mounted: Mounted) =>
-    !mounted.l.size &&
-    (!mounted.t.size || (mounted.t.size === 1 && mounted.t.has(atom)))
-
-  const tryUnmountAtom = <Value>(atom: Atom<Value>, mounted: Mounted): void => {
-    if (!canUnmountAtom(atom, mounted)) {
-      return
-    }
-    // unmount self
-    const onUnmount = mounted.u
-    if (onUnmount) {
-      onUnmount()
-    }
-    mountedMap.delete(atom)
-    if (import.meta.env?.MODE !== 'production') {
-      mountedAtoms.delete(atom)
-    }
-    // unmount dependencies afterward
-    const atomState = getAtomState(atom)
-    if (atomState) {
-      // cancel promise
-      if (hasPromiseAtomValue(atomState)) {
-        cancelPromise(atomState.v)
-      }
-      atomState.d.forEach((_, a) => {
-        if (a !== atom) {
-          const mountedDep = mountedMap.get(a)
-          if (mountedDep) {
-            mountedDep.t.delete(atom)
-            tryUnmountAtom(a, mountedDep)
+        let hasChangedDeps = false
+        for (const dep of prevAtomState.d.keys()) {
+          if (dep !== a && changedAtoms.has(dep)) {
+            hasChangedDeps = true
+            break
           }
         }
-      })
-    } else if (import.meta.env?.MODE !== 'production') {
-      console.warn('[Bug] could not find atom state to unmount', atom)
-    }
-  }
-
-  const mountDependencies = <Value>(
-    atom: Atom<Value>,
-    atomState: AtomState<Value>,
-    prevDependencies?: Dependencies,
-  ): void => {
-    const depSet = new Set(atomState.d.keys())
-    const maybeUnmountAtomSet = new Set<AnyAtom>()
-    prevDependencies?.forEach((_, a) => {
-      if (depSet.has(a)) {
-        // not changed
-        depSet.delete(a)
-        return
-      }
-      maybeUnmountAtomSet.add(a)
-      const mounted = mountedMap.get(a)
-      if (mounted) {
-        mounted.t.delete(atom) // delete from dependents
-      }
-    })
-    depSet.forEach((a) => {
-      mountAtom(a, atom)
-    })
-    maybeUnmountAtomSet.forEach((a) => {
-      const mounted = mountedMap.get(a)
-      if (mounted) {
-        tryUnmountAtom(a, mounted)
-      }
-    })
-  }
-
-  const flushPending = (
-    pendingAtoms: AnyAtom[] | Set<AnyAtom>,
-  ): void | Set<AnyAtom> => {
-    let flushed: Set<AnyAtom>
-    if (import.meta.env?.MODE !== 'production') {
-      flushed = new Set()
-    }
-    const pending: [AnyAtom, AtomState | undefined][] = []
-    const collectPending = (pendingAtom: AnyAtom) => {
-      if (!pendingMap.has(pendingAtom)) {
-        return
-      }
-      const [prevAtomState, dependents] = pendingMap.get(pendingAtom)!
-      pendingMap.delete(pendingAtom)
-      pending.push([pendingAtom, prevAtomState])
-      dependents.forEach(collectPending)
-      // FIXME might be better if we can avoid collecting from dependencies
-      getAtomState(pendingAtom)?.d.forEach((_, a) => collectPending(a))
-    }
-    pendingAtoms.forEach(collectPending)
-    pending.forEach(([atom, prevAtomState]) => {
-      const atomState = getAtomState(atom)
-      if (!atomState) {
-        if (import.meta.env?.MODE !== 'production') {
-          console.warn('[Bug] no atom state to flush')
+        if (hasChangedDeps) {
+          const nextAtomState = readAtomState(a, isMarked)
+          addPendingDependent(a, nextAtomState)
+          if (!isEqualAtomValue(prevAtomState, nextAtomState)) {
+            changedAtoms.add(a)
+          }
         }
-        return
+        markedAtoms.delete(a)
       }
-      if (atomState !== prevAtomState) {
-        const mounted = mountedMap.get(atom)
-        if (mounted && atomState.d !== prevAtomState?.d) {
-          mountDependencies(atom, atomState, prevAtomState?.d)
+    }
+
+    const writeAtomState = <Value, Args extends unknown[], Result>(
+      atom: WritableAtom<Value, Args, Result>,
+      ...args: Args
+    ): Result => {
+      const getter: Getter = <V>(a: Atom<V>) =>
+        returnAtomValue(readAtomState(resolveAtom(a)))
+      const setter: Setter = <V, As extends unknown[], R>(
+        a: WritableAtom<V, As, R>,
+        ...args: As
+      ) => {
+        const resolvedA = resolveAtom(a)
+        const isSync = pendingStack.length > 0
+        if (!isSync) {
+          pendingStack.push(new Set([resolvedA]))
         }
-        if (
-          mounted &&
-          !(
-            // TODO This seems pretty hacky. Hope to fix it.
-            // Maybe we could `mountDependencies` in `setAtomState`?
-            (
-              !hasPromiseAtomValue(prevAtomState) &&
-              (isEqualAtomValue(prevAtomState, atomState) ||
-                isEqualAtomError(prevAtomState, atomState))
-            )
-          )
-        ) {
-          mounted.l.forEach((listener) => listener())
+        let r: R | undefined
+        if (resolvedA === (atom as AnyAtom)) {
+          if (!hasInitialValue(resolvedA)) {
+            // NOTE technically possible but restricted as it may cause bugs
+            throw new Error('atom not writable')
+          }
+          const prevAtomState = getAtomState(resolvedA)
+          const nextAtomState = setAtomValueOrPromise(resolvedA, args[0] as V)
+          if (!isEqualAtomValue(prevAtomState, nextAtomState)) {
+            recomputeDependents(resolvedA)
+          }
+        } else {
+          r = writeAtomState(resolvedA as AnyWritableAtom, ...args) as R
+        }
+        if (!isSync) {
+          const flushed = flushPending(pendingStack.pop()!)
           if (import.meta.env?.MODE !== 'production') {
-            flushed.add(atom)
+            devListenersRev2.forEach((l) =>
+              l({ type: 'async-write', flushed: flushed! }),
+            )
           }
         }
+        return r as R
       }
-    })
-    if (import.meta.env?.MODE !== 'production') {
-      // @ts-expect-error Variable 'flushed' is used before being assigned.
-      return flushed
+      const result = atom.write(getter, setter, ...args)
+      return result
     }
-  }
 
-  const subscribeAtom = (atom: AnyAtom, listener: () => void) => {
-    const resolvedAtom = resolveAtom(atom)
-    const mounted = mountAtom(resolvedAtom)
-    const flushed = flushPending([resolvedAtom])
-    const listeners = mounted.l
-    listeners.add(listener)
-    if (import.meta.env?.MODE !== 'production') {
-      devListenersRev2.forEach((l) =>
-        l({ type: 'sub', flushed: flushed as Set<AnyAtom> }),
-      )
-    }
-    return () => {
-      listeners.delete(listener)
-      tryUnmountAtom(resolvedAtom, mounted)
+    const writeAtom = <Value, Args extends unknown[], Result>(
+      atom: WritableAtom<Value, Args, Result>,
+      ...args: Args
+    ): Result => {
+      const resolvedAtom = resolveAtom(atom)
+      pendingStack.push(new Set([resolvedAtom]))
+      const result = writeAtomState(resolvedAtom, ...args)
+
+      const flushed = flushPending(pendingStack.pop()!)
       if (import.meta.env?.MODE !== 'production') {
-        // devtools uses this to detect if it _can_ unmount or not
-        devListenersRev2.forEach((l) => l({ type: 'unsub' }))
+        devListenersRev2.forEach((l) => l({ type: 'write', flushed: flushed! }))
+      }
+      return result
+    }
+
+    const mountAtom = <Value>(
+      atom: Atom<Value>,
+      initialDependent?: AnyAtom,
+      onMountQueue?: (() => void)[],
+    ): Mounted => {
+      const existingMount = mountedMap.get(atom)
+      if (existingMount) {
+        if (initialDependent) {
+          existingMount.t.add(initialDependent)
+        }
+        return existingMount
+      }
+
+      const queue = onMountQueue || []
+      // mount dependencies before mounting self
+      getAtomState(atom)?.d.forEach((_, a) => {
+        if (a !== atom) {
+          mountAtom(a, atom, queue)
+        }
+      })
+      // recompute atom state
+      readAtomState(atom)
+      // mount self
+      const mounted: Mounted = {
+        t: new Set(initialDependent && [initialDependent]),
+        l: new Set(),
+      }
+      mountedMap.set(atom, mounted)
+      if (import.meta.env?.MODE !== 'production') {
+        mountedAtoms.add(atom)
+      }
+      // onMount
+      if (isActuallyWritableAtom(atom) && atom.onMount) {
+        const { onMount } = atom
+        queue.push(() => {
+          const onUnmount = onMount((...args) => writeAtom(atom, ...args))
+          if (onUnmount) {
+            mounted.u = onUnmount
+          }
+        })
+      }
+      if (!onMountQueue) {
+        queue.forEach((f) => f())
+      }
+      return mounted
+    }
+
+    // FIXME doesn't work with mutually dependent atoms
+    const canUnmountAtom = (atom: AnyAtom, mounted: Mounted) =>
+      !mounted.l.size &&
+      (!mounted.t.size || (mounted.t.size === 1 && mounted.t.has(atom)))
+
+    const tryUnmountAtom = <Value>(
+      atom: Atom<Value>,
+      mounted: Mounted,
+    ): void => {
+      if (!canUnmountAtom(atom, mounted)) {
+        return
+      }
+      // unmount self
+      const onUnmount = mounted.u
+      if (onUnmount) {
+        onUnmount()
+      }
+      mountedMap.delete(atom)
+      if (import.meta.env?.MODE !== 'production') {
+        mountedAtoms.delete(atom)
+      }
+      // unmount dependencies afterward
+      const atomState = getAtomState(atom)
+      if (atomState) {
+        // cancel promise
+        if (hasPromiseAtomValue(atomState)) {
+          cancelPromise(atomState.v)
+        }
+        atomState.d.forEach((_, a) => {
+          if (a !== atom) {
+            const mountedDep = mountedMap.get(a)
+            if (mountedDep) {
+              mountedDep.t.delete(atom)
+              tryUnmountAtom(a, mountedDep)
+            }
+          }
+        })
+      } else if (import.meta.env?.MODE !== 'production') {
+        console.warn('[Bug] could not find atom state to unmount', atom)
       }
     }
-  }
 
-  const store: Store = {
-    get: readAtom,
-    set: writeAtom,
-    sub: subscribeAtom,
-  }
-  if (import.meta.env?.MODE !== 'production') {
-    const devStore: DevStoreRev2 = {
-      // store dev methods (these are tentative and subject to change without notice)
-      dev_subscribe_store: (l) => {
-        devListenersRev2.add(l)
-        return () => {
-          devListenersRev2.delete(l)
+    const mountDependencies = <Value>(
+      atom: Atom<Value>,
+      atomState: AtomState<Value>,
+      prevDependencies?: Dependencies,
+    ): void => {
+      const depSet = new Set(atomState.d.keys())
+      const maybeUnmountAtomSet = new Set<AnyAtom>()
+      prevDependencies?.forEach((_, a) => {
+        if (depSet.has(a)) {
+          // not changed
+          depSet.delete(a)
+          return
         }
-      },
-      dev_get_mounted_atoms: () => mountedAtoms.values(),
-      dev_get_atom_state: getAtomState,
-      dev_get_mounted: (a) => mountedMap.get(a),
-      dev_restore_atoms: (values) => {
-        pendingStack.push(new Set())
-        for (const [atom, valueOrPromise] of values) {
-          if (hasInitialValue(atom)) {
-            setAtomValueOrPromise(atom, valueOrPromise)
-            recomputeDependents(atom)
+        maybeUnmountAtomSet.add(a)
+        const mounted = mountedMap.get(a)
+        if (mounted) {
+          mounted.t.delete(atom) // delete from dependents
+        }
+      })
+      depSet.forEach((a) => {
+        mountAtom(a, atom)
+      })
+      maybeUnmountAtomSet.forEach((a) => {
+        const mounted = mountedMap.get(a)
+        if (mounted) {
+          tryUnmountAtom(a, mounted)
+        }
+      })
+    }
+
+    const flushPending = (
+      pendingAtoms: AnyAtom[] | Set<AnyAtom>,
+    ): void | Set<AnyAtom> => {
+      let flushed: Set<AnyAtom>
+      if (import.meta.env?.MODE !== 'production') {
+        flushed = new Set()
+      }
+      const pending: [AnyAtom, AtomState | undefined][] = []
+      const collectPending = (pendingAtom: AnyAtom) => {
+        if (!pendingMap.has(pendingAtom)) {
+          return
+        }
+        const [prevAtomState, dependents] = pendingMap.get(pendingAtom)!
+        pendingMap.delete(pendingAtom)
+        pending.push([pendingAtom, prevAtomState])
+        dependents.forEach(collectPending)
+        // FIXME might be better if we can avoid collecting from dependencies
+        getAtomState(pendingAtom)?.d.forEach((_, a) => collectPending(a))
+      }
+      pendingAtoms.forEach(collectPending)
+      pending.forEach(([atom, prevAtomState]) => {
+        const atomState = getAtomState(atom)
+        if (!atomState) {
+          if (import.meta.env?.MODE !== 'production') {
+            console.warn('[Bug] no atom state to flush')
+          }
+          return
+        }
+        if (atomState !== prevAtomState) {
+          const mounted = mountedMap.get(atom)
+          if (mounted && atomState.d !== prevAtomState?.d) {
+            mountDependencies(atom, atomState, prevAtomState?.d)
+          }
+          if (
+            mounted &&
+            !(
+              // TODO This seems pretty hacky. Hope to fix it.
+              // Maybe we could `mountDependencies` in `setAtomState`?
+              (
+                !hasPromiseAtomValue(prevAtomState) &&
+                (isEqualAtomValue(prevAtomState, atomState) ||
+                  isEqualAtomError(prevAtomState, atomState))
+              )
+            )
+          ) {
+            mounted.l.forEach((listener) => listener())
+            if (import.meta.env?.MODE !== 'production') {
+              flushed.add(atom)
+            }
           }
         }
-        const flushed = flushPending(pendingStack.pop()!)
-        devListenersRev2.forEach((l) =>
-          l({ type: 'restore', flushed: flushed! }),
-        )
-      },
+      })
+      if (import.meta.env?.MODE !== 'production') {
+        // @ts-expect-error Variable 'flushed' is used before being assigned.
+        return flushed
+      }
     }
-    Object.assign(store, devStore)
+
+    const subscribeAtom = (atom: AnyAtom, listener: () => void) => {
+      const resolvedAtom = resolveAtom(atom)
+      const mounted = mountAtom(resolvedAtom)
+      const flushed = flushPending([resolvedAtom])
+      const listeners = mounted.l
+      listeners.add(listener)
+      if (import.meta.env?.MODE !== 'production') {
+        devListenersRev2.forEach((l) =>
+          l({ type: 'sub', flushed: flushed as Set<AnyAtom> }),
+        )
+      }
+      return () => {
+        listeners.delete(listener)
+        tryUnmountAtom(resolvedAtom, mounted)
+        if (import.meta.env?.MODE !== 'production') {
+          // devtools uses this to detect if it _can_ unmount or not
+          devListenersRev2.forEach((l) => l({ type: 'unsub' }))
+        }
+      }
+    }
+
+    const store: Store = {
+      get: readAtom,
+      set: writeAtom,
+      sub: subscribeAtom,
+      unstable_derive: buildStore,
+    }
+    if (import.meta.env?.MODE !== 'production') {
+      const devStore: DevStoreRev2 = {
+        // store dev methods (these are tentative and subject to change without notice)
+        dev_subscribe_store: (l) => {
+          devListenersRev2.add(l)
+          return () => {
+            devListenersRev2.delete(l)
+          }
+        },
+        dev_get_mounted_atoms: () => mountedAtoms.values(),
+        dev_get_atom_state: getAtomState,
+        dev_get_mounted: (a) => mountedMap.get(a),
+        dev_restore_atoms: (values) => {
+          pendingStack.push(new Set())
+          for (const [atom, valueOrPromise] of values) {
+            if (hasInitialValue(atom)) {
+              setAtomValueOrPromise(atom, valueOrPromise)
+              recomputeDependents(atom)
+            }
+          }
+          const flushed = flushPending(pendingStack.pop()!)
+          devListenersRev2.forEach((l) =>
+            l({ type: 'restore', flushed: flushed! }),
+          )
+        },
+      }
+      Object.assign(store, devStore)
+    }
+    return store
   }
-  return store as Store
+  return buildStore()
 }
 
 let defaultStore: Store | undefined

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -8,9 +8,6 @@ type OnUnmount = () => void
 type Getter = Parameters<AnyAtom['read']>[0]
 type Setter = Parameters<AnyWritableAtom['write']>[1]
 
-const isSelfAtom = (atom: AnyAtom, a: AnyAtom): boolean =>
-  atom.unstable_is ? atom.unstable_is(a) : a === atom
-
 const hasInitialValue = <T extends Atom<AnyValue>>(
   atom: T,
 ): atom is T & (T extends Atom<infer Value> ? { init: Value } : never) =>
@@ -150,6 +147,7 @@ type PrdStore = {
     ...args: Args
   ) => Result
   sub: (atom: AnyAtom, listener: () => void) => () => void
+  unstable_resolve?: <Value>(atom: Atom<Value>) => Atom<Value>
 }
 type Store = PrdStore & Partial<DevStoreRev2>
 
@@ -183,6 +181,9 @@ export const createStore = (): Store => {
     devListenersRev2 = new Set()
     mountedAtoms = new Set()
   }
+
+  const resolveAtom = <Value>(atom: Atom<Value>) =>
+    store.unstable_resolve?.(atom) || atom
 
   const getAtomState = <Value>(atom: Atom<Value>) =>
     atomStateMap.get(atom) as AtomState<Value> | undefined
@@ -238,7 +239,7 @@ export const createStore = (): Store => {
     )
     let changed = false
     nextDependencies.forEach((aState, a) => {
-      if (!aState && isSelfAtom(atom, a)) {
+      if (!aState && a === resolveAtom(atom)) {
         aState = nextAtomState
       }
       if (aState) {
@@ -410,8 +411,7 @@ export const createStore = (): Store => {
       // If all dependencies haven't changed, we can use the cache.
       if (
         Array.from(atomState.d).every(([a, s]) => {
-          // we shouldn't use isSelfAtom. https://github.com/pmndrs/jotai/pull/2371
-          if (a === atom) {
+          if (a === resolveAtom(atom)) {
             return true
           }
           const aState = readAtomState(a, force)
@@ -427,7 +427,7 @@ export const createStore = (): Store => {
     const nextDependencies: NextDependencies = new Map()
     let isSync = true
     const getter: Getter = <V>(a: Atom<V>) => {
-      if (isSelfAtom(atom, a)) {
+      if (a === resolveAtom(atom as AnyAtom)) {
         const aState = getAtomState(a)
         if (aState) {
           nextDependencies.set(a, aState)
@@ -512,7 +512,6 @@ export const createStore = (): Store => {
       }
       markedAtoms.add(n)
       for (const m of getDependents(n)) {
-        // we shouldn't use isSelfAtom here.
         if (n !== m) {
           visit(m)
         }
@@ -569,7 +568,7 @@ export const createStore = (): Store => {
         pendingStack.push(new Set([a]))
       }
       let r: R | undefined
-      if (isSelfAtom(atom, a)) {
+      if (a === resolveAtom(atom as AnyAtom)) {
         if (!hasInitialValue(a)) {
           // NOTE technically possible but restricted as it may cause bugs
           throw new Error('atom not writable')
@@ -803,41 +802,44 @@ export const createStore = (): Store => {
     }
   }
 
-  if (import.meta.env?.MODE !== 'production') {
-    return {
-      get: readAtom,
-      set: writeAtom,
-      sub: subscribeAtom,
-      // store dev methods (these are tentative and subject to change without notice)
-      dev_subscribe_store: (l) => {
-        devListenersRev2.add(l)
-        return () => {
-          devListenersRev2.delete(l)
+  const store: Store =
+    import.meta.env?.MODE !== 'production'
+      ? {
+          get: readAtom,
+          set: writeAtom,
+          sub: subscribeAtom,
+          // store dev methods (these are tentative and subject to change without notice)
+          dev_subscribe_store: (l: DevListenerRev2) => {
+            devListenersRev2.add(l)
+            return () => {
+              devListenersRev2.delete(l)
+            }
+          },
+          dev_get_mounted_atoms: () => mountedAtoms.values(),
+          dev_get_atom_state: (a: AnyAtom) => atomStateMap.get(a),
+          dev_get_mounted: (a: AnyAtom) => mountedMap.get(a),
+          dev_restore_atoms: (
+            values: Iterable<readonly [AnyAtom, AnyValue]>,
+          ) => {
+            pendingStack.push(new Set())
+            for (const [atom, valueOrPromise] of values) {
+              if (hasInitialValue(atom)) {
+                setAtomValueOrPromise(atom, valueOrPromise)
+                recomputeDependents(atom)
+              }
+            }
+            const flushed = flushPending(pendingStack.pop()!)
+            devListenersRev2.forEach((l) =>
+              l({ type: 'restore', flushed: flushed! }),
+            )
+          },
         }
-      },
-      dev_get_mounted_atoms: () => mountedAtoms.values(),
-      dev_get_atom_state: (a) => atomStateMap.get(a),
-      dev_get_mounted: (a) => mountedMap.get(a),
-      dev_restore_atoms: (values) => {
-        pendingStack.push(new Set())
-        for (const [atom, valueOrPromise] of values) {
-          if (hasInitialValue(atom)) {
-            setAtomValueOrPromise(atom, valueOrPromise)
-            recomputeDependents(atom)
-          }
+      : {
+          get: readAtom,
+          set: writeAtom,
+          sub: subscribeAtom,
         }
-        const flushed = flushPending(pendingStack.pop()!)
-        devListenersRev2.forEach((l) =>
-          l({ type: 'restore', flushed: flushed! }),
-        )
-      },
-    }
-  }
-  return {
-    get: readAtom,
-    set: writeAtom,
-    sub: subscribeAtom,
-  }
+  return store
 }
 
 let defaultStore: Store | undefined

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -491,6 +491,7 @@ export const createStore = (): Store => {
 
   const recomputeDependents = (atom: AnyAtom): void => {
     const getDependents = (a: AnyAtom): Dependents => {
+      a = resolveAtom(a) // not sure if this is correct
       const dependents = new Set(mountedMap.get(a)?.t)
       pendingMap.get(a)?.[1].forEach((dependent) => {
         dependents.add(dependent)

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -182,11 +182,10 @@ export const createStore = (): Store => {
     mountedAtoms = new Set()
   }
 
-  const resolveAtom = <Value>(atom: Atom<Value>) =>
-    store.unstable_resolve?.(atom) || atom
-
   const getAtomState = <Value>(atom: Atom<Value>) =>
-    atomStateMap.get(atom) as AtomState<Value> | undefined
+    atomStateMap.get(store.unstable_resolve?.(atom) || atom) as
+      | AtomState<Value>
+      | undefined
 
   const addPendingDependent = (atom: AnyAtom, atomState: AtomState) => {
     atomState.d.forEach((_, a) => {
@@ -209,8 +208,7 @@ export const createStore = (): Store => {
       Object.freeze(atomState)
     }
     const prevAtomState = getAtomState(atom)
-    atomStateMap.set(atom, atomState)
-    pendingStack[pendingStack.length - 1]?.add(atom)
+    atomStateMap.set(store.unstable_resolve?.(atom) || atom, atomState)
     if (!pendingMap.has(atom)) {
       pendingMap.set(atom, [prevAtomState, new Set()])
       addPendingDependent(atom, atomState)
@@ -239,7 +237,7 @@ export const createStore = (): Store => {
     )
     let changed = false
     nextDependencies.forEach((aState, a) => {
-      if (!aState && a === resolveAtom(atom)) {
+      if (!aState && a === atom) {
         aState = nextAtomState
       }
       if (aState) {
@@ -411,7 +409,7 @@ export const createStore = (): Store => {
       // If all dependencies haven't changed, we can use the cache.
       if (
         Array.from(atomState.d).every(([a, s]) => {
-          if (a === resolveAtom(atom)) {
+          if (a === atom) {
             return true
           }
           const aState = readAtomState(a, force)
@@ -427,7 +425,7 @@ export const createStore = (): Store => {
     const nextDependencies: NextDependencies = new Map()
     let isSync = true
     const getter: Getter = <V>(a: Atom<V>) => {
-      if (a === resolveAtom(atom as AnyAtom)) {
+      if (a === (atom as AnyAtom)) {
         const aState = getAtomState(a)
         if (aState) {
           nextDependencies.set(a, aState)
@@ -491,7 +489,6 @@ export const createStore = (): Store => {
 
   const recomputeDependents = (atom: AnyAtom): void => {
     const getDependents = (a: AnyAtom): Dependents => {
-      a = resolveAtom(a) // not sure if this is correct
       const dependents = new Set(mountedMap.get(a)?.t)
       pendingMap.get(a)?.[1].forEach((dependent) => {
         dependents.add(dependent)
@@ -569,7 +566,7 @@ export const createStore = (): Store => {
         pendingStack.push(new Set([a]))
       }
       let r: R | undefined
-      if (a === resolveAtom(atom as AnyAtom)) {
+      if (a === (atom as AnyAtom)) {
         if (!hasInitialValue(a)) {
           // NOTE technically possible but restricted as it may cause bugs
           throw new Error('atom not writable')
@@ -817,7 +814,7 @@ export const createStore = (): Store => {
             }
           },
           dev_get_mounted_atoms: () => mountedAtoms.values(),
-          dev_get_atom_state: (a: AnyAtom) => atomStateMap.get(a),
+          dev_get_atom_state: getAtomState,
           dev_get_mounted: (a: AnyAtom) => mountedMap.get(a),
           dev_restore_atoms: (
             values: Iterable<readonly [AnyAtom, AnyValue]>,

--- a/src/vanilla/store2.ts
+++ b/src/vanilla/store2.ts
@@ -267,10 +267,8 @@ export const createStore = (): Store => {
     debugMountedAtoms = new Set()
   }
 
-  const resolveAtom = <Value>(atom: Atom<Value>) =>
-    store.unstable_resolve?.(atom) || atom
-
   const getAtomState = <Value>(atom: Atom<Value>) => {
+    atom = store.unstable_resolve?.(atom) || atom
     let atomState = atomStateMap.get(atom) as AtomState<Value> | undefined
     if (!atomState) {
       atomState = { d: new Map(), p: new Set(), n: 0 }
@@ -379,7 +377,7 @@ export const createStore = (): Store => {
     atomState.d.clear()
     let isSync = true
     const getter: Getter = <V>(a: Atom<V>) => {
-      if (a === resolveAtom(atom as AnyAtom)) {
+      if (a === (atom as AnyAtom)) {
         const aState = getAtomState(a)
         if (!isAtomStateInitialized(aState)) {
           if (hasInitialValue(a)) {
@@ -463,7 +461,6 @@ export const createStore = (): Store => {
 
   const recomputeDependents = (pending: Pending, atom: AnyAtom) => {
     const getDependents = (a: AnyAtom): Set<AnyAtom> => {
-      a = resolveAtom(a) // not sure if this is correct
       const aState = getAtomState(a)
       const dependents = new Set(aState.m?.t)
       for (const atomWithPendingContinuablePromise of aState.p) {
@@ -540,7 +537,7 @@ export const createStore = (): Store => {
       ...args: As
     ) => {
       let r: R | undefined
-      if (a === resolveAtom(atom as AnyAtom)) {
+      if (a === (atom as AnyAtom)) {
         if (!hasInitialValue(a)) {
           // NOTE technically possible but restricted as it may cause bugs
           throw new Error('atom not writable')

--- a/src/vanilla/store2.ts
+++ b/src/vanilla/store2.ts
@@ -463,6 +463,7 @@ export const createStore = (): Store => {
 
   const recomputeDependents = (pending: Pending, atom: AnyAtom) => {
     const getDependents = (a: AnyAtom): Set<AnyAtom> => {
+      a = resolveAtom(a) // not sure if this is correct
       const aState = getAtomState(a)
       const dependents = new Set(aState.m?.t)
       for (const atomWithPendingContinuablePromise of aState.p) {


### PR DESCRIPTION
## Related Issues or Discussions
Replaces PR: https://github.com/pmndrs/jotai/pull/2569

## Context
[jotai-scope](https://github.com/jotaijs/jotai-scope) implementation can be made simpler if the store exposed the ability to customize which atom config to reference based on another atom config.

## Summary
`unstable_resolve` is a new store method. This method customizes how atoms are resolved by their atom config (e.g. using an atom as a key to look up another atom). By default the resolve behavior is `atom => atom`.

### ResolveAtom Invocation Sites
The following functions convert their atom arg to a resolved atom. Since these six functions cover the store interface, it is not necessary to call resolveAtom elsewhere.
1. `readAtom`
1. `writeAtom`
1. `subscribeAtom`
1. `readAtomState -> getter`
1. `writeAtomState -> getter`
1. `writeAtomState -> setter`

Note: store dev methods do not call resolveAtom. The caller of these dev methods is expected to handle atom resolution.

## Example
```js
const pseudo = atom('pseudo')
const a = atom('a')
const store = createStore()
store.unstable_resolve = (atom) => atom === pseudo ? a : atom
expect(store.get(pseudo)).toBe('a')
```

## TODO
1. Determine if this change is sufficient for jotai-scope

## Check List

- [X] `pnpm run prettier` for formatting code and docs
