### PR TITLE
[Idea] tweak atom type naming

### DIFF
--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -1,24 +1,28 @@
 type Getter = <Value>(atom: Atom<Value>) => Value
 
+type Peeker = Getter
+
 type Setter = <Value, Args extends unknown[], Result>(
   atom: WritableAtom<Value, Args, Result>,
   ...args: Args
 ) => Result
 
-type SetAtom<Args extends unknown[], Result> = <A extends Args>(
+type SetSelf<Args extends unknown[], Result> = <A extends Args>(
   ...args: A
 ) => Result
+
+type SetSelfAsync<Args extends unknown[], Result> = SetSelf<Args, Result>
 
 /**
  * setSelf is for internal use only and subject to change without notice.
  */
-type Read<Value, SetSelf = never> = (
+type Read<Value, SetSelfAsync = never> = (
   get: Getter,
-  options: { readonly signal: AbortSignal; readonly setSelf: SetSelf },
+  options: { readonly signal: AbortSignal; readonly setSelf: SetSelfAsync },
 ) => Value
 
 type Write<Args extends unknown[], Result> = (
-  get: Getter,
+  peek: Peeker,
   set: Setter,
   ...args: Args
 ) => Result
@@ -32,9 +36,9 @@ type WithInitialValue<Value> = {
 type OnUnmount = () => void
 
 type OnMount<Args extends unknown[], Result> = <
-  S extends SetAtom<Args, Result>,
+  S extends SetSelf<Args, Result>,
 >(
-  setAtom: S,
+  setSelf: S,
 ) => OnUnmount | void
 
 export interface Atom<Value> {
@@ -51,7 +55,7 @@ export interface Atom<Value> {
 
 export interface WritableAtom<Value, Args extends unknown[], Result>
   extends Atom<Value> {
-  read: Read<Value, SetAtom<Args, Result>>
+  read: Read<Value, SetSelfAsync<Args, Result>>
   write: Write<Args, Result>
   onMount?: OnMount<Args, Result>
 }
@@ -68,7 +72,7 @@ let keyCount = 0 // global key count for all atoms
 
 // writable derived atom
 export function atom<Value, Args extends unknown[], Result>(
-  read: Read<Value, SetAtom<Args, Result>>,
+  read: Read<Value, SetSelfAsync<Args, Result>>,
   write: Write<Args, Result>,
 ): WritableAtom<Value, Args, Result>
 
@@ -91,7 +95,7 @@ export function atom<Value>(
 ): PrimitiveAtom<Value> & WithInitialValue<Value>
 
 export function atom<Value, Args extends unknown[], Result>(
-  read?: Value | Read<Value, SetAtom<Args, Result>>,
+  read?: Value | Read<Value, SetSelfAsync<Args, Result>>,
   write?: Write<Args, Result>,
 ) {
   const key = `atom${++keyCount}`
@@ -103,7 +107,7 @@ export function atom<Value, Args extends unknown[], Result>(
     },
   } as WritableAtom<Value, Args, Result> & { init?: Value | undefined }
   if (typeof read === 'function') {
-    config.read = read as Read<Value, SetAtom<Args, Result>>
+    config.read = read as Read<Value, SetSelfAsync<Args, Result>>
   } else {
     config.init = read
     config.read = defaultRead


### PR DESCRIPTION
## Summary

I'm wondering if we could improve the clarity of the api by tweaking the type naming a bit.

The current naming conventions have inconsistencies:
- The `get` function in `atom.write` does not add atom's dependencies to the top-level.
- The `setSelf` function in `atom.read` options only supports asynchronous updates.
- The `setAtom` function in `atom.onMount` has the same behavior and type signature as `setSelf`, but it also supports synchronous updates. Additionally, the name `setAtom` does not clearly indicate that it can only update the self atom.

---

## Checklist

- [x] Run `pnpm run prettier` to format code and documentation.
