### PR TITLE
feat(utils): atomFamily supports getParams and unstable_listen api

### DIFF
--- a/src/vanilla/utils/atomFamily.ts
+++ b/src/vanilla/utils/atomFamily.ts
@@ -1,4 +1,4 @@
-import type { Atom } from '../../vanilla.ts'
+import { type Atom } from '../../vanilla.ts'
 
 type ShouldRemove<Param> = (createdAt: number, param: Param) => boolean
 type Cleanup = () => void
@@ -56,8 +56,8 @@ export function atomFamily<Param, AtomType extends Atom<unknown>>(
     }
 
     const newAtom = initializeAtom(param)
-    notifyListeners('CREATE', param, newAtom)
     atoms.set(param, [newAtom, Date.now()])
+    notifyListeners('CREATE', param, newAtom)
     return newAtom
   }
 
@@ -84,13 +84,13 @@ export function atomFamily<Param, AtomType extends Atom<unknown>>(
     if (areEqual === undefined) {
       if (!atoms.has(param)) return
       const [atom] = atoms.get(param)!
-      notifyListeners('REMOVE', param, atom)
       atoms.delete(param)
+      notifyListeners('REMOVE', param, atom)
     } else {
       for (const [key, [atom]] of atoms) {
         if (areEqual(key, param)) {
-          notifyListeners('REMOVE', key, atom)
           atoms.delete(key)
+          notifyListeners('REMOVE', key, atom)
           break
         }
       }
@@ -102,8 +102,8 @@ export function atomFamily<Param, AtomType extends Atom<unknown>>(
     if (!shouldRemove) return
     for (const [key, [atom, createdAt]] of atoms) {
       if (shouldRemove(createdAt, key)) {
-        notifyListeners('REMOVE', key, atom)
         atoms.delete(key)
+        notifyListeners('REMOVE', key, atom)
       }
     }
   }

--- a/src/vanilla/utils/atomFamily.ts
+++ b/src/vanilla/utils/atomFamily.ts
@@ -1,6 +1,10 @@
 import { type Atom } from '../../vanilla.ts'
 
-type ShouldRemove<Param> = (createdAt: number, param: Param) => boolean
+/**
+ * in milliseconds
+ */
+type CreatedAt = number
+type ShouldRemove<Param> = (createdAt: CreatedAt, param: Param) => boolean
 type Cleanup = () => void
 type Callback<Param, AtomType> = (event: {
   type: 'CREATE' | 'REMOVE'
@@ -29,7 +33,6 @@ export function atomFamily<Param, AtomType extends Atom<unknown>>(
   initializeAtom: (param: Param) => AtomType,
   areEqual?: (a: Param, b: Param) => boolean,
 ) {
-  type CreatedAt = number // in milliseconds
   let shouldRemove: ShouldRemove<Param> | null = null
   const atoms: Map<Param, [AtomType, CreatedAt]> = new Map()
   const listeners = new Set<Callback<Param, AtomType>>()

--- a/src/vanilla/utils/atomFamily.ts
+++ b/src/vanilla/utils/atomFamily.ts
@@ -15,6 +15,7 @@ export interface AtomFamily<Param, AtomType> {
   setShouldRemove(shouldRemove: ShouldRemove<Param> | null): void
   /**
    * fires when a atom is created or removed
+   * This API is for advanced use cases, and can change without notice.
    */
   unstable_listen(callback: Callback<Param, AtomType>): Cleanup
 }

--- a/tests/vanilla/utils/atomFamily.test.ts
+++ b/tests/vanilla/utils/atomFamily.test.ts
@@ -1,0 +1,94 @@
+import { expect, it, vi } from 'vitest'
+import { type Atom, atom, createStore } from 'jotai/vanilla'
+import { atomFamily } from 'jotai/vanilla/utils'
+
+it('should create atoms with different params', () => {
+  const store = createStore()
+  const aFamily = atomFamily((param: number) => atom(param))
+
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(store.get(aFamily(2))).toEqual(2)
+})
+
+it('should remove atoms', () => {
+  const store = createStore()
+  const initializeAtom = vi.fn((param: number) => atom(param))
+  const aFamily = atomFamily(initializeAtom)
+
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(store.get(aFamily(2))).toEqual(2)
+  aFamily.remove(2)
+  initializeAtom.mockClear()
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(initializeAtom).toHaveBeenCalledTimes(0)
+  expect(store.get(aFamily(2))).toEqual(2)
+  expect(initializeAtom).toHaveBeenCalledTimes(1)
+})
+
+it('should remove atoms with custom comparator', () => {
+  const store = createStore()
+  const initializeAtom = vi.fn((param: number) => atom(param))
+  const aFamily = atomFamily(initializeAtom, (a, b) => a === b)
+
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(store.get(aFamily(2))).toEqual(2)
+  expect(store.get(aFamily(3))).toEqual(3)
+  aFamily.remove(2)
+  initializeAtom.mockClear()
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(initializeAtom).toHaveBeenCalledTimes(0)
+  expect(store.get(aFamily(2))).toEqual(2)
+  expect(initializeAtom).toHaveBeenCalledTimes(1)
+})
+
+it('should remove atoms with custom shouldRemove', () => {
+  const store = createStore()
+  const initializeAtom = vi.fn((param: number) => atom(param))
+  const aFamily = atomFamily<number, Atom<number>>(initializeAtom)
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(store.get(aFamily(2))).toEqual(2)
+  expect(store.get(aFamily(3))).toEqual(3)
+  aFamily.setShouldRemove((_createdAt, param) => param % 2 === 0)
+  initializeAtom.mockClear()
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(initializeAtom).toHaveBeenCalledTimes(0)
+  expect(store.get(aFamily(2))).toEqual(2)
+  expect(initializeAtom).toHaveBeenCalledTimes(1)
+  expect(store.get(aFamily(3))).toEqual(3)
+  expect(initializeAtom).toHaveBeenCalledTimes(1)
+})
+
+it('should notify listeners', () => {
+  const aFamily = atomFamily((param: number) => atom(param))
+  const listener = vi.fn(() => {})
+  type Event = { type: 'CREATE' | 'REMOVE'; param: number; atom: Atom<number> }
+  const unsubscribe = aFamily.unstable_listen(listener)
+  const atom1 = aFamily(1)
+  expect(listener).toHaveBeenCalledTimes(1)
+  const eventCreate = listener.mock.calls[0]?.at(0) as unknown as Event
+  if (!eventCreate) throw new Error('eventCreate is undefined')
+  expect(eventCreate.type).toEqual('CREATE')
+  expect(eventCreate.param).toEqual(1)
+  expect(eventCreate.atom).toEqual(atom1)
+  listener.mockClear()
+  aFamily.remove(1)
+  expect(listener).toHaveBeenCalledTimes(1)
+  const eventRemove = listener.mock.calls[0]?.at(0) as unknown as Event
+  expect(eventRemove.type).toEqual('REMOVE')
+  expect(eventRemove.param).toEqual(1)
+  expect(eventRemove.atom).toEqual(atom1)
+  unsubscribe()
+  listener.mockClear()
+  aFamily(2)
+  expect(listener).toHaveBeenCalledTimes(0)
+})
+
+it('should return all params', () => {
+  const store = createStore()
+  const aFamily = atomFamily((param: number) => atom(param))
+
+  expect(store.get(aFamily(1))).toEqual(1)
+  expect(store.get(aFamily(2))).toEqual(2)
+  expect(store.get(aFamily(3))).toEqual(3)
+  expect(Array.from(aFamily.getParams())).toEqual([1, 2, 3])
+})

--- a/tests/vanilla/utils/atomFamily.test.ts
+++ b/tests/vanilla/utils/atomFamily.test.ts
@@ -1,5 +1,6 @@
 import { expect, it, vi } from 'vitest'
-import { type Atom, atom, createStore } from 'jotai/vanilla'
+import { atom, createStore } from 'jotai/vanilla'
+import type { Atom } from 'jotai/vanilla'
 import { atomFamily } from 'jotai/vanilla/utils'
 
 it('should create atoms with different params', () => {


### PR DESCRIPTION
## Related Bug Reports or Discussions
### Past ideas
idea1: https://github.com/pmndrs/jotai/pull/2678
idea2: https://github.com/pmndrs/jotai/pull/2679
idea3: https://github.com/pmndrs/jotai/pull/2681
idea4: https://github.com/pmndrs/jotai/pull/2683

Fixes #2056
Fixes https://github.com/jotaijs/jotai-scope/issues/50

## Summary
jotai-scope is trying to support scoping atomFamily.
```jsx
const fooFamily = atomFamily((id) => atom(id))
<ScopedProvider atomFamilies={[fooFamily]}>{children}</ScopeProvider>
```
This PR demonstrates one approach in which the atomFamily supports `getParams` and `unstable_listen`.

The following pseudo code represents logic that would live in jotai-scope.
```js
function handleChange({ type, atom }) {
  if (type === 'CREATE') {
    atomSet.add(atom)
  } else {
    atomSet.delete(atom)
  }
}

for (const atomFamily of atomFamilies) {
  atomFamily.unstable_listen(handleChange)
  for (const param of atomFamily.getParams()) {
    atomSet.add(atomFamily(param))
  }
}
  ...
const isExplicitlyScoped = atomSet.has(atom)
```

## Check List

- [x] `pnpm run prettier` for formatting code and docs
