### PR TITLE
test: improve code coverage for atomWithDefault

### DIFF
--- a/tests/react/vanilla-utils/atomWithDefault.test.tsx
+++ b/tests/react/vanilla-utils/atomWithDefault.test.tsx
@@ -1,6 +1,6 @@
 import { StrictMode, Suspense } from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
-import { userEvent } from '@testing-library/user-event'
+import userEvent from '@testing-library/user-event'
 import { expect, it } from 'vitest'
 import { useAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -209,8 +209,6 @@ it('refresh async atoms to default values', async () => {
 it('can be set synchronously by passing value', async () => {
   const countAtom = atomWithDefault(() => 1)
 
-  const user = userEvent.setup()
-
   const Counter = () => {
     const [count, setCount] = useAtom(countAtom)
 
@@ -226,7 +224,7 @@ it('can be set synchronously by passing value', async () => {
 
   expect(screen.getByText('count: 1')).toBeDefined()
 
-  await user.click(screen.getByRole('button', { name: 'Set to 10' }))
+  await userEvent.click(screen.getByRole('button', { name: 'Set to 10' }))
 
   expect(screen.getByText('count: 10')).toBeDefined()
 })

--- a/tests/react/vanilla-utils/atomWithDefault.test.tsx
+++ b/tests/react/vanilla-utils/atomWithDefault.test.tsx
@@ -1,7 +1,7 @@
 import { StrictMode, Suspense } from 'react'
 import { render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { it } from 'vitest'
+import { expect, it } from 'vitest'
 import { useAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
 import { RESET, atomWithDefault } from 'jotai/vanilla/utils'
@@ -204,4 +204,29 @@ it('refresh async atoms to default values', async () => {
     resolve()
     getByText('count1: 4, count2: 8')
   })
+})
+
+it('can be set synchronously by passing value', async () => {
+  const countAtom = atomWithDefault(() => 1)
+
+  const user = userEvent.setup()
+
+  const Counter = () => {
+    const [count, setCount] = useAtom(countAtom)
+
+    return (
+      <>
+        <div>count: {count}</div>
+        <button onClick={() => setCount(10)}>Set to 10</button>
+      </>
+    )
+  }
+
+  const { getByText, getByRole } = render(<Counter />)
+
+  expect(getByText('count: 1')).toBeDefined()
+
+  await user.click(getByRole('button', { name: 'Set to 10' }))
+
+  expect(getByText('count: 10')).toBeDefined()
 })

--- a/tests/react/vanilla-utils/atomWithDefault.test.tsx
+++ b/tests/react/vanilla-utils/atomWithDefault.test.tsx
@@ -1,6 +1,6 @@
 import { StrictMode, Suspense } from 'react'
-import { render, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import { expect, it } from 'vitest'
 import { useAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
@@ -222,11 +222,11 @@ it('can be set synchronously by passing value', async () => {
     )
   }
 
-  const { getByText, getByRole } = render(<Counter />)
+  render(<Counter />)
 
-  expect(getByText('count: 1')).toBeDefined()
+  expect(screen.getByText('count: 1')).toBeDefined()
 
-  await user.click(getByRole('button', { name: 'Set to 10' }))
+  await user.click(screen.getByRole('button', { name: 'Set to 10' }))
 
-  expect(getByText('count: 10')).toBeDefined()
+  expect(screen.getByText('count: 10')).toBeDefined()
 })


### PR DESCRIPTION
## Summary

Added unit test with missing scenario of setting `atomWithDefault` with primitive value. Provides 100% of code coverage for this utility.


## Check List

- [x] `pnpm run prettier` for formatting code and docs
