### PR TITLE
fix(utils): make 'unwrap' update immediate after resolve

### DIFF
--- a/src/vanilla/utils/unwrap.ts
+++ b/src/vanilla/utils/unwrap.ts
@@ -60,12 +60,16 @@ export function unwrap<Value, Args extends unknown[], Result, PendingValue>(
             return { v: promise as Awaited<Value> }
           }
           if (promise !== prev?.p) {
-            promise
-              .then(
-                (v) => promiseResultCache.set(promise, v as Awaited<Value>),
-                (e) => promiseErrorCache.set(promise, e),
-              )
-              .finally(setSelf)
+            promise.then(
+              (v) => {
+                promiseResultCache.set(promise, v as Awaited<Value>)
+                setSelf()
+              },
+              (e) => {
+                promiseErrorCache.set(promise, e)
+                setSelf()
+              },
+            )
           }
           if (promiseErrorCache.has(promise)) {
             throw promiseErrorCache.get(promise)

--- a/tests/vanilla/utils/unwrap.test.ts
+++ b/tests/vanilla/utils/unwrap.test.ts
@@ -137,4 +137,16 @@ describe('unwrap', () => {
     await new Promise((r) => setTimeout(r)) // wait for a tick
     expect(store.get(unwrap(asyncAtom))).toEqual('concrete')
   })
+
+  it('should get a fulfilled value after the promise resolves', async () => {
+    const store = createStore()
+    const asyncAtom = atom(Promise.resolve('concrete'))
+    const syncAtom = unwrap(asyncAtom)
+
+    expect(store.get(syncAtom)).toEqual(undefined)
+
+    await store.get(asyncAtom)
+
+    expect(store.get(syncAtom)).toEqual('concrete')
+  })
 })


### PR DESCRIPTION
## Related Bug Reports or Discussions

Identical to https://github.com/pmndrs/jotai/pull/2790, but for `unwrap`
This regression is from the change here: https://github.com/pmndrs/jotai/pull/2695

## Summary
 
When upgrading from 2.8.4 to 2.10.1, `unwrap` hangs in certain cases. I narrowed it down to atoms such as this one:

`atomWithDefault((get) => get(unwrap(anAsyncAtom)))`

Applying https://github.com/pmndrs/jotai/pull/2790 to `unwrap` fixes things.

Note that the recommended pattern for such atoms is to use two atoms:

```
const atomA = unwrap(anAsyncAtom);
const atomB = atomWithDefault((get) => get(atomA));
```

In this case, inlining `atomA` into `atomWithDefault` only works if `unwrap`'s default fallback is used, meaning the following code will hang:

`const atomB = atomWithDefault((get) => get(unwrap(anAsyncAtom, (prev) => prev ?? 'MAGIC_DEFAULT')));`

## Check List

- [x] `pnpm run prettier` for formatting code and docs
