### PR TITLE
fix(website): Add ctl=1 as a query parameter to the StackBlitz iframe's src URL.

### DIFF
--- a/website/src/components/stackblitz.js
+++ b/website/src/components/stackblitz.js
@@ -4,7 +4,7 @@ export const Stackblitz = ({ id, file }) => {
       <iframe
         title={id}
         className="h-[400px] w-full"
-        src={`https://stackblitz.com/edit/${id}?embed=1${file ? `&file=${file}` : ''}&terminal=dev`}
+        src={`https://stackblitz.com/edit/${id}?embed=1${file ? `&file=${file}` : ''}&terminal=dev&ctl=1`}
         allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
         sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
         loading="lazy"


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #2791

## Summary

- Add ctl=1 as a query parameter to the StackBlitz iframe's src URL.

### AS-IS

![조타이수정전](
https://github.com/user-attachments/assets/1b7b78b1-5294-4144-a88a-e6a3faaf78f2
)

### TO-BE

![조타이수정후](
https://github.com/user-attachments/assets/1a6dc35b-5d98-4a19-97eb-b3d8481ab2be
)


## Check List

- [x] `pnpm run prettier` for formatting code and docs