### PR TITLE
fix(store2): reusing continuable promise causes dependencies to be lost

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -385,12 +385,8 @@ const buildStore = (getAtomState: StoreArgs[0]): Store => {
       }
     }
 
-    if (isContinuablePromise(atomState.v) && atomState.v.status === PENDING) {
-      // If the atom has a pending promise, we should preserve the dependents
-    } else {
-      // Compute a new state for this atom.
-      atomState.d.clear()
-    }
+    // Compute a new state for this atom.
+    atomState.d.clear()
     let isSync = true
     const getter: Getter = <V>(a: Atom<V>) => {
       if (isSelfAtom(atom, a)) {

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -384,8 +384,13 @@ const buildStore = (getAtomState: StoreArgs[0]): Store => {
         return atomState
       }
     }
-    // Compute a new state for this atom.
-    atomState.d.clear()
+
+    if (isContinuablePromise(atomState.v) && atomState.v.status === PENDING) {
+      // If the atom has a pending promise, we should preserve the dependents
+    } else {
+      // Compute a new state for this atom.
+      atomState.d.clear()
+    }
     let isSync = true
     const getter: Getter = <V>(a: Atom<V>) => {
       if (isSelfAtom(atom, a)) {

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -611,7 +611,7 @@ it('should preserve dependencies when reusing continuable promise', async () => 
         setSelf()
         return value
       })
-      setTimeout(() => {
+      Promise.resolve().then(() => {
         inProgress = false
       })
       return promise


### PR DESCRIPTION
## Related Bug Reports or Discussions
https://github.com/jotaijs/jotai-effect/issues/42

## Summary
When a promise is reused on subsequent recomputations, the dependencies are not preserved.
~This is affecting the functionality of atomEffect.~ A [workaround](https://github.com/jotaijs/jotai-effect/pull/43) has been found.
This test is broken since https://github.com/pmndrs/jotai/commit/1a40452738cc40176d44d27b9e7f52dbd156f0ba

## Check List

- [x] `pnpm run prettier` for formatting code and docs
