### PR TITLE
add debugStore testUtil

### DIFF
--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -1,0 +1,24 @@
+import { createStore } from 'jotai'
+
+type Store = ReturnType<typeof createStore>
+type GetAtomState = Parameters<Parameters<Store['unstable_derive']>[0]>[0]
+type DebugStore = Store & { getAtomState: GetAtomState }
+
+export function createDebugStore() {
+  let getAtomState: GetAtomState
+  const store = createStore().unstable_derive((...storeArgs) => {
+    ;[getAtomState] = storeArgs
+    const [, setAtomState] = storeArgs
+    storeArgs[1] = (atom, atomState) => {
+      return setAtomState(
+        atom,
+        Object.assign(atomState, { label: atom.debugLabel }),
+      )
+    }
+    return storeArgs
+  })
+  if (getAtomState! === undefined) {
+    throw new Error('failed to create debug store')
+  }
+  return Object.assign(store, { getAtomState }) as DebugStore
+}


### PR DESCRIPTION
## Summary
`createDebugStore` is a test util for creating a store that adds `label` to the atomState from the corresponding atom's debugLabel property. This is useful when debugging store behavior.

## Check List

- [x] `pnpm run fix:format` for formatting code and docs
