### PR TITLE
[DO_NOT_MERGE] Exploration in moving all internal functions under an object and expose to unstable_derive

### DIFF
--- a/tests/vanilla/unstable_derive.test.tsx
+++ b/tests/vanilla/unstable_derive.test.tsx
@@ -31,6 +31,7 @@ describe('unstable_derive for scoping atoms', () => {
           atomRead,
           atomWrite,
           atomOnMount,
+          {},
         ]
       },
     )
@@ -76,6 +77,7 @@ describe('unstable_derive for scoping atoms', () => {
           atomRead,
           atomWrite,
           atomOnMount,
+          {},
         ]
       },
     )
@@ -128,6 +130,7 @@ describe('unstable_derive for scoping atoms', () => {
             },
             atomWrite,
             atomOnMount,
+            {},
           ]
         },
       )


### PR DESCRIPTION
## Summary
All functions are put under an object `internal`, which is then passed to unstable_derive. This allows complete modification of internals including the ability to intercept calls to certain functions. Obviously, this goes against the SOLID principle of software development, "closed for modification", but I thought it is an interesting study and might reveal new patterns or methodologies down the road.

Please treat this PR as an experiment only. This PR is _NOT FOR MERGE_.

Downsides
- method names cannot be minified
- we do not want to expose this level of control
- internals will change, so unstable_derive api would change frequently
- violates open-closed principle
- it makes unstable_derive callback not a collector. `internals` argument received should not be returned in the array, instead return `{}` to avoid overriding derived store internals.  It would be more useful to intercept the derived store internals than the parent store internals, so if we wanted to do something like this, we would probably return a store creator thunk.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
