### PR TITLE
feat: atom.toString returns its debugLabel if defined

### DIFF
--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -92,7 +92,9 @@ export function atom<Value, Args extends unknown[], Result>(
 ) {
   const key = `atom${++keyCount}`
   const config = {
-    toString: () => key,
+    toString() {
+      return this.debugLabel ?? key
+    },
   } as WritableAtom<Value, Args, Result> & { init?: Value }
   if (typeof read === 'function') {
     config.read = read as Read<Value, SetAtom<Args, Result>>


### PR DESCRIPTION
## Summary
If an atom's debugLabel property is defined, the atom toString method will return the debugLabel otherwise the atom's key.
```ts
const baseAtom = atom(0)
baseAtom.debugLabel = 'base'
console.log(String(baseAtom)) // 'base'
```

## Check List

- [ ] `pnpm run prettier` for formatting code and docs
