### PR TITLE
Updated `location.mdx` regarding `atomWithLocation` instances

### DIFF
--- a/docs/extensions/location.mdx
+++ b/docs/extensions/location.mdx
@@ -23,6 +23,9 @@ atomWithLocation(options): PrimitiveAtom
 
 `atomWithLocation` creates a new atom that links to `window.location`.
 
+Typically, you should only instantiate atomWithLocation once per application. This is because changes made to one instance might not be reflected in others. 
+As this atom is designed to synchronize with the window.location object, using multiple instances can lead to unpredictable behavior.
+
 ### Parameters
 
 **options** (optional): an object of options to customize the behavior of the atom

--- a/docs/extensions/location.mdx
+++ b/docs/extensions/location.mdx
@@ -23,8 +23,8 @@ atomWithLocation(options): PrimitiveAtom
 
 `atomWithLocation` creates a new atom that links to `window.location`.
 
-Typically, you should only instantiate atomWithLocation once per application. This is because changes made to one instance might not be reflected in others. 
-As this atom is designed to synchronize with the window.location object, using multiple instances can lead to unpredictable behavior.
+Typically, you should only instantiate `atomWithLocation` once per application. This is because changes made to one instance might not be reflected in others.
+As this atom is designed to synchronize with the `window.location` object, using multiple instances can lead to unpredictable behavior.
 
 ### Parameters
 


### PR DESCRIPTION
Added an important warning note against instantiating `atomWithLocation` more than once in an app

## Related Bug Reports or Discussions

https://github.com/jotaijs/jotai-location/issues/38

## Check List

- [x] `pnpm run prettier` for formatting code and docs
