### PR TITLE
feat(core): new dev (rev5) methods

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -1,7 +1,11 @@
 export { atom } from './vanilla/atom.ts'
 export type { Atom, WritableAtom, PrimitiveAtom } from './vanilla/atom.ts'
 
-export { createStore, getDefaultStore } from './vanilla/store.ts'
+export {
+  createStore,
+  getDefaultStore,
+  unstable_deriveDevStoreRev5,
+} from './vanilla/store.ts'
 
 export type {
   Getter,

--- a/tests/vanilla/storedev.test.tsx
+++ b/tests/vanilla/storedev.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { atom, createStore } from 'jotai/vanilla'
+import { atom, createStore, unstable_deriveDevStoreRev5 } from 'jotai/vanilla'
 import type {
   INTERNAL_DevStoreRev4,
   INTERNAL_PrdStore,
@@ -104,6 +104,95 @@ describe('[DEV-ONLY] dev-only methods rev4', () => {
     }
     const countAtom = atom(0, () => {})
     store.dev4_restore_atoms([[countAtom, 1]])
+    expect(store.get(countAtom)).toBe(1)
+  })
+})
+
+describe('[DEV-ONLY] dev-only methods rev5', () => {
+  const createDevStore = () => {
+    const store = createStore()
+    return unstable_deriveDevStoreRev5(store)
+  }
+
+  it('should get atom value', () => {
+    const store = createDevStore()
+    const countAtom = atom(0)
+    countAtom.debugLabel = 'countAtom'
+    store.set(countAtom, 1)
+    expect(store.dev5_get_atom_state(countAtom)?.v).toEqual(1)
+  })
+
+  it('should restore atoms and its dependencies correctly', () => {
+    const store = createDevStore()
+    const countAtom = atom(0)
+    const derivedAtom = atom((get) => get(countAtom) * 2)
+    store.set(countAtom, 1)
+    store.dev5_restore_atoms([[countAtom, 2]])
+    expect(store.get(countAtom)).toBe(2)
+    expect(store.get?.(derivedAtom)).toBe(4)
+  })
+
+  it('should restore atoms and call store listeners correctly', () => {
+    const store = createDevStore()
+    const countAtom = atom(0)
+    const derivedAtom = atom((get) => get(countAtom) * 2)
+    const countCb = vi.fn()
+    const derivedCb = vi.fn()
+    store.set(countAtom, 2)
+    const unsubCount = store.sub(countAtom, countCb)
+    const unsubDerived = store.sub(derivedAtom, derivedCb)
+    store.dev5_restore_atoms([
+      [countAtom, 1],
+      [derivedAtom, 2],
+    ])
+
+    expect(countCb).toHaveBeenCalled()
+    expect(derivedCb).toHaveBeenCalled()
+    unsubCount()
+    unsubDerived()
+  })
+
+  it('should return all the mounted atoms correctly', () => {
+    const store = createDevStore()
+    const countAtom = atom(0)
+    countAtom.debugLabel = 'countAtom'
+    const derivedAtom = atom((get) => get(countAtom) * 2)
+    const unsub = store.sub(derivedAtom, vi.fn())
+    store.set(countAtom, 1)
+    const result = store.dev5_get_mounted_atoms()
+    expect(
+      Array.from(result).sort(
+        (a, b) => Object.keys(a).length - Object.keys(b).length,
+      ),
+    ).toStrictEqual([
+      { toString: expect.any(Function), read: expect.any(Function) },
+      {
+        toString: expect.any(Function),
+        init: 0,
+        read: expect.any(Function),
+        write: expect.any(Function),
+        debugLabel: 'countAtom',
+      },
+    ])
+    unsub()
+  })
+
+  it("should return all the mounted atoms correctly after they're unsubscribed", () => {
+    const store = createDevStore()
+    const countAtom = atom(0)
+    countAtom.debugLabel = 'countAtom'
+    const derivedAtom = atom((get) => get(countAtom) * 2)
+    const unsub = store.sub(derivedAtom, vi.fn())
+    store.set(countAtom, 1)
+    unsub()
+    const result = store.dev5_get_mounted_atoms()
+    expect(Array.from(result)).toStrictEqual([])
+  })
+
+  it('should restore atoms with custom write function', () => {
+    const store = createDevStore()
+    const countAtom = atom(0, () => {})
+    store.dev5_restore_atoms([[countAtom, 1]])
     expect(store.get(countAtom)).toBe(1)
   })
 })


### PR DESCRIPTION
This introduces rev5 dev methods (prefixed `dev5_`)
The biggest change is it's no longer enabled by default, and we need to explicitly call `unstable_deriveDevStoreRev5`.

The goal is to isolate dev methods to be tree-shakable.
This also opens up using dev methods in the production build, which is sometimes requested.

Plan:
- rev5 will be introduced in v2.11.x
- rev4 will be deprecated in v2.11.y
- rev4 will be removed in v2.12.0 (or later)

@arjunvegda Does it sound okay?