### PR TITLE
replace batch dependents map with batched changed atoms

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -180,11 +180,11 @@ type Batch = [
   priority2: Set<() => void>,
 ] & {
   /** changed Atoms */
-  D: Set<AnyAtom>
+  C: Set<AnyAtom>
 }
 
 const createBatch = (): Batch =>
-  Object.assign([new Set(), new Set(), new Set()], { D: new Set() }) as Batch
+  Object.assign([new Set(), new Set(), new Set()], { C: new Set() }) as Batch
 
 const addBatchFunc = (
   batch: Batch,
@@ -199,8 +199,8 @@ const registerBatchAtom = (
   atom: AnyAtom,
   atomState: AtomState,
 ) => {
-  if (!batch.D.has(atom)) {
-    batch.D.add(atom)
+  if (!batch.C.has(atom)) {
+    batch.C.add(atom)
     atomState.u?.(batch)
     const scheduleListeners = () => {
       atomState.m?.l.forEach((listener) => addBatchFunc(batch, 1, listener))
@@ -222,8 +222,8 @@ const flushBatch = (batch: Batch) => {
       }
     }
   }
-  while (batch.D.size || batch.some((channel) => channel.size)) {
-    batch.D.clear()
+  while (batch.C.size || batch.some((channel) => channel.size)) {
+    batch.C.clear()
     for (const channel of batch) {
       channel.forEach(call)
       channel.clear()

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -150,7 +150,6 @@ const addPendingPromiseToDependency = (
 }
 
 const addDependency = <Value>(
-  batch: Batch | undefined,
   atom: Atom<Value>,
   atomState: AtomState<Value>,
   a: AnyAtom,
@@ -164,9 +163,6 @@ const addDependency = <Value>(
     addPendingPromiseToDependency(atom, atomState.v, aState)
   }
   aState.m?.t.add(atom)
-  if (batch) {
-    addBatchAtomDependent(batch, a, atom)
-  }
 }
 
 //
@@ -183,12 +179,12 @@ type Batch = [
   /** atom mount hooks */
   priority2: Set<() => void>,
 ] & {
-  /** Atom dependents map */
-  D: Map<AnyAtom, Set<AnyAtom>>
+  /** changed Atoms */
+  D: Set<AnyAtom>
 }
 
 const createBatch = (): Batch =>
-  Object.assign([new Set(), new Set(), new Set()], { D: new Map() }) as Batch
+  Object.assign([new Set(), new Set(), new Set()], { D: new Set() }) as Batch
 
 const addBatchFunc = (
   batch: Batch,
@@ -204,7 +200,7 @@ const registerBatchAtom = (
   atomState: AtomState,
 ) => {
   if (!batch.D.has(atom)) {
-    batch.D.set(atom, new Set())
+    batch.D.add(atom)
     atomState.u?.(batch)
     const scheduleListeners = () => {
       atomState.m?.l.forEach((listener) => addBatchFunc(batch, 1, listener))
@@ -212,20 +208,6 @@ const registerBatchAtom = (
     addBatchFunc(batch, 1, scheduleListeners)
   }
 }
-
-const addBatchAtomDependent = (
-  batch: Batch,
-  atom: AnyAtom,
-  dependent: AnyAtom,
-) => {
-  const dependents = batch.D.get(atom)
-  if (dependents) {
-    dependents.add(dependent)
-  }
-}
-
-const getBatchAtomDependents = (batch: Batch, atom: AnyAtom) =>
-  batch.D.get(atom)
 
 const flushBatch = (batch: Batch) => {
   let error: AnyError
@@ -240,7 +222,7 @@ const flushBatch = (batch: Batch) => {
       }
     }
   }
-  while (batch.some((channel) => channel.size)) {
+  while (batch.D.size || batch.some((channel) => channel.size)) {
     batch.D.clear()
     for (const channel of batch) {
       channel.forEach(call)
@@ -390,10 +372,10 @@ const buildStore = (...storeArgs: StoreArgs): Store => {
         return returnAtomValue(aState)
       } finally {
         if (isSync) {
-          addDependency(batch, atom, atomState, a, aState)
+          addDependency(atom, atomState, a, aState)
         } else {
           const batch = createBatch()
-          addDependency(batch, atom, atomState, a, aState)
+          addDependency(atom, atomState, a, aState)
           mountDependencies(batch, atom, atomState)
           flushBatch(batch)
         }
@@ -475,9 +457,6 @@ const buildStore = (...storeArgs: StoreArgs): Store => {
         ensureAtomState(atomWithPendingPromise),
       )
     }
-    getBatchAtomDependents(batch, atom)?.forEach((dependent) => {
-      dependents.set(dependent, ensureAtomState(dependent))
-    })
     return dependents
   }
 

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -1087,16 +1087,24 @@ it('should pass store and atomState to the atom initializer', () => {
   store.get(a)
 })
 
-it.only('uses recomputes dependents of unmounted atoms', () => {
+it('recomputes dependents of unmounted atoms', () => {
   const a = atom(0)
-  const bRead = vi.fn((get) => get(a))
+  a.debugLabel = 'a'
+  const bRead = vi.fn((get: Getter) => {
+    console.log('bRead')
+    return get(a)
+  })
   const b = atom(bRead)
+  b.debugLabel = 'b'
+  const c = atom((get) => get(b))
+  c.debugLabel = 'c'
   const w = atom(null, (get, set) => {
-    get(b)
-    bRead.mockClear()
     set(a, 1)
-    expect(bRead).toHaveBeenCalled()
+    get(c)
+    set(a, 2)
+    bRead.mockClear()
   })
   const store = createStore()
   store.set(w)
+  expect(bRead).not.toHaveBeenCalled()
 })

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -1086,3 +1086,17 @@ it('should pass store and atomState to the atom initializer', () => {
   }
   store.get(a)
 })
+
+it.only('uses recomputes dependents of unmounted atoms', () => {
+  const a = atom(0)
+  const bRead = vi.fn((get) => get(a))
+  const b = atom(bRead)
+  const w = atom(null, (get, set) => {
+    get(b)
+    bRead.mockClear()
+    set(a, 1)
+    expect(bRead).toHaveBeenCalled()
+  })
+  const store = createStore()
+  store.set(w)
+})


### PR DESCRIPTION
## Summary
Batch.D was previously `Map<Atom, Set<AtomDependent>>`.
This allowed atom dependents to recompute without being mounted. There isn't an obvious reason to do so.
All tests pass after removing this functionality.

## Dropped behavior
After this change, the following test would fail.
I don't think we should be update dependents of unmounted atoms.
```ts
it('recomputes dependents of unmounted atoms', () => {
  const a = atom(0)
  const bRead = vi.fn((get) => get(a))
  const b = atom(bRead)
  const c = atom((get) => get(b))
  const w = atom(null, (get, set) => {
    set(a, 1) // batch.D.set(a, new Set())
    get(c) // batch.D.get(a).add(b)
    set(a, 2) // topSortedReversed: [b, a]
    bRead.mockClear()
    // after this write function completes, flushBatch will recompute `a` and `b`
    // note: a and b are not mounted
  })
  const store = createStore()
  store.set(w)
  expect(bRead).toHaveBeenCalled()
})
```

## Check List

- [x] `pnpm run fix:format` for formatting code and docs
