### PR TITLE
Add test "Atom graph supports cycles"

### DIFF
--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -901,7 +901,7 @@ it('throws falsy errors in onMount, onUnmount, and listeners', () => {
   expect(() => store.set(c, 1)).toThrow('')
 })
 
-it.only('supports cycles in the atom graph', () => {
+it('supports cycles in the atom graph', () => {
   const store = createStore() as INTERNAL_DevStoreRev4 & INTERNAL_PrdStore
   const v = atom(0)
   v.debugLabel = 'v'
@@ -926,11 +926,17 @@ it.only('supports cycles in the atom graph', () => {
   store.sub(a, () => {})
 
   const vState = getAtomState(v) as AtomState
-  // vState.label = 'v'
+  if (vState) {
+    vState.label = 'v'
+  }
   const aState = getAtomState(a) as AtomState
-  // aState.label = 'a'
+  if (vState) {
+    aState.label = 'a'
+  }
   const bState = getAtomState(b) as AtomState
-  // bState.label = 'b'
+  if (vState) {
+    bState.label = 'b'
+  }
 
   let unsub: () => void
 


### PR DESCRIPTION
## Related Bug Reports or Discussions
https://github.com/pmndrs/jotai/pull/2742#issuecomment-2479272955
https://github.com/pmndrs/jotai/discussions/2823

## Summary
With the change https://github.com/pmndrs/jotai/pull/2742 ([v2.10.1](https://github.com/pmndrs/jotai/releases/tag/v2.10.1)), cycles in atom graphs will error with a RangeError in readAtomState and onmount.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
