### PR TITLE
fix: onMount setSelf does not notify listeners

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -666,9 +666,9 @@ const buildStore = (
     const pending = createPending()
     const atomState = getAtomState(atom)
     const mounted = mountAtom(pending, atom, atomState)
-    flushPending(pending)
     const listeners = mounted.l
     listeners.add(listener)
+    flushPending(pending)
     return () => {
       listeners.delete(listener)
       const pending = createPending()

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -910,3 +910,26 @@ it('should use the correct pending on unmount', () => {
   expect(store.get(a)).toBe(1)
   expect(aListener).toHaveBeenCalledTimes(1)
 })
+
+it('should call subscribers after setAtom updates atom value on mount but not on unmount', () => {
+  const store = createStore()
+  const a = atom(0)
+  let unmount
+  a.onMount = vi.fn(((setAtom) => {
+    setAtom(1)
+    unmount = vi.fn(() => {
+      setAtom(2)
+    })
+    return unmount
+  }) as NonNullable<(typeof a)['onMount']>)
+  const listener = vi.fn()
+  const unsub = store.sub(a, listener)
+  expect(store.get(a)).toBe(1)
+  expect(a.onMount).toHaveBeenCalledTimes(1)
+  expect(listener).toHaveBeenCalledTimes(1)
+  listener.mockClear()
+  unsub()
+  expect(store.get(a)).toBe(2)
+  expect(unmount).toHaveBeenCalledTimes(1)
+  expect(listener).toHaveBeenCalledTimes(0)
+})


### PR DESCRIPTION
## Related Bug Reports or Discussions
- https://github.com/pmndrs/jotai/discussions/2810

## onMount setSelf does not notify listeners (https://github.com/pmndrs/jotai/discussions/2810)
- adds failing test: when changing the atom value with onMount setSelf, subscribers are not called
- fixes failing test

### Why aren't listeners called when calling setAtom in onMount?
Because the listener is added only after flushPending is called.

Fix: swap the order of flush pending and listeners.add(listener).

### Why aren't listeners called when calling setAtom in onUnmount?
Because the listener is deleted before flushPending is called.

There's a logic cycle here:
1. the listener is deleted _before_ calling unmountAtom, because unmountAtom only processes if atomState.m.l.size === 0
2. unmountAtom adds the onUnmount pending function
3. flushPending calls onUnmount pending function
4. setAtom fires in onUnmount pending function, which updates the atom
5. subscriber doesn't fire because it was removed in 1

👉 NOTE: This is expected behavior.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
