### PR TITLE
docs: (jotai-tanstack-query) remove wonka as a peer dependency

### DIFF
--- a/docs/extensions/query.mdx
+++ b/docs/extensions/query.mdx
@@ -19,10 +19,10 @@ jotai-tanstack-query currently supports TanStack Query v5.
 
 ### Install
 
-In addition to `jotai`, you have to install `jotai-tanstack-query`, `@tanstack/query-core` and `wonka` to use the extension.
+In addition to `jotai`, you have to install `jotai-tanstack-query` and `@tanstack/query-core` to use the extension.
 
 ```bash
-npm i jotai-tanstack-query @tanstack/query-core wonka
+npm i jotai-tanstack-query @tanstack/query-core
 ```
 
 ### Incremental Adoption


### PR DESCRIPTION
## Summary
Wonka has been removed as a peer dependency from jotai-tanstack-query as part of https://github.com/jotaijs/jotai-tanstack-query/pull/84. This PR is to update the documentation.


## Check List

- [x] `pnpm run prettier` for formatting code and docs
