### PR TITLE
chore(tests, docs): prefer user-event

### DIFF
--- a/docs/guides/testing.mdx
+++ b/docs/guides/testing.mdx
@@ -36,7 +36,8 @@ export function Counter() {
 
 ```jsx
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { Counter } from './Counter'
 
 test('should increment counter', () => {
@@ -46,7 +47,7 @@ test('should increment counter', () => {
   const counter = screen.getByText('0')
   const incrementButton = screen.getByText('one up')
   // Act
-  fireEvent.click(incrementButton)
+  await userEvent.click(incrementButton)
   // Assert
   expect(counter.textContent).toEqual('1')
 })
@@ -60,7 +61,8 @@ In order to do that, simply use a [Provider](../core/provider.mdx), and export y
 
 ```tsx
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { useHydrateAtoms } from 'jotai/utils'
 import { countAtom, Counter } from './Counter'
 import { Provider } from 'jotai'
@@ -89,7 +91,7 @@ test('should not increment on max (100)', () => {
 
   const counter = screen.getByText('100')
   const incrementButton = screen.getByText('one up')
-  fireEvent.click(incrementButton)
+  await userEvent.click(incrementButton)
   expect(counter.textContent).toEqual('100')
 })
 ```
@@ -144,7 +146,8 @@ Of course, you can test React-Native components too the same way, with or withou
 
 ```tsx
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react-native'
+import { render } from '@testing-library/react-native'
+import userEvent from '@testing-library/user-event'
 import { Counter } from './counter'
 
 test('should increment counter', () => {
@@ -153,7 +156,7 @@ test('should increment counter', () => {
   const counter = getByText('0')
   const incrementButton = getByText('one up')
   // Act
-  fireEvent.press(incrementButton)
+  await userEvent.press(incrementButton)
   // Assert
   expect(counter.props.children.toString()).toEqual('1')
 })

--- a/docs/guides/testing.mdx
+++ b/docs/guides/testing.mdx
@@ -146,8 +146,7 @@ Of course, you can test React-Native components too the same way, with or withou
 
 ```tsx
 import React from 'react'
-import { render } from '@testing-library/react-native'
-import userEvent from '@testing-library/user-event'
+import { render, fireEvent } from '@testing-library/react-native'
 import { Counter } from './counter'
 
 test('should increment counter', () => {
@@ -156,7 +155,7 @@ test('should increment counter', () => {
   const counter = getByText('0')
   const incrementButton = getByText('one up')
   // Act
-  await userEvent.press(incrementButton)
+  fireEvent.press(incrementButton)
   // Assert
   expect(counter.props.children.toString()).toEqual('1')
 })

--- a/tests/react/async.test.tsx
+++ b/tests/react/async.test.tsx
@@ -668,11 +668,11 @@ it('a derived atom from a newly created async atom (#351)', async () => {
   await findByText('loading')
   await findByText('derived: 11, commits: 1')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('loading')
   await findByText('derived: 12, commits: 2')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('loading')
   await findByText('derived: 13, commits: 3')
 })
@@ -776,6 +776,7 @@ it('non suspense async write self atom with setTimeout (#389)', async () => {
 
   await findByText('count: 0')
 
+  // The use of fireEvent is required to reproduce the issue
   fireEvent.click(getByText('button'))
   await findByText('count: 1')
   await findByText('count: -1')

--- a/tests/react/async.test.tsx
+++ b/tests/react/async.test.tsx
@@ -668,11 +668,13 @@ it('a derived atom from a newly created async atom (#351)', async () => {
   await findByText('loading')
   await findByText('derived: 11, commits: 1')
 
-  await userEvent.click(getByText('button'))
+  // The use of fireEvent is required to reproduce the issue
+  fireEvent.click(getByText('button'))
   await findByText('loading')
   await findByText('derived: 12, commits: 2')
 
-  await userEvent.click(getByText('button'))
+  // The use of fireEvent is required to reproduce the issue
+  fireEvent.click(getByText('button'))
   await findByText('loading')
   await findByText('derived: 13, commits: 3')
 })

--- a/tests/react/async2.test.tsx
+++ b/tests/react/async2.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode, Suspense } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { assert, describe, expect, it } from 'vitest'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -40,7 +41,7 @@ describe('useAtom delay option test', () => {
 
     await findByText('count: 0')
 
-    fireEvent.click(getByText('button'))
+    await userEvent.click(getByText('button'))
     await findByText('loading')
     await findByText('count: 1')
   })
@@ -78,7 +79,7 @@ describe('useAtom delay option test', () => {
 
     await findByText('count: 0')
 
-    fireEvent.click(getByText('button'))
+    await userEvent.click(getByText('button'))
     await findByText('count: 1')
   })
 })
@@ -137,7 +138,7 @@ describe('atom read function setSelf option test', () => {
     resolve()
     await findByText('text: hello0')
 
-    fireEvent.click(getByText('button'))
+    await userEvent.click(getByText('button'))
     await findByText('text: hello1')
   })
 })
@@ -195,8 +196,8 @@ describe('timing issue with setSelf', () => {
     await waitFor(() => assert(resolve.length === 1))
     resolve[0]!()
 
-    // The use of fireEvent is required to reproduce the issue
-    fireEvent.click(getByText('button'))
+    // The use of await userEvent is required to reproduce the issue
+    await userEvent.click(getByText('button'))
 
     await waitFor(() => assert(resolve.length === 3))
     resolve[1]!()
@@ -204,8 +205,8 @@ describe('timing issue with setSelf', () => {
 
     await waitFor(() => assert(result === 2))
 
-    // The use of fireEvent is required to reproduce the issue
-    fireEvent.click(getByText('button'))
+    // The use of await userEvent is required to reproduce the issue
+    await userEvent.click(getByText('button'))
 
     await waitFor(() => assert(resolve.length === 5))
     resolve[3]!()
@@ -253,13 +254,13 @@ describe('infinite pending', () => {
 
     await findByText('loading')
 
-    fireEvent.click(getByText('button'))
+    await userEvent.click(getByText('button'))
     await findByText('count: 1')
 
-    fireEvent.click(getByText('button'))
+    await userEvent.click(getByText('button'))
     await findByText('loading')
 
-    fireEvent.click(getByText('button'))
+    await userEvent.click(getByText('button'))
     await findByText('count: 3')
   })
 })

--- a/tests/react/async2.test.tsx
+++ b/tests/react/async2.test.tsx
@@ -1,6 +1,5 @@
 import { StrictMode, Suspense } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { assert, describe, expect, it } from 'vitest'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -41,7 +40,7 @@ describe('useAtom delay option test', () => {
 
     await findByText('count: 0')
 
-    await userEvent.click(getByText('button'))
+    fireEvent.click(getByText('button'))
     await findByText('loading')
     await findByText('count: 1')
   })
@@ -79,7 +78,7 @@ describe('useAtom delay option test', () => {
 
     await findByText('count: 0')
 
-    await userEvent.click(getByText('button'))
+    fireEvent.click(getByText('button'))
     await findByText('count: 1')
   })
 })
@@ -138,7 +137,7 @@ describe('atom read function setSelf option test', () => {
     resolve()
     await findByText('text: hello0')
 
-    await userEvent.click(getByText('button'))
+    fireEvent.click(getByText('button'))
     await findByText('text: hello1')
   })
 })
@@ -254,13 +253,13 @@ describe('infinite pending', () => {
 
     await findByText('loading')
 
-    await userEvent.click(getByText('button'))
+    fireEvent.click(getByText('button'))
     await findByText('count: 1')
 
-    await userEvent.click(getByText('button'))
+    fireEvent.click(getByText('button'))
     await findByText('loading')
 
-    await userEvent.click(getByText('button'))
+    fireEvent.click(getByText('button'))
     await findByText('count: 3')
   })
 })

--- a/tests/react/async2.test.tsx
+++ b/tests/react/async2.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode, Suspense } from 'react'
-import { render, waitFor } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { assert, describe, expect, it } from 'vitest'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai/react'
@@ -196,8 +196,8 @@ describe('timing issue with setSelf', () => {
     await waitFor(() => assert(resolve.length === 1))
     resolve[0]!()
 
-    // The use of await userEvent is required to reproduce the issue
-    await userEvent.click(getByText('button'))
+    // The use of fireEvent is required to reproduce the issue
+    fireEvent.click(getByText('button'))
 
     await waitFor(() => assert(resolve.length === 3))
     resolve[1]!()
@@ -205,8 +205,8 @@ describe('timing issue with setSelf', () => {
 
     await waitFor(() => assert(result === 2))
 
-    // The use of await userEvent is required to reproduce the issue
-    await userEvent.click(getByText('button'))
+    // The use of fireEvent is required to reproduce the issue
+    fireEvent.click(getByText('button'))
 
     await waitFor(() => assert(resolve.length === 5))
     resolve[3]!()

--- a/tests/react/async2.test.tsx
+++ b/tests/react/async2.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode, Suspense } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { assert, describe, expect, it } from 'vitest'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -40,6 +41,7 @@ describe('useAtom delay option test', () => {
 
     await findByText('count: 0')
 
+    // The use of fireEvent is required to reproduce the issue
     fireEvent.click(getByText('button'))
     await findByText('loading')
     await findByText('count: 1')
@@ -78,6 +80,7 @@ describe('useAtom delay option test', () => {
 
     await findByText('count: 0')
 
+    // The use of fireEvent is required to reproduce the issue
     fireEvent.click(getByText('button'))
     await findByText('count: 1')
   })
@@ -137,6 +140,7 @@ describe('atom read function setSelf option test', () => {
     resolve()
     await findByText('text: hello0')
 
+    // The use of fireEvent is required to reproduce the issue
     fireEvent.click(getByText('button'))
     await findByText('text: hello1')
   })
@@ -253,13 +257,13 @@ describe('infinite pending', () => {
 
     await findByText('loading')
 
-    fireEvent.click(getByText('button'))
+    await userEvent.click(getByText('button'))
     await findByText('count: 1')
 
-    fireEvent.click(getByText('button'))
+    await userEvent.click(getByText('button'))
     await findByText('loading')
 
-    fireEvent.click(getByText('button'))
+    await userEvent.click(getByText('button'))
     await findByText('count: 3')
   })
 })

--- a/tests/react/basic.test.tsx
+++ b/tests/react/basic.test.tsx
@@ -7,7 +7,8 @@ import {
   useRef,
   useState,
 } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { unstable_batchedUpdates } from 'react-dom'
 import { expect, it, vi } from 'vitest'
 import { useAtom } from 'jotai/react'
@@ -53,7 +54,7 @@ it('uses a primitive atom', async () => {
 
   await findByText('count: 0')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 1')
 })
 
@@ -83,7 +84,7 @@ it('uses a read-only derived atom', async () => {
     getByText('count: 0')
     getByText('doubledCount: 0')
   })
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await waitFor(() => {
     getByText('count: 1')
     getByText('doubledCount: 2')
@@ -119,7 +120,7 @@ it('uses a read-write derived atom', async () => {
     getByText('count: 0')
     getByText('doubledCount: 0')
   })
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await waitFor(() => {
     getByText('count: 2')
     getByText('doubledCount: 4')
@@ -163,7 +164,7 @@ it('uses a write-only derived atom', async () => {
     getByText('button commits: 1')
   })
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await waitFor(() => {
     getByText('commits: 2, count: 1')
     getByText('button commits: 1')
@@ -212,13 +213,13 @@ it('only re-renders if value has changed', async () => {
     getByText('commits: 1, count2: 0')
     getByText('commits: 1, product: 0')
   })
-  fireEvent.click(getByText('button-count1'))
+  await userEvent.click(getByText('button-count1'))
   await waitFor(() => {
     getByText('commits: 2, count1: 1')
     getByText('commits: 1, count2: 0')
     getByText('commits: 1, product: 0')
   })
-  fireEvent.click(getByText('button-count2'))
+  await userEvent.click(getByText('button-count2'))
   await waitFor(() => {
     getByText('commits: 2, count1: 1')
     getByText('commits: 2, count2: 1')
@@ -294,12 +295,12 @@ it('works with async get', async () => {
   resolve()
   await findByText('commits: 1, count: 0, delayedCount: 0')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('loading')
   resolve()
   await findByText('commits: 2, count: 1, delayedCount: 1')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('loading')
   resolve()
   await findByText('commits: 3, count: 2, delayedCount: 2')
@@ -335,10 +336,10 @@ it('works with async get without setTimeout', async () => {
   await findByText('loading')
   await findByText('count: 0, delayedCount: 0')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 1, delayedCount: 1')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 2, delayedCount: 2')
 })
 
@@ -377,11 +378,11 @@ it('uses atoms with tree dependencies', async () => {
 
   await findByText('commits: 1, count: 0')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   resolve()
   await findByText('commits: 2, count: 1')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   resolve()
   await findByText('commits: 3, count: 2')
 })
@@ -416,7 +417,7 @@ it('runs update only once in StrictMode', async () => {
   await findByText('count: 0')
   expect(updateCount).toBe(0)
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 1')
   expect(updateCount).toBe(1)
 })
@@ -453,7 +454,7 @@ it('uses an async write-only atom', async () => {
 
   await findByText('commits: 1, count: 0')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   resolve()
   await findByText('commits: 2, count: 1')
 })
@@ -483,7 +484,7 @@ it('uses a writable atom without read function', async () => {
 
   await findByText('count: 1')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   resolve()
   await findByText('count: 11')
 })
@@ -574,7 +575,7 @@ it('only invoke read function on use atom', async () => {
 
   await findByText('commits: 1, count: 0, readCount: 1, doubled: 0')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('commits: 2, count: 1, readCount: 2, doubled: 2')
 })
 
@@ -619,16 +620,16 @@ it('uses a read-write derived atom with two primitive atoms', async () => {
 
   await findByText('countA: 0, countB: 0, sum: 0')
 
-  fireEvent.click(getByText('incA'))
+  await userEvent.click(getByText('incA'))
   await findByText('countA: 1, countB: 0, sum: 1')
 
-  fireEvent.click(getByText('incB'))
+  await userEvent.click(getByText('incB'))
   await findByText('countA: 1, countB: 1, sum: 2')
 
-  fireEvent.click(getByText('reset'))
+  await userEvent.click(getByText('reset'))
   await findByText('countA: 0, countB: 0, sum: 0')
 
-  fireEvent.click(getByText('incBoth'))
+  await userEvent.click(getByText('incBoth'))
   await findByText('countA: 1, countB: 1, sum: 2')
 })
 
@@ -662,7 +663,7 @@ it('updates a derived atom in useEffect with two primitive atoms', async () => {
 
   await findByText('countA: 1, countB: 1, sum: 2')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('countA: 2, countB: 2, sum: 4')
 })
 
@@ -775,13 +776,13 @@ it('changes atom from parent (#273, #275)', async () => {
 
   await findByText('commits: 1, id: a')
 
-  fireEvent.click(getByText('atom a'))
+  await userEvent.click(getByText('atom a'))
   await findByText('commits: 1, id: a')
 
-  fireEvent.click(getByText('atom b'))
+  await userEvent.click(getByText('atom b'))
   await findByText('commits: 2, id: b')
 
-  fireEvent.click(getByText('atom a'))
+  await userEvent.click(getByText('atom a'))
   await findByText('commits: 3, id: a')
 })
 
@@ -814,7 +815,7 @@ it('should be able to use a double derived atom twice and useEffect (#373)', asy
   )
 
   await findByText('count: 0,0,0')
-  fireEvent.click(getByText('one up'))
+  await userEvent.click(getByText('one up'))
   await findByText('count: 1,4,4')
 })
 
@@ -841,7 +842,7 @@ it('write self atom (undocumented usage)', async () => {
 
   await findByText('count: 0')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 1')
 })
 
@@ -909,9 +910,9 @@ it('sync re-renders with useState re-renders (#827)', async () => {
   )
 
   await findByText('commits: 1')
-  fireEvent.click(getByText('rotate'))
+  await userEvent.click(getByText('rotate'))
   await findByText('commits: 2')
-  fireEvent.click(getByText('rotate'))
+  await userEvent.click(getByText('rotate'))
   await findByText('commits: 3')
 })
 
@@ -998,6 +999,6 @@ it('useAtom returns consistent value with input with changing atoms (#1235)', as
 
   await findByText('count: 0')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 1')
 })

--- a/tests/react/items.test.tsx
+++ b/tests/react/items.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { it } from 'vitest'
 import { useAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -67,25 +68,25 @@ it('remove an item, then add another', async () => {
     </StrictMode>,
   )
 
-  fireEvent.click(getByText('Add'))
+  await userEvent.click(getByText('Add'))
   await findByText('item1 checked: no')
 
-  fireEvent.click(getByText('Add'))
+  await userEvent.click(getByText('Add'))
   await waitFor(() => {
     getByText('item1 checked: no')
     getByText('item2 checked: no')
   })
 
-  fireEvent.click(getByText('Check item2'))
+  await userEvent.click(getByText('Check item2'))
   await waitFor(() => {
     getByText('item1 checked: no')
     getByText('item2 checked: yes')
   })
 
-  fireEvent.click(getByText('Remove item1'))
+  await userEvent.click(getByText('Remove item1'))
   await findByText('item2 checked: yes')
 
-  fireEvent.click(getByText('Add'))
+  await userEvent.click(getByText('Add'))
   await waitFor(() => {
     getByText('item2 checked: yes')
     getByText('item3 checked: no')
@@ -196,8 +197,8 @@ it('add an item with filtered list', async () => {
     </StrictMode>,
   )
 
-  fireEvent.click(getByText('Checked'))
-  fireEvent.click(getByText('Add'))
-  fireEvent.click(getByText('All'))
+  await userEvent.click(getByText('Checked'))
+  await userEvent.click(getByText('Add'))
+  await userEvent.click(getByText('All'))
   await findByText('item1 checked: no')
 })

--- a/tests/react/onmount.test.tsx
+++ b/tests/react/onmount.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode, Suspense, useState } from 'react'
-import { act, fireEvent, render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { expect, it, vi } from 'vitest'
 import { useAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -28,7 +29,7 @@ it('one atom, one effect', async () => {
   await findByText('count: 1')
   expect(onMountFn).toHaveBeenCalledTimes(1)
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 2')
   expect(onMountFn).toHaveBeenCalledTimes(1)
 })
@@ -73,7 +74,7 @@ it('two atoms, one each', async () => {
   expect(onMountFn).toHaveBeenCalledTimes(1)
   expect(onMountFn2).toHaveBeenCalledTimes(1)
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await waitFor(() => {
     getByText('count: 2')
     getByText('count2: 2')
@@ -143,7 +144,7 @@ it('mount/unmount test', async () => {
   expect(onMountFn).toHaveBeenCalledTimes(1)
   expect(onUnMountFn).toHaveBeenCalledTimes(0)
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await waitFor(() => {
     expect(onMountFn).toHaveBeenCalledTimes(1)
     expect(onUnMountFn).toHaveBeenCalledTimes(1)
@@ -195,7 +196,7 @@ it('one derived atom, one onMount for the derived one, and one for the regular a
   expect(onMountFn).toHaveBeenCalledTimes(1)
   expect(onUnMountFn).toHaveBeenCalledTimes(0)
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await waitFor(() => {
     expect(derivedOnMountFn).toHaveBeenCalledTimes(1)
     expect(derivedOnUnMountFn).toHaveBeenCalledTimes(1)
@@ -268,22 +269,22 @@ it('mount/unMount order', async () => {
   )
   expect(committed).toEqual([0, 0])
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await waitFor(() => {
     expect(committed).toEqual([1, 0])
   })
 
-  fireEvent.click(getByText('derived atom'))
+  await userEvent.click(getByText('derived atom'))
   await waitFor(() => {
     expect(committed).toEqual([1, 1])
   })
 
-  fireEvent.click(getByText('derived atom'))
+  await userEvent.click(getByText('derived atom'))
   await waitFor(() => {
     expect(committed).toEqual([1, 0])
   })
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await waitFor(() => {
     expect(committed).toEqual([0, 0])
   })
@@ -336,7 +337,7 @@ it('mount/unmount test with async atom', async () => {
   expect(onMountFn).toHaveBeenCalledTimes(1)
   expect(onUnMountFn).toHaveBeenCalledTimes(0)
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   expect(onMountFn).toHaveBeenCalledTimes(1)
   expect(onUnMountFn).toHaveBeenCalledTimes(1)
 })
@@ -393,13 +394,13 @@ it('subscription usage test', async () => {
   })
   await findByText('count: 11')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('N/A')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 11')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('N/A')
 
   act(() => {
@@ -407,7 +408,7 @@ it('subscription usage test', async () => {
   })
   await findByText('N/A')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 12')
 })
 
@@ -455,10 +456,10 @@ it('subscription in base atom test', async () => {
 
   await findByText('count: 10')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 11')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 12')
 })
 
@@ -512,9 +513,9 @@ it('create atom with onMount in async get', async () => {
   await findByText('count: 1')
   await findByText('count: 10')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 11')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 12')
 })

--- a/tests/react/optimization.test.tsx
+++ b/tests/react/optimization.test.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { expect, it } from 'vitest'
 import { useAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -47,7 +48,7 @@ it('only relevant render function called (#156)', async () => {
   const renderCount1AfterMount = renderCount1
   const renderCount2AfterMount = renderCount2
 
-  fireEvent.click(getByText('button1'))
+  await userEvent.click(getByText('button1'))
   await waitFor(() => {
     getByText('count1: 1')
     getByText('count2: 0')
@@ -55,7 +56,7 @@ it('only relevant render function called (#156)', async () => {
   expect(renderCount1).toBe(renderCount1AfterMount + 1)
   expect(renderCount2).toBe(renderCount2AfterMount + 0)
 
-  fireEvent.click(getByText('button2'))
+  await userEvent.click(getByText('button2'))
   await waitFor(() => {
     getByText('count1: 1')
     getByText('count2: 1')
@@ -100,11 +101,11 @@ it('only render once using atoms with write-only atom', async () => {
   await findByText('count1: 0, count2: 0')
   const renderCountAfterMount = renderCount
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count1: 1, count2: 1')
   expect(renderCount).toBe(renderCountAfterMount + 1)
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count1: 2, count2: 2')
   expect(renderCount).toBe(renderCountAfterMount + 2)
 })
@@ -138,11 +139,11 @@ it('useless re-renders with static atoms (#355)', async () => {
   await findByText('count: 0')
   const renderCountAfterMount = renderCount
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 1')
   expect(renderCount).toBe(renderCountAfterMount + 1)
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 2')
   expect(renderCount).toBe(renderCountAfterMount + 2)
 })
@@ -173,19 +174,19 @@ it('does not re-render if value is the same (#1158)', async () => {
   await findByText('count: 0')
   const renderCountAfterMount = renderCount
 
-  fireEvent.click(getByText('noop'))
+  await userEvent.click(getByText('noop'))
   await findByText('count: 0')
   expect(renderCount).toBe(renderCountAfterMount + 0)
 
-  fireEvent.click(getByText('inc'))
+  await userEvent.click(getByText('inc'))
   await findByText('count: 1')
   expect(renderCount).toBe(renderCountAfterMount + 1)
 
-  fireEvent.click(getByText('noop'))
+  await userEvent.click(getByText('noop'))
   await findByText('count: 1')
   expect(renderCount).toBe(renderCountAfterMount + 1)
 
-  fireEvent.click(getByText('inc'))
+  await userEvent.click(getByText('inc'))
   await findByText('count: 2')
   expect(renderCount).toBe(renderCountAfterMount + 2)
 })
@@ -250,21 +251,21 @@ it('no extra rerenders after commit with derived atoms (#1213)', async () => {
   expect(renderCount1 > 0).toBeTruthy()
   expect(renderCount2 > 0).toBeTruthy()
 
-  fireEvent.click(getByText('inc1'))
+  await userEvent.click(getByText('inc1'))
   await waitFor(() => {
     getByText('count1: 1')
     getByText('count2: 0')
   })
   expect(renderCount1).toBe(renderCount1AfterCommit)
 
-  fireEvent.click(getByText('inc2'))
+  await userEvent.click(getByText('inc2'))
   await waitFor(() => {
     getByText('count1: 1')
     getByText('count2: 1')
   })
   expect(renderCount2).toBe(renderCount2AfterCommit)
 
-  fireEvent.click(getByText('inc1'))
+  await userEvent.click(getByText('inc1'))
   await waitFor(() => {
     getByText('count1: 2')
     getByText('count2: 1')

--- a/tests/react/useAtomValue.test.tsx
+++ b/tests/react/useAtomValue.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { it } from 'vitest'
 import { useAtomValue, useSetAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -25,6 +26,6 @@ it('useAtomValue basic test', async () => {
   )
 
   await findByText('count: 0')
-  fireEvent.click(getByText('dispatch'))
+  await userEvent.click(getByText('dispatch'))
   await findByText('count: 1')
 })

--- a/tests/react/useSetAtom.test.tsx
+++ b/tests/react/useSetAtom.test.tsx
@@ -1,6 +1,7 @@
 import { StrictMode, useEffect, useRef } from 'react'
 import type { PropsWithChildren } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { it } from 'vitest'
 import { useAtomValue, useSetAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -58,17 +59,17 @@ it('useSetAtom does not trigger rerender in component', async () => {
     getByText('count: 0, commits: 1')
     getByText('updater commits: 1')
   })
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await waitFor(() => {
     getByText('count: 1, commits: 2')
     getByText('updater commits: 1')
   })
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await waitFor(() => {
     getByText('count: 2, commits: 3')
     getByText('updater commits: 1')
   })
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await waitFor(() => {
     getByText('count: 3, commits: 4')
     getByText('updater commits: 1')
@@ -112,7 +113,7 @@ it('useSetAtom with write without an argument', async () => {
   await waitFor(() => {
     getByText('count: 0')
   })
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await waitFor(() => {
     getByText('count: 1')
   })

--- a/tests/react/utils/useAtomCallback.test.tsx
+++ b/tests/react/utils/useAtomCallback.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode, useCallback, useEffect, useState } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { it } from 'vitest'
 import { useAtom } from 'jotai/react'
 import { useAtomCallback } from 'jotai/react/utils'
@@ -50,7 +51,7 @@ it('useAtomCallback with get', async () => {
   )
 
   await findByText('atom count: 0')
-  fireEvent.click(getByText('dispatch'))
+  await userEvent.click(getByText('dispatch'))
   await waitFor(() => {
     getByText('atom count: 1')
     getByText('state count: 1')
@@ -102,7 +103,7 @@ it('useAtomCallback with set and update', async () => {
   )
 
   await findByText('count: 0')
-  fireEvent.click(getByText('dispatch'))
+  await userEvent.click(getByText('dispatch'))
   await waitFor(() => {
     getByText('count: 1')
     getByText('changeable count: 1')
@@ -136,7 +137,7 @@ it('useAtomCallback with set and update and arg', async () => {
   )
 
   await findByText('count: 0')
-  fireEvent.click(getByText('dispatch'))
+  await userEvent.click(getByText('dispatch'))
   await waitFor(() => {
     getByText('count: 42')
   })
@@ -170,6 +171,6 @@ it('useAtomCallback with sync atom (#1100)', async () => {
 
   await findByText('atom count: 0')
 
-  fireEvent.click(getByText('dispatch'))
+  await userEvent.click(getByText('dispatch'))
   await findByText('atom count: 1')
 })

--- a/tests/react/utils/useHydrateAtoms.test.tsx
+++ b/tests/react/utils/useHydrateAtoms.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode, useEffect, useRef } from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { expect, it, vi } from 'vitest'
 import { useAtom, useAtomValue } from 'jotai/react'
 import { useHydrateAtoms } from 'jotai/react/utils'
@@ -48,8 +49,8 @@ it('useHydrateAtoms should only hydrate on first render', async () => {
 
   await findByText('count: 42')
   await findByText('status: rejected')
-  fireEvent.click(getByText('dispatch'))
-  fireEvent.click(getByText('update'))
+  await userEvent.click(getByText('dispatch'))
+  await userEvent.click(getByText('update'))
   await findByText('count: 43')
   await findByText('status: fulfilled')
 
@@ -101,7 +102,7 @@ it('useHydrateAtoms should only hydrate on first render using a Map', async () =
 
   await findByText('count: 42')
   await findByText('is active: no')
-  fireEvent.click(getByText('dispatch'))
+  await userEvent.click(getByText('dispatch'))
   await findByText('count: 43')
 
   rerender(
@@ -140,7 +141,7 @@ it('useHydrateAtoms should not trigger unnecessary re-renders', async () => {
 
   await findByText('count: 42')
   await findByText('commits: 1')
-  fireEvent.click(getByText('dispatch'))
+  await userEvent.click(getByText('dispatch'))
   await findByText('count: 43')
   await findByText('commits: 2')
 })
@@ -170,7 +171,7 @@ it('useHydrateAtoms should work with derived atoms', async () => {
 
   await findByText('count: 42')
   await findByText('doubleCount: 84')
-  fireEvent.click(getByText('dispatch'))
+  await userEvent.click(getByText('dispatch'))
   await findByText('count: 43')
   await findByText('doubleCount: 86')
 })
@@ -207,7 +208,7 @@ it('useHydrateAtoms can only restore an atom once', async () => {
   )
 
   await findByText('count: 42')
-  fireEvent.click(getByText('dispatch'))
+  await userEvent.click(getByText('dispatch'))
   await findByText('count: 43')
 
   rerender(
@@ -217,7 +218,7 @@ it('useHydrateAtoms can only restore an atom once', async () => {
   )
 
   await findByText('count: 43')
-  fireEvent.click(getByText('dispatch'))
+  await userEvent.click(getByText('dispatch'))
   await findByText('count: 44')
 })
 
@@ -292,8 +293,8 @@ it('passing dangerouslyForceHydrate to useHydrateAtoms will re-hydrated atoms', 
 
   await findByText('count: 42')
   await findByText('status: rejected')
-  fireEvent.click(getByText('dispatch'))
-  fireEvent.click(getByText('update'))
+  await userEvent.click(getByText('dispatch'))
+  await userEvent.click(getByText('update'))
   await findByText('count: 43')
   await findByText('status: fulfilled')
 

--- a/tests/react/utils/useReducerAtom.test.tsx
+++ b/tests/react/utils/useReducerAtom.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, it, vi } from 'vitest'
 import { useReducerAtom } from 'jotai/react/utils'
 import { atom } from 'jotai/vanilla'
@@ -35,10 +36,10 @@ it('useReducerAtom with no action argument', async () => {
 
   await findByText('count: 0')
 
-  fireEvent.click(getByText('dispatch'))
+  await userEvent.click(getByText('dispatch'))
   await findByText('count: 2')
 
-  fireEvent.click(getByText('dispatch'))
+  await userEvent.click(getByText('dispatch'))
   await findByText('count: 4')
 })
 
@@ -75,13 +76,13 @@ it('useReducerAtom with optional action argument', async () => {
 
   await findByText('count: 0')
 
-  fireEvent.click(getByText('dispatch INCREASE'))
+  await userEvent.click(getByText('dispatch INCREASE'))
   await findByText('count: 1')
 
-  fireEvent.click(getByText('dispatch empty'))
+  await userEvent.click(getByText('dispatch empty'))
   await findByText('count: 1')
 
-  fireEvent.click(getByText('dispatch DECREASE'))
+  await userEvent.click(getByText('dispatch DECREASE'))
   await findByText('count: 0')
 })
 
@@ -115,9 +116,9 @@ it('useReducerAtom with non-optional action argument', async () => {
 
   await findByText('count: 0')
 
-  fireEvent.click(getByText('dispatch INCREASE'))
+  await userEvent.click(getByText('dispatch INCREASE'))
   await findByText('count: 1')
 
-  fireEvent.click(getByText('dispatch DECREASE'))
+  await userEvent.click(getByText('dispatch DECREASE'))
   await findByText('count: 0')
 })

--- a/tests/react/utils/useResetAtom.test.tsx
+++ b/tests/react/utils/useResetAtom.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { it } from 'vitest'
 import { useAtom } from 'jotai/react'
 import { useResetAtom } from 'jotai/react/utils'
@@ -32,24 +33,24 @@ it('atomWithReset resets to its first value', async () => {
 
   await findByText('count: 0')
 
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('count: 1')
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('count: 2')
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('count: 3')
 
-  fireEvent.click(getByText('reset'))
+  await userEvent.click(getByText('reset'))
   await findByText('count: 0')
 
-  fireEvent.click(getByText('set to 10'))
+  await userEvent.click(getByText('set to 10'))
   await findByText('count: 10')
 
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('count: 11')
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('count: 12')
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('count: 13')
 })
 
@@ -82,14 +83,14 @@ it('atomWithReset reset based on previous value', async () => {
 
   await findByText('count: 0')
 
-  fireEvent.click(getByText('increment till 3, then reset'))
+  await userEvent.click(getByText('increment till 3, then reset'))
   await findByText('count: 1')
-  fireEvent.click(getByText('increment till 3, then reset'))
+  await userEvent.click(getByText('increment till 3, then reset'))
   await findByText('count: 2')
-  fireEvent.click(getByText('increment till 3, then reset'))
+  await userEvent.click(getByText('increment till 3, then reset'))
   await findByText('count: 3')
 
-  fireEvent.click(getByText('increment till 3, then reset'))
+  await userEvent.click(getByText('increment till 3, then reset'))
   await findByText('count: 0')
 })
 
@@ -121,10 +122,10 @@ it('atomWithReset through read-write atom', async () => {
 
   await findByText('count: 0')
 
-  fireEvent.click(getByText('set to 10'))
+  await userEvent.click(getByText('set to 10'))
   await findByText('count: 10')
 
-  fireEvent.click(getByText('reset'))
+  await userEvent.click(getByText('reset'))
   await findByText('count: 0')
 })
 
@@ -162,13 +163,13 @@ it('useResetAtom with custom atom', async () => {
 
   await findByText('count: 0')
 
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('count: 1')
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('count: 2')
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('count: 3')
 
-  fireEvent.click(getByText('reset'))
+  await userEvent.click(getByText('reset'))
   await findByText('count: 0')
 })

--- a/tests/react/vanilla-utils/atomFamily.test.tsx
+++ b/tests/react/vanilla-utils/atomFamily.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode, Suspense, useState } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { expect, it } from 'vitest'
 import { useAtom, useSetAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -92,13 +93,13 @@ it('primitive atomFamily initialized with props', async () => {
 
   await findByText('count: 1')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 11')
 
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('count: 2')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 12')
 })
 
@@ -173,21 +174,21 @@ it('derived atomFamily functionality as usual', async () => {
     getByText('index: 2, count: 0')
   })
 
-  fireEvent.click(getByText('increment #1'))
+  await userEvent.click(getByText('increment #1'))
   await waitFor(() => {
     getByText('index: 0, count: 0')
     getByText('index: 1, count: 1')
     getByText('index: 2, count: 0')
   })
 
-  fireEvent.click(getByText('increment #0'))
+  await userEvent.click(getByText('increment #0'))
   await waitFor(() => {
     getByText('index: 0, count: 1')
     getByText('index: 1, count: 1')
     getByText('index: 2, count: 0')
   })
 
-  fireEvent.click(getByText('increment #2'))
+  await userEvent.click(getByText('increment #2'))
   await waitFor(() => {
     getByText('index: 0, count: 1')
     getByText('index: 1, count: 1')
@@ -249,12 +250,12 @@ it('a derived atom from an async atomFamily (#351)', async () => {
   resolve.splice(0).forEach((fn) => fn())
   await findByText('derived: 11')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('loading')
   resolve.splice(0).forEach((fn) => fn())
   await findByText('derived: 12')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('loading')
   resolve.splice(0).forEach((fn) => fn())
   await findByText('derived: 13')

--- a/tests/react/vanilla-utils/atomWithDefault.test.tsx
+++ b/tests/react/vanilla-utils/atomWithDefault.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode, Suspense } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { it } from 'vitest'
 import { useAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -31,13 +32,13 @@ it('simple sync get default', async () => {
 
   await findByText('count1: 1, count2: 2')
 
-  fireEvent.click(getByText('button1'))
+  await userEvent.click(getByText('button1'))
   await findByText('count1: 2, count2: 4')
 
-  fireEvent.click(getByText('button2'))
+  await userEvent.click(getByText('button2'))
   await findByText('count1: 2, count2: 5')
 
-  fireEvent.click(getByText('button1'))
+  await userEvent.click(getByText('button1'))
   await findByText('count1: 3, count2: 5')
 })
 
@@ -77,16 +78,16 @@ it('simple async get default', async () => {
   resolve()
   await findByText('count1: 1, count2: 2')
 
-  fireEvent.click(getByText('button1'))
+  await userEvent.click(getByText('button1'))
   await findByText('loading')
   resolve()
   await findByText('count1: 2, count2: 4')
 
-  fireEvent.click(getByText('button2'))
+  await userEvent.click(getByText('button2'))
   resolve()
   await findByText('count1: 2, count2: 5')
 
-  fireEvent.click(getByText('button1'))
+  await userEvent.click(getByText('button1'))
   resolve()
   await findByText('count1: 3, count2: 5')
 })
@@ -118,19 +119,19 @@ it('refresh sync atoms to default values', async () => {
 
   await findByText('count1: 1, count2: 2')
 
-  fireEvent.click(getByText('button1'))
+  await userEvent.click(getByText('button1'))
   await findByText('count1: 2, count2: 4')
 
-  fireEvent.click(getByText('button2'))
+  await userEvent.click(getByText('button2'))
   await findByText('count1: 2, count2: 5')
 
-  fireEvent.click(getByText('button1'))
+  await userEvent.click(getByText('button1'))
   await findByText('count1: 3, count2: 5')
 
-  fireEvent.click(getByText('Refresh count2'))
+  await userEvent.click(getByText('Refresh count2'))
   await findByText('count1: 3, count2: 6')
 
-  fireEvent.click(getByText('button1'))
+  await userEvent.click(getByText('button1'))
   await findByText('count1: 4, count2: 8')
 })
 
@@ -173,32 +174,32 @@ it('refresh async atoms to default values', async () => {
     getByText('count1: 1, count2: 2')
   })
 
-  fireEvent.click(getByText('button1'))
+  await userEvent.click(getByText('button1'))
   await findByText('loading')
   await waitFor(() => {
     resolve()
     getByText('count1: 2, count2: 4')
   })
 
-  fireEvent.click(getByText('button2'))
+  await userEvent.click(getByText('button2'))
   await waitFor(() => {
     resolve()
     getByText('count1: 2, count2: 5')
   })
 
-  fireEvent.click(getByText('button1'))
+  await userEvent.click(getByText('button1'))
   await waitFor(() => {
     resolve()
     getByText('count1: 3, count2: 5')
   })
 
-  fireEvent.click(getByText('Refresh count2'))
+  await userEvent.click(getByText('Refresh count2'))
   await waitFor(() => {
     resolve()
     getByText('count1: 3, count2: 6')
   })
 
-  fireEvent.click(getByText('button1'))
+  await userEvent.click(getByText('button1'))
   await waitFor(() => {
     resolve()
     getByText('count1: 4, count2: 8')

--- a/tests/react/vanilla-utils/atomWithObservable.test.tsx
+++ b/tests/react/vanilla-utils/atomWithObservable.test.tsx
@@ -1,6 +1,7 @@
 import { Component, StrictMode, Suspense, useState } from 'react'
 import type { ReactElement, ReactNode } from 'react'
-import { act, fireEvent, render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { BehaviorSubject, Observable, Subject, delay, map, of } from 'rxjs'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fromValue, makeSubject, pipe, toObservable } from 'wonka'
@@ -104,7 +105,7 @@ it('writable count state', async () => {
   act(() => subject.next(2))
   await findByText('count: 2')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 9')
   expect(subject.value).toBe(9)
 
@@ -136,7 +137,7 @@ it('writable count state without initial value', async () => {
 
   await findByText('loading')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 9')
 
   act(() => subject.next(3))
@@ -179,7 +180,7 @@ it('writable count state with delayed value', async () => {
   act(() => vi.runOnlyPendingTimers())
   await findByText('count: 1')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 9')
 })
 
@@ -292,8 +293,8 @@ it('resubscribe on remount', async () => {
   act(() => subject.next(1))
   await findByText('count: 1')
 
-  fireEvent.click(getByText('Toggle'))
-  fireEvent.click(getByText('Toggle'))
+  await userEvent.click(getByText('Toggle'))
+  await userEvent.click(getByText('Toggle'))
 
   act(() => subject.next(2))
   await findByText('count: 2')
@@ -347,7 +348,7 @@ it('writable count state with initialValue', async () => {
   act(() => subject.next(1))
   await findByText('count: 1')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 9')
 })
 
@@ -511,7 +512,7 @@ it("don't omit values emitted between init and mount", async () => {
   })
   await findByText('count: 2')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('count: 9')
 })
 
@@ -625,17 +626,17 @@ describe('error handling', () => {
     act(() => vi.runOnlyPendingTimers())
     await findByText('errored')
 
-    fireEvent.click(getByText('retry'))
+    await userEvent.click(getByText('retry'))
     await findByText('loading')
     act(() => vi.runOnlyPendingTimers())
     await findByText('count: 1')
 
-    fireEvent.click(getByText('next'))
+    await userEvent.click(getByText('next'))
     await findByText('loading')
     act(() => vi.runOnlyPendingTimers())
     await findByText('errored')
 
-    fireEvent.click(getByText('retry'))
+    await userEvent.click(getByText('retry'))
     await findByText('loading')
     act(() => vi.runOnlyPendingTimers())
     await findByText('count: 3')
@@ -714,17 +715,17 @@ describe('error handling', () => {
     act(() => vi.runOnlyPendingTimers())
     await findByText('errored')
 
-    fireEvent.click(getByText('retry'))
+    await userEvent.click(getByText('retry'))
     await findByText('loading')
     act(() => vi.runOnlyPendingTimers())
     await findByText('count: 1')
 
-    fireEvent.click(getByText('refresh'))
+    await userEvent.click(getByText('refresh'))
     await findByText('loading')
     act(() => vi.runOnlyPendingTimers())
     await findByText('errored')
 
-    fireEvent.click(getByText('retry'))
+    await userEvent.click(getByText('retry'))
     await findByText('loading')
     act(() => vi.runOnlyPendingTimers())
     await findByText('count: 3')
@@ -785,7 +786,7 @@ describe('wonka', () => {
 
     await findByText('loading')
 
-    fireEvent.click(getByText('button'))
+    await userEvent.click(getByText('button'))
     await findByText('count: 1')
   })
 })

--- a/tests/react/vanilla-utils/atomWithReducer.test.tsx
+++ b/tests/react/vanilla-utils/atomWithReducer.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { it } from 'vitest'
 import { useAtom } from 'jotai/react'
 import { atomWithReducer } from 'jotai/vanilla/utils'
@@ -37,13 +38,13 @@ it('atomWithReducer with optional action argument', async () => {
 
   await findByText('count: 0')
 
-  fireEvent.click(getByText('dispatch INCREASE'))
+  await userEvent.click(getByText('dispatch INCREASE'))
   await findByText('count: 1')
 
-  fireEvent.click(getByText('dispatch empty'))
+  await userEvent.click(getByText('dispatch empty'))
   await findByText('count: 1')
 
-  fireEvent.click(getByText('dispatch DECREASE'))
+  await userEvent.click(getByText('dispatch DECREASE'))
   await findByText('count: 0')
 })
 
@@ -77,9 +78,9 @@ it('atomWithReducer with non-optional action argument', async () => {
 
   await findByText('count: 0')
 
-  fireEvent.click(getByText('dispatch INCREASE'))
+  await userEvent.click(getByText('dispatch INCREASE'))
   await findByText('count: 1')
 
-  fireEvent.click(getByText('dispatch DECREASE'))
+  await userEvent.click(getByText('dispatch DECREASE'))
   await findByText('count: 0')
 })

--- a/tests/react/vanilla-utils/freezeAtom.test.tsx
+++ b/tests/react/vanilla-utils/freezeAtom.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, it, vi } from 'vitest'
 import { useAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -30,7 +31,7 @@ it('freezeAtom basic test', async () => {
 
   await findByText('isFrozen: true')
 
-  fireEvent.click(getByText('change'))
+  await userEvent.click(getByText('change'))
   await findByText('isFrozen: true')
 })
 
@@ -70,7 +71,7 @@ describe('freezeAtomCreator', () => {
 
     await findByText('isFrozen: true')
 
-    fireEvent.click(getByText('change'))
+    await userEvent.click(getByText('change'))
     await findByText('isFrozen: true')
   })
 })

--- a/tests/react/vanilla-utils/loadable.test.tsx
+++ b/tests/react/vanilla-utils/loadable.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode, Suspense, useEffect } from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { expect, it, vi } from 'vitest'
 import { useAtomValue, useSetAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -86,7 +87,7 @@ it('loadable goes back to loading after re-fetch', async () => {
   getByText('Loading...')
   resolve(5)
   await findByText('Data: 5')
-  fireEvent.click(getByText('refresh'))
+  await userEvent.click(getByText('refresh'))
   await findByText('Loading...')
   resolve(6)
   await findByText('Data: 6')
@@ -125,7 +126,7 @@ it('loadable can recover from error', async () => {
   getByText('Loading...')
   reject(new Error('An error occurred'))
   await findByText('Error: An error occurred')
-  fireEvent.click(getByText('refresh'))
+  await userEvent.click(getByText('refresh'))
   await findByText('Loading...')
   resolve(6)
   await findByText('Data: 6')
@@ -209,7 +210,7 @@ it('loadable of a derived async atom does not trigger infinite loop (#1114)', as
   )
 
   getByText('Loading...')
-  fireEvent.click(getByText('trigger'))
+  await userEvent.click(getByText('trigger'))
   resolve(5)
   await findByText('Data: 5')
 })

--- a/tests/react/vanilla-utils/selectAtom.test.tsx
+++ b/tests/react/vanilla-utils/selectAtom.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode, useEffect, useRef } from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { it } from 'vitest'
 import { useAtomValue, useSetAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -50,11 +51,11 @@ it('selectAtom works as expected', async () => {
 
   await findByText('a: 0')
 
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('a: 1')
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('a: 2')
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('a: 3')
 })
 
@@ -104,28 +105,28 @@ it('do not update unless equality function says value has changed', async () => 
 
   await findByText('value: {"a":0}')
   await findByText('commits: 1')
-  fireEvent.click(getByText('copy'))
+  await userEvent.click(getByText('copy'))
   await findByText('value: {"a":0}')
   await findByText('commits: 1')
 
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('value: {"a":1}')
   await findByText('commits: 2')
-  fireEvent.click(getByText('copy'))
+  await userEvent.click(getByText('copy'))
   await findByText('value: {"a":1}')
   await findByText('commits: 2')
 
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('value: {"a":2}')
   await findByText('commits: 3')
-  fireEvent.click(getByText('copy'))
+  await userEvent.click(getByText('copy'))
   await findByText('value: {"a":2}')
   await findByText('commits: 3')
 
-  fireEvent.click(getByText('increment'))
+  await userEvent.click(getByText('increment'))
   await findByText('value: {"a":3}')
   await findByText('commits: 4')
-  fireEvent.click(getByText('copy'))
+  await userEvent.click(getByText('copy'))
   await findByText('value: {"a":3}')
   await findByText('commits: 4')
 })

--- a/tests/react/vanilla-utils/splitAtom.test.tsx
+++ b/tests/react/vanilla-utils/splitAtom.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode, useEffect, useRef } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { expect, it } from 'vitest'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -78,7 +79,7 @@ it('no unnecessary updates when updating atoms', async () => {
   expect(catBox.checked).toBeFalsy()
   expect(dragonBox.checked).toBeFalsy()
 
-  fireEvent.click(catBox)
+  await userEvent.click(catBox)
 
   await waitFor(() => {
     getByText('TaskListUpdates: 1')
@@ -89,7 +90,7 @@ it('no unnecessary updates when updating atoms', async () => {
   expect(catBox.checked).toBeTruthy()
   expect(dragonBox.checked).toBeFalsy()
 
-  fireEvent.click(dragonBox)
+  await userEvent.click(dragonBox)
 
   await waitFor(() => {
     getByText('TaskListUpdates: 1')
@@ -153,7 +154,7 @@ it('removing atoms', async () => {
     expect(queryByText('help nana')).toBeTruthy()
   })
 
-  fireEvent.click(getByTestId('get cat food-removebutton'))
+  await userEvent.click(getByTestId('get cat food-removebutton'))
 
   await waitFor(() => {
     expect(queryByText('get cat food')).toBeFalsy()
@@ -161,7 +162,7 @@ it('removing atoms', async () => {
     expect(queryByText('help nana')).toBeTruthy()
   })
 
-  fireEvent.click(getByTestId('get dragon food-removebutton'))
+  await userEvent.click(getByTestId('get dragon food-removebutton'))
 
   await waitFor(() => {
     expect(queryByText('get cat food')).toBeFalsy()
@@ -169,7 +170,7 @@ it('removing atoms', async () => {
     expect(queryByText('help nana')).toBeTruthy()
   })
 
-  fireEvent.click(getByTestId('help nana-removebutton'))
+  await userEvent.click(getByTestId('help nana-removebutton'))
 
   await waitFor(() => {
     expect(queryByText('get cat food')).toBeFalsy()
@@ -253,21 +254,21 @@ it('inserting atoms', async () => {
     )
   })
 
-  fireEvent.click(getByTestId('help nana-insertbutton'))
+  await userEvent.click(getByTestId('help nana-insertbutton'))
   await waitFor(() => {
     expect(queryByTestId('list')?.textContent).toBe(
       'get cat food+get dragon food+new task1+help nana+',
     )
   })
 
-  fireEvent.click(getByTestId('get cat food-insertbutton'))
+  await userEvent.click(getByTestId('get cat food-insertbutton'))
   await waitFor(() => {
     expect(queryByTestId('list')?.textContent).toBe(
       'new task2+get cat food+get dragon food+new task1+help nana+',
     )
   })
 
-  fireEvent.click(getByTestId('addtaskbutton'))
+  await userEvent.click(getByTestId('addtaskbutton'))
   await waitFor(() => {
     expect(queryByTestId('list')?.textContent).toBe(
       'new task2+get cat food+get dragon food+new task1+help nana+end+',
@@ -359,28 +360,28 @@ it('moving atoms', async () => {
     )
   })
 
-  fireEvent.click(getByTestId('help nana-leftbutton'))
+  await userEvent.click(getByTestId('help nana-leftbutton'))
   await waitFor(() => {
     expect(queryByTestId('list')?.textContent).toBe(
       'get cat food<>help nana<>get dragon food<>',
     )
   })
 
-  fireEvent.click(getByTestId('get cat food-rightbutton'))
+  await userEvent.click(getByTestId('get cat food-rightbutton'))
   await waitFor(() => {
     expect(queryByTestId('list')?.textContent).toBe(
       'help nana<>get cat food<>get dragon food<>',
     )
   })
 
-  fireEvent.click(getByTestId('get cat food-rightbutton'))
+  await userEvent.click(getByTestId('get cat food-rightbutton'))
   await waitFor(() => {
     expect(queryByTestId('list')?.textContent).toBe(
       'help nana<>get dragon food<>get cat food<>',
     )
   })
 
-  fireEvent.click(getByTestId('help nana-leftbutton'))
+  await userEvent.click(getByTestId('help nana-leftbutton'))
   await waitFor(() => {
     expect(queryByTestId('list')?.textContent).toBe(
       'get dragon food<>get cat food<>help nana<>',
@@ -487,7 +488,7 @@ it('no error with cached atoms (fix 510)', async () => {
     </StrictMode>,
   )
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
 })
 
 it('variable sized splitted atom', async () => {
@@ -521,7 +522,7 @@ it('variable sized splitted atom', async () => {
 
   await findByText('numbers: 1,2,3')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('numbers: 1,2')
 })
 
@@ -550,6 +551,6 @@ it('should not update splitted atom when single item is set to identical value',
 
   await findByText('changed: false')
 
-  fireEvent.click(getByText('button'))
+  await userEvent.click(getByText('button'))
   await findByText('changed: false')
 })


### PR DESCRIPTION
We've migrated to user-event for some tests, and this does it for all possible ones.