### PR TITLE
docs(CONTRIBUTING.md): change 'pnpm' to 'pnpm install' for installing dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ If you would like to contribute by fixing an open issue or developing a new feat
 
 ### Core lib
 
-1. Install dependencies by running `pnpm`.
+1. Install dependencies by running `pnpm install`.
 2. Create failing tests for your fix or new feature in the `tests` folder
 3. Implement your changes
 4. Build the library `pnpm run build` _(Pro-tip: `pnpm run build-watch` runs the build in watch mode)_


### PR DESCRIPTION
## Summary

* Same with https://github.com/pmndrs/zustand/pull/2890

## Check List

- [x] `pnpm run prettier` for formatting code and docs
