### PR TITLE
lazy recomputeDependents

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -104,8 +104,8 @@ type AtomState<Value = AnyValue> = {
   v?: Value
   /** Atom error */
   e?: AnyError
-  /** Indicates whether the atom value is has been changed */
-  x?: boolean
+  /** Indicates that the atom value has been changed */
+  x?: true
 }
 
 const isAtomStateInitialized = <Value>(atomState: AtomState<Value>) =>
@@ -461,24 +461,18 @@ const buildStore = (
     atom: AnyAtom,
     atomState: AtomState,
   ) => {
-    atomState.x = false
+    delete atomState.x
     pending[0].delete(atom)
   }
 
   const isPendingRecompute = (atom: AnyAtom) => getAtomState(atom).x
 
-  const getMountedDependents = (
-    pending: Pending,
-    a: AnyAtom,
-    aState: AtomState,
-  ) => {
-    return new Set<AnyAtom>(
-      [
-        ...(aState.m?.t || []),
-        ...aState.p,
-        ...(getPendingDependents(pending, a) || []),
-      ].filter((a) => getAtomState(a).m),
-    )
+  const getDependents = (pending: Pending, a: AnyAtom, aState: AtomState) => {
+    return new Set<AnyAtom>([
+      ...(aState.m?.t || []),
+      ...aState.p,
+      ...(getPendingDependents(pending, a) || []),
+    ])
   }
 
   /** @returns map of all dependents or dependencies (deep) of the root atoms */
@@ -507,7 +501,7 @@ const buildStore = (
   }
 
   const getAllDependents = (pending: Pending, atoms: Iterable<AnyAtom>) =>
-    getDeep((a, aState) => getMountedDependents(pending, a, aState), atoms)
+    getDeep((a, aState) => getDependents(pending, a, aState), atoms)
 
   // This is a topological sort via depth-first search, slightly modified from
   // what's described here for simplicity and performance reasons:

--- a/tests/vanilla/dependency.test.tsx
+++ b/tests/vanilla/dependency.test.tsx
@@ -1,5 +1,9 @@
 import { expect, it, vi } from 'vitest'
 import { atom, createStore } from 'jotai/vanilla'
+import type {
+  INTERNAL_DevStoreRev4,
+  INTERNAL_PrdStore,
+} from 'jotai/vanilla/store'
 
 it('can propagate updates with async atom chains', async () => {
   const store = createStore()
@@ -404,4 +408,41 @@ it('can cache reading an atom in write function (with mounting)', () => {
   expect(aReadCount).toBe(1)
   store.set(w)
   expect(aReadCount).toBe(1)
+})
+
+it('batches sync writes', () => {
+  const a = atom(0)
+  a.debugLabel = 'a'
+  const b = atom((get) => get(a) + 1)
+  b.debugLabel = 'b'
+  const fetch = vi.fn()
+  const c = atom((get) => fetch(get(a)))
+  c.debugLabel = 'c'
+  const w = atom(null, (get, set) => {
+    const b1 = get(b) // 1
+    set(a, b1)
+    expect(fetch).toHaveBeenCalledTimes(0)
+    const b2 = get(b) // 2
+    set(a, b2)
+    expect(fetch).toHaveBeenCalledTimes(0)
+  })
+  w.debugLabel = 'w'
+  const store = createStore() as INTERNAL_DevStoreRev4 & INTERNAL_PrdStore
+  store.sub(b, () => {})
+  store.sub(c, () => {})
+  const getAtomState = store.dev4_get_internal_weak_map().get
+  const aState = getAtomState(a) as any
+  aState.label = 'a'
+  const bState = getAtomState(b) as any
+  bState.label = 'b'
+  const cState = getAtomState(c) as any
+  cState.label = 'c'
+  fetch.mockClear()
+  store.set(w)
+  // we expect b to be recomputed when a's value is changed by `set`
+  // we expect c to be recomputed in flushPending after the graph has updated
+  // this distinction is possible by tracking what atoms are accessed with w.write's `get`
+  expect(store.get(a)).toBe(2)
+  expect(fetch).toHaveBeenCalledOnce()
+  expect(fetch).toBeCalledWith(2)
 })

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -340,6 +340,7 @@ it('resolves dependencies reliably after a delay (#2192)', async () => {
   await waitFor(() => assert(resolve.length === 1))
 
   resolve[0]!()
+  await new Promise((r) => setTimeout(r))
   const increment = (c: number) => c + 1
   store.set(countAtom, increment)
   store.set(countAtom, increment)


### PR DESCRIPTION
## Related Bug Reports or Discussions

https://github.com/pmndrs/jotai/discussions/2782

## Summary

Currently, recomputeDependents runs for each call to set. This causes overlapping dependents to recompute multiple times.

We still need to recompute some dependents if they are accessed with `get`. But the remaining dependents can be recomputed at the end of the transaction in flushPending.
```ts
const a = atom(0)
const b = atom((get) => get(a))
const fetch = vi.fn()
const c = atom((get) => fetch(get(a)))
const w = atom(null, (get, set) => {
  set(a, 1)
  expect(get(b)).toBe(1)
  expect(fetch).toHaveBeenCalledTimes(0)
})
const store = createStore()
store.sub(b, () => {})
store.sub(c, () => {})
fetch.mockClear()
store.set(w)
expect(fetch).toHaveBeenCalledOnce()
expect(fetch).toBeCalledWith(1)
expect(store.get(a)).toBe(1)
```

<img width="560" alt="image" src="https://github.com/user-attachments/assets/1847ece3-4202-49c7-894b-f409854278d6">


## Proposed Fix

1. on `set`
    - keep a list of all atoms that have been changed
    - mark the atom's state and its dependents' state as dirty
2. on `get`, if the atom's state is dirty
    - recompute the atom and all it's dependencies that are dirty
3. on `flushPending`, recompute all remaining dirty dependents

## More complex example
Suppose you write to node 17. Itself and it's dependents are `{17, 15, 16, 12, 13, 14, 9, 10, 11, 6, 3, 1}`.
We save these nodes as pending recompute.
Then suppose you read from node 1. Itself and it's dependencies are `{1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 15, 17}`.
The intersection of these two sets is `{1, 3, 6, 9, 12, 15, 17}`.
On `get`, only these nodes will be eagerly recomputed.
On `flushPending`, the remaining nodes `{16, 13, 14, 10, 11}` will be recomputed.

<img width="563" alt="image" src="https://github.com/user-attachments/assets/0f4f8123-a772-41a0-b4e1-f1265ff724e9">

## Description of Core Functions
### `getMountedDependents`
Was previously `getDependents`. Is called by `getAllDependents`. Returns a set of all mounted dependents.

### `getAllDependents`
Is called by `markRecomputePending` and `getSortedDependents`. Returns a map of atoms to a set of their dependents (`Map<AnyAtom, Set<AnyAtom>>`).

### `markRecomputePending`
Is called by `recomputeDependents` and `setter`. Sets `atomState.x` to true.

### `getSortedDependents`
Is called by `recomputeDependents`. Returns a topological sorted list of atoms and its dependent atoms (deep).

### `recomputeDependents`
Is called by `recomputeDependencies` and `flushPending`. Receives a set of atoms for which to recompute dependents on. Iteratively calls `readAtomState` and `mountDependencies` on all atoms and their dependents (deep) whose `atomState.x` is true.

### `recomputeDependencies`
Is called by the `getter` in `writeAtomState`. Recomputes the dependents (deep) of all dependencies (deep) whose `atomState.x` is true.

### `flushPending`
Is called in the following places
1. In the `readAtomState` `getter` finally block if `getter` is called async.
2. In `complete` which is called when a valueOrPromise is a promise and has settled.
3. In `setter` finally block if `setter` is called async.
4. In `writeAtom` finally block.
5. In `setAtom` finally block if `setAtom` is called async.
6. At the end of `subscribeAtom`
7. At the end of `unsubscribeAtom`

## Check List

- [x] `pnpm run prettier` for formatting code and docs
