### PR TITLE
test: calculate coverage for src files only

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'json', 'html', 'text-summary'],
       reportsDirectory: './coverage/',
+      include: ['src/**'],
     },
     onConsoleLog(log) {
       if (log.includes('DOMException')) return false


### PR DESCRIPTION
## Summary

Code coverage should rather take into account files from `src`. Files from folders like `benchmark`, `examples` or `website` should not be taken into account when evaluating coverage.

Quote from Vitest 
> It's recommended to always define [coverage.include](https://vitest.dev/config/#coverage-include) in your configuration file. This helps Vitest to reduce the amount of files picked by [coverage.all](https://vitest.dev/config/#coverage-all).

## Check List

- [x] `pnpm run prettier` for formatting code and docs
