### PR TITLE
fix: setAtom uses stale pending on atom unmount

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -603,9 +603,9 @@ const buildStore = (
       if (isActuallyWritableAtom(atom)) {
         const mounted = atomState.m
         let setAtom: (...args: unknown[]) => unknown
-        const createSetAtom =
-          (pending: Pending, isSync: boolean) =>
-          (...args: unknown[]) => {
+        const createInvocationContext = <T>(pending: Pending, fn: () => T) => {
+          let isSync = true
+          setAtom = (...args: unknown[]) => {
             try {
               return writeAtomState(pending, atom, ...args)
             } finally {
@@ -614,12 +614,10 @@ const buildStore = (
               }
             }
           }
-        const createInvocationContext = <T>(pending: Pending, fn: () => T) => {
-          setAtom = createSetAtom(pending, true)
           try {
             return fn()
           } finally {
-            setAtom = createSetAtom(pending, false)
+            isSync = false
           }
         }
         addPendingFunction(pending, () => {

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -602,16 +602,17 @@ const buildStore = (
       }
       if (isActuallyWritableAtom(atom)) {
         const mounted = atomState.m
-        const createSetAtom = (pending: Pending, isSync: boolean) =>
-          isSync
-            ? (...args: unknown[]) => writeAtomState(pending, atom, ...args)
-            : (...args: unknown[]) => {
-                try {
-                  return writeAtomState(pending, atom, ...args)
-                } finally {
-                  flushPending(pending)
-                }
+        const createSetAtom =
+          (pending: Pending, isSync: boolean) =>
+          (...args: unknown[]) => {
+            try {
+              return writeAtomState(pending, atom, ...args)
+            } finally {
+              if (!isSync) {
+                flushPending(pending)
               }
+            }
+          }
         addPendingFunction(pending, () => {
           let onUnmount: OnUnmount | void
           let setAtom = createSetAtom(pending, true)

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -614,22 +614,19 @@ const buildStore = (
               }
             }
           }
-        addPendingFunction(pending, () => {
-          const createInvocationContext = (
-            pending: Pending,
-            fn: () => void,
-          ) => {
-            setAtom = createSetAtom(pending, true)
-            try {
-              return fn()
-            } finally {
-              setAtom = createSetAtom(pending, false)
-            }
+        const createInvocationContext = <T>(pending: Pending, fn: () => T) => {
+          setAtom = createSetAtom(pending, true)
+          try {
+            return fn()
+          } finally {
+            setAtom = createSetAtom(pending, false)
           }
+        }
+        addPendingFunction(pending, () => {
           const onUnmount = createInvocationContext(pending, () =>
             atomOnMount(atom, (...args) => setAtom(...args)),
           )
-          if (typeof onUnmount === 'function') {
+          if (onUnmount) {
             mounted.u = (pending) => createInvocationContext(pending, onUnmount)
           }
         })

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -896,3 +896,17 @@ it('throws falsy errors in onMount, onUnmount, and listeners', () => {
   })
   expect(() => store.set(c, 1)).toThrow('')
 })
+
+it('should use the correct pending on unmount', () => {
+  const store = createStore()
+  const a = atom(0)
+  const b = atom(0, (_, set, update: number) => set(a, update))
+  b.onMount = (setAtom) => () => setAtom(1)
+  const aListener = vi.fn()
+  store.sub(a, aListener)
+  const unsub = store.sub(b, () => {})
+  aListener.mockClear()
+  unsub()
+  expect(store.get(a)).toBe(1)
+  expect(aListener).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
## Related Bug Reports or Discussions
- https://github.com/pmndrs/jotai/discussions/2812

## setAtom uses stale pending on atom unmount (https://github.com/pmndrs/jotai/discussions/2812)
- adds failing test: should use the correct pending on unmount
- fixes failing test

### Why is setAtom using a stale reference of pending?
Because setAtom is defined in mountAtom and references that function's pending.

Fix: dependency inject the current pending when invoking the pending functions

## Check List

- [x] `pnpm run prettier` for formatting code and docs
