### PR TITLE
docs: fix typo in Immer

### DIFF
--- a/docs/extensions/immer.mdx
+++ b/docs/extensions/immer.mdx
@@ -84,7 +84,7 @@ Check this example with withImmer:
 This hook takes an atom and replaces the atom's `writeFunction` with the new immer-like `writeFunction` like the previous helpers.
 
 ```jsx
-import { useAtom } from 'jotai'
+import { atom } from 'jotai'
 import { useImmerAtom } from 'jotai-immer'
 
 const primitiveAtom = atom({ value: 0 })


### PR DESCRIPTION
## Summary

Corrected from `useAtom` to `atom`.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
