### PR TITLE
add tests: can read sync derived atom in write without initializing

### DIFF
--- a/tests/vanilla/dependency.test.tsx
+++ b/tests/vanilla/dependency.test.tsx
@@ -1,6 +1,5 @@
 import { expect, it, vi } from 'vitest'
 import { atom, createStore } from 'jotai/vanilla'
-import type { Getter } from 'jotai/vanilla'
 
 it('can propagate updates with async atom chains', async () => {
   const store = createStore()

--- a/tests/vanilla/dependency.test.tsx
+++ b/tests/vanilla/dependency.test.tsx
@@ -1,5 +1,6 @@
 import { expect, it, vi } from 'vitest'
 import { atom, createStore } from 'jotai/vanilla'
+import type { Getter } from 'jotai/vanilla'
 
 it('can propagate updates with async atom chains', async () => {
   const store = createStore()
@@ -333,4 +334,16 @@ it('handles complex dependency chains', async () => {
   const promise2 = store.get(asyncDerived)
   resolve()
   expect(await promise2).toBe(10)
+})
+
+it('can read sync derived atom in write without initializing', () => {
+  const store = createStore()
+  const a = atom(0)
+  const b = atom((get) => get(a) + 1)
+  const c = atom(null, (get, set) => set(a, get(b)))
+  store.set(c)
+  expect(store.get(a)).toBe(1)
+  store.set(c)
+  // note: this is why write get needs to update deps
+  expect(store.get(a)).toBe(2)
 })


### PR DESCRIPTION
## Related Bug Reports or Discussions
https://github.com/pmndrs/jotai/discussions/2789#discussioncomment-11275111

## Summary
This PR adds two tests to enforce the behavior:
 - _atoms accessed with write get should have their dependencies updated_

## Check List

- [x] `pnpm run prettier` for formatting code and docs
