### PR TITLE
refactor(store): Replace runWithTransactions to flushCallbacks

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -433,7 +433,7 @@ const buildStore = (...storeArgs: StoreArgs): Store => {
     return dependents
   }
 
-  const invalidateDependents = <Value>(atomState: AtomState<Value>) => {
+  const invalidateDependents = (atomState: AtomState) => {
     const visited = new WeakSet<AtomState>()
     const stack: AtomState[] = [atomState]
     while (stack.length) {
@@ -441,8 +441,10 @@ const buildStore = (...storeArgs: StoreArgs): Store => {
       if (!visited.has(aState)) {
         visited.add(aState)
         for (const [d, s] of getMountedOrPendingDependents(aState)) {
-          invalidatedAtoms.set(d, s.n)
-          stack.push(s)
+          if (!invalidatedAtoms.has(d)) {
+            invalidatedAtoms.set(d, s.n)
+            stack.push(s)
+          }
         }
       }
     }
@@ -528,8 +530,8 @@ const buildStore = (...storeArgs: StoreArgs): Store => {
       a: WritableAtom<V, As, R>,
       ...args: As
     ) => {
+      const aState = ensureAtomState(a)
       try {
-        const aState = ensureAtomState(a)
         if (isSelfAtom(atom, a)) {
           if (!hasInitialValue(a)) {
             // NOTE technically possible but restricted as it may cause bugs


### PR DESCRIPTION
## Summary
Current implementation with `runWithTransactions` uses a single synchronous callback (`fn`) invocation followed by conditionally running store hooks. For some flows, this code reduces to simply calling `fn`. The states in which hooks should be called are well defined so refactoring to synchronously calling a finalizer (`flushCallbacks`) is introduced in this PR.

A side-effect of this PR is it resolves several incompatibilities with jotai-effect.

### Details
`flushCallbacks` is called at the end of 7 flows:
1. writeAtom
2. writeAtomState setter async
3. subscribe
4. unsubscribe
5. readAtomState getter async
6. promise complete
7. onMount setAtom async

## Check List

- [x] `pnpm run fix:format` for formatting code and docs
