### PR TITLE
[idea] add pending to `store.unstable_derive`

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -243,6 +243,7 @@ type StoreArgs = readonly [
     setAtom: (...args: Args) => Result,
   ) => OnUnmount | void,
   createPending: (pending?: Pending | undefined) => Pending,
+  flushPending: (pending: Pending) => void,
 ]
 
 // for debugging purpose only
@@ -270,7 +271,7 @@ export type INTERNAL_DevStoreRev4 = DevStoreRev4
 export type INTERNAL_PrdStore = PrdStore
 
 const buildStore = (
-  ...[getAtomState, atomRead, atomWrite, atomOnMount, createPending]: StoreArgs
+  ...[getAtomState, atomRead, atomWrite, atomOnMount, createPending, flushPending]: StoreArgs
 ): Store => {
   // for debugging purpose only
   let debugMountedAtoms: Set<AnyAtom>
@@ -702,7 +703,7 @@ const buildStore = (
   }
 
   const unstable_derive = (fn: (...args: StoreArgs) => StoreArgs) =>
-    buildStore(...fn(getAtomState, atomRead, atomWrite, atomOnMount, createPending))
+    buildStore(...fn(getAtomState, atomRead, atomWrite, atomOnMount, createPending, flushPending))
 
   const store: Store = {
     get: readAtom,
@@ -765,6 +766,7 @@ export const createStore = (): Store => {
     (_, atom, ...params) => atom.write(...params),
     (_, atom, ...params) => atom.onMount?.(...params),
     () => [new Map(), new Map(), new Set()],
+    flushPending,
   )
 }
 

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -245,7 +245,7 @@ type StoreArgs = readonly [
     atom: WritableAtom<Value, Args, Result>,
     setAtom: (...args: Args) => Result,
   ) => OnUnmount | void,
-  createPending: (pending?: Pending | undefined) => Pending,
+  createPending: (prevPending?: Pending | undefined) => Pending,
   flushPending: (pending: Pending) => void,
 ]
 
@@ -790,7 +790,7 @@ export const createStore = (): Store => {
     (_, atom, ...params) => atom.read(...params),
     (_, atom, ...params) => atom.write(...params),
     (_, atom, ...params) => atom.onMount?.(...params),
-    () => [new Map(), new Map(), new Set()],
+    (_) => [new Map(), new Map(), new Set()],
     flushPending,
   )
 }

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -165,7 +165,7 @@ type Pending = readonly [
   dependents: Map<AnyAtom, Set<AnyAtom>>,
   atomStates: Map<AnyAtom, AtomState>,
   functions: Set<() => void>,
-  ...unknown[],
+  ...custom: unknown[],
 ]
 
 const addPendingAtom = (

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -138,7 +138,7 @@ const addPendingPromiseToDependency = (
 }
 
 const addDependency = <Value>(
-  pending: Pending | undefined,
+  pending: Pending,
   atom: Atom<Value>,
   atomState: AtomState<Value>,
   a: AnyAtom,
@@ -227,11 +227,11 @@ const flushPending = (pending: Pending) => {
 // internal & unstable type
 type StoreArgs = readonly [
   getAtomState: <Value>(
-    pending: Pending | undefined,
+    pending: Pending,
     atom: Atom<Value>,
   ) => AtomState<Value>,
   atomRead: <Value>(
-    pending: Pending | undefined,
+    pending: Pending,
     atom: Atom<Value>,
     ...params: Parameters<Atom<Value>['read']>
   ) => Value,
@@ -245,7 +245,7 @@ type StoreArgs = readonly [
     atom: WritableAtom<Value, Args, Result>,
     setAtom: (...args: Args) => Result,
   ) => OnUnmount | void,
-  createPending: (prevPending?: Pending | undefined) => Pending,
+  createPending: (prevPending?: Pending) => Pending,
   flushPending: (pending: Pending) => void,
 ]
 
@@ -291,7 +291,7 @@ const buildStore = (
   }
 
   const setAtomStateValueOrPromise = (
-    pending: Pending | undefined,
+    pending: Pending,
     atom: AnyAtom,
     atomState: AtomState,
     valueOrPromise: unknown,
@@ -323,7 +323,7 @@ const buildStore = (
   }
 
   const readAtomState = <Value>(
-    pending: Pending | undefined,
+    pending: Pending,
     atom: Atom<Value>,
     dirtyAtoms?: Set<AnyAtom>,
   ): AtomState<Value> => {
@@ -435,7 +435,7 @@ const buildStore = (
   }
 
   const readAtom = <Value>(atom: Atom<Value>): Value =>
-    returnAtomValue(readAtomState(undefined, atom))
+    returnAtomValue(readAtomState(createPending(), atom))
 
   const getDependents = <Value>(
     pending: Pending,
@@ -741,7 +741,7 @@ const buildStore = (
       // store dev methods (these are tentative and subject to change without notice)
       dev4_get_internal_weak_map: () => ({
         get: (atom) => {
-          const atomState = getAtomState(undefined, atom)
+          const atomState = getAtomState(createPending(), atom)
           if (atomState.n === 0) {
             // for backward compatibility
             return undefined
@@ -774,7 +774,7 @@ const buildStore = (
 
 export const createStore = (): Store => {
   const atomStateMap = new WeakMap()
-  const getAtomState = <Value>(_: Pending | undefined, atom: Atom<Value>) => {
+  const getAtomState = <Value>(_: Pending, atom: Atom<Value>) => {
     if (import.meta.env?.MODE !== 'production' && !atom) {
       throw new Error('Atom is undefined or null')
     }

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -165,7 +165,7 @@ type Pending = readonly [
   dependents: Map<AnyAtom, Set<AnyAtom>>,
   atomStates: Map<AnyAtom, AtomState>,
   functions: Set<() => void>,
-  ...unknown[]
+  ...unknown[],
 ]
 
 const addPendingAtom = (
@@ -226,7 +226,10 @@ const flushPending = (pending: Pending) => {
 
 // internal & unstable type
 type StoreArgs = readonly [
-  getAtomState: <Value>(pending: Pending | undefined, atom: Atom<Value>) => AtomState<Value>,
+  getAtomState: <Value>(
+    pending: Pending | undefined,
+    atom: Atom<Value>,
+  ) => AtomState<Value>,
   atomRead: <Value>(
     pending: Pending | undefined,
     atom: Atom<Value>,
@@ -271,7 +274,14 @@ export type INTERNAL_DevStoreRev4 = DevStoreRev4
 export type INTERNAL_PrdStore = PrdStore
 
 const buildStore = (
-  ...[getAtomState, atomRead, atomWrite, atomOnMount, createPending, flushPending]: StoreArgs
+  ...[
+    getAtomState,
+    atomRead,
+    atomWrite,
+    atomOnMount,
+    createPending,
+    flushPending,
+  ]: StoreArgs
 ): Store => {
   // for debugging purpose only
   let debugMountedAtoms: Set<AnyAtom>
@@ -292,7 +302,11 @@ const buildStore = (
     if (isPromiseLike(valueOrPromise)) {
       patchPromiseForCancelability(valueOrPromise)
       for (const a of atomState.d.keys()) {
-        addPendingPromiseToDependency(atom, valueOrPromise, getAtomState(pending, a))
+        addPendingPromiseToDependency(
+          atom,
+          valueOrPromise,
+          getAtomState(pending, a),
+        )
       }
       atomState.v = valueOrPromise
       delete atomState.e
@@ -666,7 +680,9 @@ const buildStore = (
     if (
       atomState.m &&
       !atomState.m.l.size &&
-      !Array.from(atomState.m.t).some((a) => getAtomState(pending, a).m?.d.has(atom))
+      !Array.from(atomState.m.t).some((a) =>
+        getAtomState(pending, a).m?.d.has(atom),
+      )
     ) {
       // unmount self
       const onUnmount = atomState.m.u
@@ -703,7 +719,16 @@ const buildStore = (
   }
 
   const unstable_derive = (fn: (...args: StoreArgs) => StoreArgs) =>
-    buildStore(...fn(getAtomState, atomRead, atomWrite, atomOnMount, createPending, flushPending))
+    buildStore(
+      ...fn(
+        getAtomState,
+        atomRead,
+        atomWrite,
+        atomOnMount,
+        createPending,
+        flushPending,
+      ),
+    )
 
   const store: Store = {
     get: readAtom,

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -165,9 +165,8 @@ type Pending = readonly [
   dependents: Map<AnyAtom, Set<AnyAtom>>,
   atomStates: Map<AnyAtom, AtomState>,
   functions: Set<() => void>,
+  ...unknown[]
 ]
-
-const createPending = (): Pending => [new Map(), new Map(), new Set()]
 
 const addPendingAtom = (
   pending: Pending,
@@ -240,6 +239,7 @@ type StoreArgs = readonly [
     atom: WritableAtom<Value, Args, Result>,
     setAtom: (...args: Args) => Result,
   ) => OnUnmount | void,
+  createPending: () => Pending,
 ]
 
 // for debugging purpose only
@@ -267,7 +267,7 @@ export type INTERNAL_DevStoreRev4 = DevStoreRev4
 export type INTERNAL_PrdStore = PrdStore
 
 const buildStore = (
-  ...[getAtomState, atomRead, atomWrite, atomOnMount]: StoreArgs
+  ...[getAtomState, atomRead, atomWrite, atomOnMount, createPending]: StoreArgs
 ): Store => {
   // for debugging purpose only
   let debugMountedAtoms: Set<AnyAtom>
@@ -760,6 +760,7 @@ export const createStore = (): Store => {
     (atom, ...params) => atom.read(...params),
     (atom, ...params) => atom.write(...params),
     (atom, ...params) => atom.onMount?.(...params),
+    () => [new Map(), new Map(), new Set()],
   )
 }
 


### PR DESCRIPTION
## Summary
Improves capability of unstable_derive store api. Pending is a good candidate to represent a transaction primitive. These changes make it possible to have fine-grained control over the atom lifecycle.

### Details
- Adds createPending to StoreArgs
- Shares pending with all StoreArgs
- Adds flushPending to StoreArgs

## Check List

- [x] `pnpm run prettier` for formatting code and docs
