### PR TITLE
fix: unwrap synchronously returns awaited values of resolved promise atoms

### DIFF
--- a/src/vanilla/utils/unwrap.ts
+++ b/src/vanilla/utils/unwrap.ts
@@ -9,9 +9,26 @@ const memo2 = <T>(create: () => T, dep1: object, dep2: object): T => {
   return getCached(create, cache2, dep2)
 }
 
-const isPromise = (x: unknown): x is Promise<unknown> => x instanceof Promise
+const isPromise = <Value>(x: Value): x is Value & Promise<Awaited<Value>> =>
+  x instanceof Promise
 
 const defaultFallback = () => undefined
+
+type AnyError = unknown
+type AtomState<Value> = { w?: { v: Awaited<Value> } | { e: AnyError } }
+type GetAtomState = <Value>(atom: Atom<Value>) => AtomState<Value>
+type GetAtomStateRef = { v: GetAtomState }
+const getAtomStateAtom = atom(() => ({}) as GetAtomStateRef)
+// HACK to access atom state
+getAtomStateAtom.unstable_onInit = (store) => {
+  store.unstable_derive((...args) => {
+    store.get(getAtomStateAtom).value = args[0]
+    return args
+  })
+}
+if (import.meta.env?.MODE !== 'production') {
+  getAtomStateAtom.debugPrivate = true
+}
 
 export function unwrap<Value, Args extends unknown[], Result>(
   anAtom: WritableAtom<Value, Args, Result>,
@@ -31,85 +48,86 @@ export function unwrap<Value, PendingValue>(
   fallback: (prev?: Awaited<Value>) => PendingValue,
 ): Atom<Awaited<Value> | PendingValue>
 
-export function unwrap<Value, Args extends unknown[], Result, PendingValue>(
-  anAtom: WritableAtom<Value, Args, Result> | Atom<Value>,
+export function unwrap<Value, T extends Atom<Value>, PendingValue>(
+  targetAtom: T,
   fallback: (prev?: Awaited<Value>) => PendingValue = defaultFallback as never,
 ) {
   return memo2(
     () => {
-      type PromiseAndValue = { readonly p?: Promise<unknown> } & (
-        | { readonly v: Awaited<Value> }
-        | { readonly f: PendingValue; readonly v?: Awaited<Value> }
-      )
       const promiseErrorCache = new WeakMap<Promise<unknown>, unknown>()
       const promiseResultCache = new WeakMap<Promise<unknown>, Awaited<Value>>()
       const refreshAtom = atom(0)
+      type PrevRef = { v: Awaited<Value> | undefined }
+      const prevAtom = atom(() => ({}) as PrevRef)
+      const stateAtom = atom(
+        (get, { setSelf }) => {
+          get(refreshAtom)
+          const prev = get(prevAtom).v
+          const valueOrPromise = get(targetAtom)
+          const atomState = get(getAtomStateAtom).v(targetAtom)
+          if (!isPromise(valueOrPromise)) {
+            return { v: valueOrPromise as Awaited<Value> }
+          }
+          if (
+            !promiseResultCache.has(valueOrPromise) &&
+            !promiseErrorCache.has(valueOrPromise)
+          ) {
+            if (atomState.w) {
+              if ('v' in atomState.w) {
+                // resolved
+                promiseResultCache.set(valueOrPromise, atomState.w.v)
+              }
+              if ('e' in atomState.w) {
+                // rejected
+                promiseErrorCache.set(valueOrPromise, atomState.w.e)
+              }
+            } else {
+              // not settled
+              valueOrPromise.then(
+                (v) => {
+                  promiseResultCache.set(valueOrPromise, v)
+                  setSelf()
+                },
+                (e) => {
+                  promiseErrorCache.set(valueOrPromise, e)
+                  setSelf()
+                },
+              )
+            }
+          }
+          if (promiseErrorCache.has(valueOrPromise)) {
+            // rejected
+            throw promiseErrorCache.get(valueOrPromise)
+          }
+          if (!promiseResultCache.has(valueOrPromise)) {
+            // not settled
+            return { f: fallback(prev) }
+          }
+          return { v: promiseResultCache.get(valueOrPromise)! }
+        },
+        (_, set) => set(refreshAtom, (v) => v + 1),
+      )
 
       if (import.meta.env?.MODE !== 'production') {
         refreshAtom.debugPrivate = true
+        prevAtom.debugPrivate = true
+        stateAtom.debugPrivate = true
       }
 
-      const promiseAndValueAtom: WritableAtom<PromiseAndValue, [], void> & {
-        init?: undefined
-      } = atom(
-        (get, { setSelf }) => {
-          get(refreshAtom)
-          const prev = get(promiseAndValueAtom) as PromiseAndValue | undefined
-          const promise = get(anAtom)
-          if (!isPromise(promise)) {
-            return { v: promise as Awaited<Value> }
-          }
-          if (promise !== prev?.p) {
-            promise.then(
-              (v) => {
-                promiseResultCache.set(promise, v as Awaited<Value>)
-                setSelf()
-              },
-              (e) => {
-                promiseErrorCache.set(promise, e)
-                setSelf()
-              },
-            )
-          }
-          if (promiseErrorCache.has(promise)) {
-            throw promiseErrorCache.get(promise)
-          }
-          if (promiseResultCache.has(promise)) {
-            return {
-              p: promise,
-              v: promiseResultCache.get(promise) as Awaited<Value>,
-            }
-          }
-          if (prev && 'v' in prev) {
-            return { p: promise, f: fallback(prev.v), v: prev.v }
-          }
-          return { p: promise, f: fallback() }
-        },
-        (_get, set) => {
-          set(refreshAtom, (c) => c + 1)
-        },
+      const descriptors = Object.getOwnPropertyDescriptors(
+        targetAtom as Atom<Awaited<Value> | PendingValue>,
       )
-      // HACK to read PromiseAndValue atom before initialization
-      promiseAndValueAtom.init = undefined
-
-      if (import.meta.env?.MODE !== 'production') {
-        promiseAndValueAtom.debugPrivate = true
+      descriptors.read.value = (get) => {
+        const state = get(stateAtom)
+        return 'v' in state ? (get(prevAtom).v = state.v) : state.f
       }
-
-      return atom(
-        (get) => {
-          const state = get(promiseAndValueAtom)
-          if ('f' in state) {
-            // is pending
-            return state.f
-          }
-          return state.v
-        },
-        (_get, set, ...args) =>
-          set(anAtom as WritableAtom<Value, unknown[], unknown>, ...args),
-      )
+      if ('write' in targetAtom && typeof targetAtom.write === 'function') {
+        descriptors.write!.value = targetAtom.write.bind(targetAtom)
+      }
+      // avoid reading `init` to preserve lazy initialization
+      return Object.create(Object.getPrototypeOf(targetAtom), descriptors)
     },
-    anAtom,
+    targetAtom,
     fallback,
   )
 }

--- a/tests/vanilla/utils/unwrap.test.ts
+++ b/tests/vanilla/utils/unwrap.test.ts
@@ -17,19 +17,19 @@ describe('unwrap', () => {
 
     expect(store.get(syncAtom)).toBe(undefined)
     resolve()
-    await new Promise((r) => setTimeout(r)) // wait for a tick
+    await store.get(asyncAtom)
     expect(store.get(syncAtom)).toBe(2)
 
     store.set(countAtom, 2)
     expect(store.get(syncAtom)).toBe(undefined)
     resolve()
-    await new Promise((r) => setTimeout(r)) // wait for a tick
+    await store.get(asyncAtom)
     expect(store.get(syncAtom)).toBe(4)
 
     store.set(countAtom, 3)
     expect(store.get(syncAtom)).toBe(undefined)
     resolve()
-    await new Promise((r) => setTimeout(r)) // wait for a tick
+    await store.get(asyncAtom)
     expect(store.get(syncAtom)).toBe(6)
   })
 
@@ -45,17 +45,17 @@ describe('unwrap', () => {
     const syncAtom = unwrap(asyncAtom, () => -1)
     expect(store.get(syncAtom)).toBe(-1)
     resolve()
-    await new Promise((r) => setTimeout(r)) // wait for a tick
+    await store.get(asyncAtom)
     expect(store.get(syncAtom)).toBe(2)
     store.set(countAtom, 2)
     expect(store.get(syncAtom)).toBe(-1)
     resolve()
-    await new Promise((r) => setTimeout(r)) // wait for a tick
+    await store.get(asyncAtom)
     expect(store.get(syncAtom)).toBe(4)
     store.set(countAtom, 3)
     expect(store.get(syncAtom)).toBe(-1)
     resolve()
-    await new Promise((r) => setTimeout(r)) // wait for a tick
+    await store.get(asyncAtom)
     expect(store.get(syncAtom)).toBe(6)
   })
 
@@ -72,19 +72,19 @@ describe('unwrap', () => {
 
     expect(store.get(syncAtom)).toBe(0)
     resolve()
-    await new Promise((r) => setTimeout(r)) // wait for a tick
+    await store.get(asyncAtom)
     expect(store.get(syncAtom)).toBe(2)
 
     store.set(countAtom, 2)
     expect(store.get(syncAtom)).toBe(2)
     resolve()
-    await new Promise((r) => setTimeout(r)) // wait for a tick
+    await store.get(asyncAtom)
     expect(store.get(syncAtom)).toBe(4)
 
     store.set(countAtom, 3)
     expect(store.get(syncAtom)).toBe(4)
     resolve()
-    await new Promise((r) => setTimeout(r)) // wait for a tick
+    await store.get(asyncAtom)
     expect(store.get(syncAtom)).toBe(6)
 
     store.set(countAtom, 4)
@@ -93,7 +93,7 @@ describe('unwrap', () => {
     store.set(countAtom, 5)
     expect(store.get(syncAtom)).not.toBe(0) // expect 6 or 8
     resolve()
-    await new Promise((r) => setTimeout(r)) // wait for a tick
+    await store.get(asyncAtom)
     expect(store.get(syncAtom)).toBe(10)
   })
 
@@ -114,27 +114,24 @@ describe('unwrap', () => {
     const syncAtom = unwrap(asyncAtom, (prev?: number) => prev ?? 0)
 
     expect(store.get(syncAtom)).toBe(0)
-    await new Promise((r) => setTimeout(r)) // wait for a tick
+    await store.get(asyncAtom)
     expect(store.get(syncAtom)).toBe(1)
 
     store.set(syncAtom, Promise.resolve(2))
     expect(store.get(syncAtom)).toBe(1)
-    await new Promise((r) => setTimeout(r)) // wait for a tick
+    await store.get(asyncAtom)
     expect(store.get(syncAtom)).toBe(2)
 
     store.set(syncAtom, Promise.resolve(3))
     expect(store.get(syncAtom)).toBe(2)
-    await new Promise((r) => setTimeout(r)) // wait for a tick
+    await store.get(asyncAtom)
     expect(store.get(syncAtom)).toBe(3)
   })
 
   it('should unwrap to a fulfilled value of an already resolved async atom', async () => {
     const store = createStore()
     const asyncAtom = atom(Promise.resolve('concrete'))
-
-    expect(await store.get(asyncAtom)).toEqual('concrete')
-    expect(store.get(unwrap(asyncAtom))).toEqual(undefined)
-    await new Promise((r) => setTimeout(r)) // wait for a tick
+    await store.get(asyncAtom)
     expect(store.get(unwrap(asyncAtom))).toEqual('concrete')
   })
 
@@ -142,11 +139,8 @@ describe('unwrap', () => {
     const store = createStore()
     const asyncAtom = atom(Promise.resolve('concrete'))
     const syncAtom = unwrap(asyncAtom)
-
     expect(store.get(syncAtom)).toEqual(undefined)
-
     await store.get(asyncAtom)
-
     expect(store.get(syncAtom)).toEqual('concrete')
   })
 })


### PR DESCRIPTION
## Related Bug Reports or Discussions
https://github.com/pmndrs/jotai/discussions/2877

## Summary
Synchronously return atom values whose promises have already resolved.
```ts
const asyncAtom = atom(Promise.resolve(0)
await store.get(asyncAtom)
store.get(unwrap(asyncAtom)) // 0
```

## Check List

- [x] `pnpm run prettier` for formatting code and docs
