### PR TITLE
idea3: atomFamily supports instanceof

### DIFF
--- a/src/vanilla/utils/atomFamily.ts
+++ b/src/vanilla/utils/atomFamily.ts
@@ -42,10 +42,15 @@ export function atomFamily<Param, AtomType extends Atom<unknown>>(
       }
     }
 
-    const newAtom = initializeAtom(param)
+    const newAtom = Object.setPrototypeOf(
+      initializeAtom(param),
+      createAtom.prototype,
+    )
     atoms.set(param, [newAtom, Date.now()])
     return newAtom
   }
+
+  createAtom.prototype = {}
 
   createAtom.remove = (param: Param) => {
     if (areEqual === undefined) {

--- a/tests/vanilla/utils/atomFamily.test.ts
+++ b/tests/vanilla/utils/atomFamily.test.ts
@@ -1,0 +1,69 @@
+import { expect, it, vi } from 'vitest'
+import { Atom, atom, createStore } from 'jotai/vanilla'
+import { atomFamily } from 'jotai/vanilla/utils'
+
+it('should create atoms with different params', () => {
+  const store = createStore()
+  const aFamily = atomFamily((param: number) => atom(param))
+
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(store.get(aFamily(2))).toEqual(2)
+})
+
+it('should remove atoms', () => {
+  const store = createStore()
+  const initializeAtom = vi.fn((param: number) => atom(param))
+  const aFamily = atomFamily(initializeAtom)
+
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(store.get(aFamily(2))).toEqual(2)
+  aFamily.remove(2)
+  initializeAtom.mockClear()
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(initializeAtom).toHaveBeenCalledTimes(0)
+  expect(store.get(aFamily(2))).toEqual(2)
+  expect(initializeAtom).toHaveBeenCalledTimes(1)
+})
+
+it('should remove atoms with custom comparator', () => {
+  const store = createStore()
+  const initializeAtom = vi.fn((param: number) => atom(param))
+  const aFamily = atomFamily(initializeAtom, (a, b) => a === b)
+
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(store.get(aFamily(2))).toEqual(2)
+  expect(store.get(aFamily(3))).toEqual(3)
+  aFamily.remove(2)
+  initializeAtom.mockClear()
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(initializeAtom).toHaveBeenCalledTimes(0)
+  expect(store.get(aFamily(2))).toEqual(2)
+  expect(initializeAtom).toHaveBeenCalledTimes(1)
+})
+
+it('should remove atoms with custom shouldRemove', () => {
+  const store = createStore()
+  const initializeAtom = vi.fn((param: number) => atom(param))
+  const aFamily = atomFamily<number, Atom<number>>(initializeAtom)
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(store.get(aFamily(2))).toEqual(2)
+  expect(store.get(aFamily(3))).toEqual(3)
+  aFamily.setShouldRemove((_createdAt, param) => param % 2 === 0)
+  initializeAtom.mockClear()
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(initializeAtom).toHaveBeenCalledTimes(0)
+  expect(store.get(aFamily(2))).toEqual(2)
+  expect(initializeAtom).toHaveBeenCalledTimes(1)
+  expect(store.get(aFamily(3))).toEqual(3)
+  expect(initializeAtom).toHaveBeenCalledTimes(1)
+})
+
+it('should support instanceof', () => {
+  const aFamilyA = atomFamily((param: number) => atom(param))
+  const aFamilyB = atomFamily((param: number) => atom(param))
+  expect(aFamilyA(1) instanceof aFamilyA).toEqual(true)
+  expect(aFamilyA(2) instanceof aFamilyA).toEqual(true)
+  expect(aFamilyA(1) instanceof aFamilyB).toEqual(false)
+  expect(aFamilyA(1) instanceof atom).toEqual(false)
+  expect(atom(2) instanceof aFamilyA).toEqual(false)
+})


### PR DESCRIPTION
## Related Bug Reports or Discussions
idea1: https://github.com/pmndrs/jotai/pull/2678
idea2: https://github.com/pmndrs/jotai/pull/2679

Fixes #
https://github.com/jotaijs/jotai-scope/issues/50

## Summary
jotai-scope is trying to support scoping atomFamily.
```jsx
const fooFamily = atomFamily((id) => atom(id))
<ScopedProvider atomFamilies={[fooFamily]}>{children}</ScopeProvider>
```
This PR demonstrates one approach in which the atomFamily supports use of instanceof language feature.

The following pseudo code represents logic that would live in jotai-scope.
```js
const isExplicitlyScoped = atomSet.has(atom) || Array.from(atomFamilySet).some(af => atom instanceof af)
```

## Check List

- [x] `pnpm run prettier` for formatting code and docs
