### PR TITLE
docs: update import statement for atomWithRefresh

### DIFF
--- a/docs/utilities/resettable.mdx
+++ b/docs/utilities/resettable.mdx
@@ -176,7 +176,7 @@ Passing one or more arguments to `set` will call "write" function.
 Here's how you'd use it to implement an refresh-able source of data:
 
 ```js
-import { atomWithRefresh } from 'XXX'
+import { atomWithRefresh } from 'jotai/utils'
 
 const postsAtom = atomWithRefresh((get) =>
   fetch('https://jsonplaceholder.typicode.com/posts').then((r) => r.json()),


### PR DESCRIPTION
## Related Bug Reports or Discussions

Update the import statement in the documentation to correctly show where atomWithRefresh is imported from.

as-is `from 'XXX'`
to-be `from 'jotai/utils'`

## Summary

## Check List

- [x] `pnpm run fix:format` for formatting code and docs
