### PR TITLE
idea1: add originator prop to atomFamily atoms

### DIFF
--- a/src/vanilla/utils/atomFamily.ts
+++ b/src/vanilla/utils/atomFamily.ts
@@ -2,6 +2,8 @@ import type { Atom } from '../../vanilla.ts'
 
 type ShouldRemove<Param> = (createdAt: number, param: Param) => boolean
 
+export const SymbolOriginator = Symbol('Originator')
+
 export interface AtomFamily<Param, AtomType> {
   (param: Param): AtomType
   remove(param: Param): void
@@ -43,6 +45,7 @@ export function atomFamily<Param, AtomType extends Atom<unknown>>(
     }
 
     const newAtom = initializeAtom(param)
+    ;(newAtom as any)[SymbolOriginator] = createAtom
     atoms.set(param, [newAtom, Date.now()])
     return newAtom
   }


### PR DESCRIPTION
## Related Bug Reports or Discussions
idea2: https://github.com/pmndrs/jotai/pull/2679

Fixes #
https://github.com/jotaijs/jotai-scope/issues/50

## Summary
jotai-scope is trying to support scoping atomFamily.
```jsx
const fooFamily = atomFamily((id) => atom(id))
<ScopedProvider atoms={[fooFamily]}>{children}</ScopeProvider>
```
This PR demonstrates one approach in which the atomFamily annotates atoms created by this approach with an originator symbol set to the createAtom function.

The following pseudo code represents logic that would live in jotai-scope
```js
const isExplicitlyScoped = atomSet.has(atom) || atomSet.has(atom[SymbolOriginator])
```

## Check List

- [x] `pnpm run prettier` for formatting code and docs
