### PR TITLE
atom toString includes debugLabel in dev mode

### DIFF
--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -92,7 +92,11 @@ export function atom<Value, Args extends unknown[], Result>(
 ) {
   const key = `atom${++keyCount}`
   const config = {
-    toString: () => key,
+    toString() {
+      return import.meta.env?.MODE !== 'production' && this.debugLabel
+        ? key + ':' + this.debugLabel
+        : key
+    },
   } as WritableAtom<Value, Args, Result> & { init?: Value }
   if (typeof read === 'function') {
     config.read = read as Read<Value, SetAtom<Args, Result>>


### PR DESCRIPTION
## Summary

```js
const anAtom = atom(0)
anAtom.debugLabel = 'countAtom'

console.log(anAtom);
// dev: 'atom1:countAtom'
// prod: 'atom1'
```

## Check List

- [x] `pnpm run prettier` for formatting code and docs
