### PR TITLE
Mention connections to functional programming in README and docs

### DIFF
--- a/docs/basics/functional-programming-and-jotai.mdx
+++ b/docs/basics/functional-programming-and-jotai.mdx
@@ -23,12 +23,13 @@ const greetingAtom = atom((get) => {
 ```
 
 Now, compare that code with `async`–`await`:
+
 ```tsx
 const namePromise = Promise.resolve('Visitor')
 const countPromise = Promise.resolve(1)
-const greetingPromise = (async function() {
-  const name = await namePromise;
-  const count = await countPromise;
+const greetingPromise = (async function () {
+  const name = await namePromise
+  const count = await countPromise
   return (
     <div>
       Hello, {nameAtom}! You have visited this page {countAtom} times.

--- a/docs/basics/functional-programming-and-jotai.mdx
+++ b/docs/basics/functional-programming-and-jotai.mdx
@@ -1,0 +1,67 @@
+---
+title: Functional programming and Jotai
+nav: 6.04
+---
+
+### Unexpected similarities
+
+If you look at getter functions long enough, you may see a striking resemblence
+to a certain JavaScript language feature.
+
+```tsx
+const nameAtom = atom('Visitor')
+const countAtom = atom(1)
+const greetingAtom = atom((get) => {
+  const name = get(nameAtom)
+  const count = get(countAtom)
+  return (
+    <div>
+      Hello, {nameAtom}! You have visited this page {countAtom} times.
+    </div>
+  )
+})
+```
+
+Now, compare that code with `async`–`await`:
+```tsx
+const namePromise = Promise.resolve('Visitor')
+const countPromise = Promise.resolve(1)
+const greetingPromise = (async function() {
+  const name = await namePromise;
+  const count = await countPromise;
+  return (
+    <div>
+      Hello, {nameAtom}! You have visited this page {countAtom} times.
+    </div>
+  )
+})()
+```
+
+This similarity is no coincidence. Both atoms and promises are **Monads**, a
+concept from **functional programming**. The syntax used in both examples is
+called **do-notation**, a syntax sugar for the plainer monad interface.
+
+---
+
+The monad interface is responsible for the fluidity of the atom and promise
+interfaces. The monad interface allowed us to define `greetingAtom` in terms of
+`nameAtom` and `countAtom`, and allowed us to define `greetingPromise` in terms
+of `namePromise` and `countPromise`.
+
+For the mathematically inclined, a structure (like `Atom` or `Promise`) is a
+monad if you can implement the following functions for it. A fun exercise is
+trying to implement `of`, `map` and `join` for Atoms, Promises and Arrays.
+
+```typescript
+type SomeMonad<T> = /* ... */
+declare function of<T>(plainValue: T): SomeMonad<T>
+declare function map<T, V>(
+  anInstance: SomeMonad<T>,
+  transformContents: (contents: T) => V
+): SomeMonad<V>
+declare function join<T>(nestedInstances: SomeMonad<SomeMonad<T>>): SomeMonad<T>
+```
+
+Monads have been an interest to mathematicians for 60 years, and to programmers
+for 40. There are countless resources out there on patterns for monads, such
+as `Traversable`–`sequence`. Take a look at them!

--- a/readme.md
+++ b/readme.md
@@ -163,7 +163,7 @@ function Controls() {
 ### Note about functional programming
 
 Jotai's fluid interface is no accident — atoms are monads, just like promises!
-Monads are an [established](https://en.wikipedia.org/wiki/Monad_(functional_programming))
+Monads are an [established](<https://en.wikipedia.org/wiki/Monad_(functional_programming)>)
 pattern for modular, pure, robust and understandable code which is [optimized for change](https://overreacted.io/optimized-for-change/).
 Read more about [Jotai and monads.](https://jotai.org/docs/basics/functional-programming-and-jotai)
 

--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,13 @@ function Controls() {
     ...
 ```
 
+### Note about functional programming
+
+Jotai's fluid interface is no accident — atoms are monads, just like promises!
+Monads are an [established](https://en.wikipedia.org/wiki/Monad_(functional_programming))
+pattern for modular, pure, robust and understandable code which is [optimized for change](https://overreacted.io/optimized-for-change/).
+Read more about [Jotai and monads.](https://jotai.org/docs/basics/functional-programming-and-jotai)
+
 ## Links
 
 - [website](https://jotai.org)


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #2724

## Summary

Jotai atoms are monads. This is a compelling reason to choose Jotai, so it should be mentioned in the README and in documentation.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
