### PR TITLE
docs: add a note for useHydrateAtoms client code usage

### DIFF
--- a/docs/utilities/ssr.mdx
+++ b/docs/utilities/ssr.mdx
@@ -24,6 +24,8 @@ const CounterPage = ({ countFromServer }) => {
 
 The primary use case for `useHydrateAtoms` are SSR apps like Next.js, where an initial value is e.g. fetched on the server, which can be passed to a component by props.
 
+⚠️ Note: Although the term "hydrate" might suggest server-side usage, this hook is designed for client-side code and should be used with the [`'use client'` directive](https://react.dev/reference/rsc/use-client).
+
 ```ts
 // Definition
 function useHydrateAtoms(


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes  [#2470#discussioncomment-10838165](https://github.com/pmndrs/jotai/discussions/2470#discussioncomment-10838165)

## Summary

This PR adds a note for `useHydrateAtoms` docs to emphasize its client code usage.

Preview:
<img width="723" alt="image" src="https://github.com/user-attachments/assets/e37edc6b-3dbe-4275-9702-92ac4f4c92d2">



## Check List

- [x] `pnpm run prettier` for formatting code and docs
