### PR TITLE
fix: do not abort atoms on unmount

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -362,8 +362,12 @@ export const createStore = (): Store => {
       registerCancelPromise(promise, (next) => {
         if (next) {
           continuePromise(next as Promise<Awaited<Value>>)
+
+          // Only abort promises that aren't user-facing. When next is set,
+          // we can replace the current promise with the next one, so we don't
+          // see any abort-related errors.
+          abortPromise?.()
         }
-        abortPromise?.()
       })
       return setAtomValue(atom, promise as Value, nextDependencies, true)
     }

--- a/src/vanilla/store2.ts
+++ b/src/vanilla/store2.ts
@@ -89,9 +89,13 @@ const createContinuablePromise = <T>(
           continuablePromiseMap.set(nextPromise, p)
           curr = nextPromise
           nextPromise.then(onFulfilled(nextPromise), onRejected(nextPromise))
+
+          // Only abort promises that aren't user-facing. When nextPromise is set,
+          // we can replace the current promise with the next one, so we don't
+          // see any abort-related errors.
+          abort()
+          abort = nextAbort
         }
-        abort()
-        abort = nextAbort
       }
     })
     p.status = PENDING

--- a/tests/react/abortable.test.tsx
+++ b/tests/react/abortable.test.tsx
@@ -119,7 +119,7 @@ describe('abortable atom test', () => {
     expect(abortedCount).toBe(1)
   })
 
-  it('can abort on unmount', async () => {
+  it('does not abort on unmount', async () => {
     const countAtom = atom(0)
     let abortedCount = 0
     const resolve: (() => void)[] = []
@@ -169,7 +169,7 @@ describe('abortable atom test', () => {
     await findByText('hidden')
 
     resolve.splice(0).forEach((fn) => fn())
-    await waitFor(() => expect(abortedCount).toBe(1))
+    await waitFor(() => expect(abortedCount).toBe(0))
   })
 
   it('throws aborted error (like fetch)', async () => {


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #2625

## Summary

@dai-shi agreed that not aborting promises on unsubscription was the best solution here.

When added to the continuable/cancellable promise idiom, it makes quite a lot of sense. Only abort the promise if you can replace it with another one.

I added the behaviour to store and store2

## Check List

- [x] `pnpm run prettier` for formatting code and docs
