### PR TITLE
idea2: add getParams to createAtom

### DIFF
--- a/src/vanilla/utils/atomFamily.ts
+++ b/src/vanilla/utils/atomFamily.ts
@@ -47,6 +47,10 @@ export function atomFamily<Param, AtomType extends Atom<unknown>>(
     return newAtom
   }
 
+  createAtom.getParams = () => {
+    return Array.from(atoms.keys())
+  }
+
   createAtom.remove = (param: Param) => {
     if (areEqual === undefined) {
       atoms.delete(param)


### PR DESCRIPTION
## Related Bug Reports or Discussions
idea1: https://github.com/pmndrs/jotai/pull/2678
Discussion: https://github.com/pmndrs/jotai/discussions/2056

Fixes #
https://github.com/jotaijs/jotai-scope/issues/50

## Summary
jotai-scope is trying to support scoping atomFamily.
```jsx
const fooFamily = atomFamily((id) => atom(id))
<ScopedProvider atoms={[fooFamily]}>{children}</ScopeProvider>
```
This PR demonstrates one approach in which the atomFamily supports a new `getParams` function.
The following pseudo code represents logic that would live in jotai-scope. For obvious complexity reasons, I find this solution less favorable to https://github.com/pmndrs/jotai/pull/2678.
```js
const isExplicitlyScoped = atomSet.has(atom) || 
  Array.from(atomSet)
    .filter(isAtomFamily)
    .some((af) => af.getParams().map(af).includes(atom))
```

## Check List

- [x] `pnpm run prettier` for formatting code and docs
