### PR TITLE
fix(store): recompute dependents on eager evaluation in writeAtomState

### DIFF
--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -515,7 +515,10 @@ const buildStore = (...storeArgs: StoreArgs): Store => {
     ...args: Args
   ): Result => {
     let isSync = true
-    const getter: Getter = <V>(a: Atom<V>) => returnAtomValue(readAtomState(a))
+    const getter: Getter = <V>(a: Atom<V>) => {
+      recomputeInvalidatedAtoms()
+      return returnAtomValue(readAtomState(a))
+    }
     const setter: Setter = <V, As extends unknown[], R>(
       a: WritableAtom<V, As, R>,
       ...args: As

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -541,15 +541,16 @@ const buildStore = (...storeArgs: StoreArgs): Store => {
     let isSync = true
     const getter: Getter = <V>(a: Atom<V>) => {
       const aState = ensureAtomState(a)
-      // FIXME: the code below is attempting to find all dirty dependencies (deep), but it doesn't work
-      const atomAndDependencies = new Map<AnyAtom, AtomState>([
-        [a, aState],
-        ...getMountedOrPendingDependents(aState),
-      ])
-      const relevantInvalidated = Array.from(
-        atomAndDependencies.entries(),
-      ).filter(([a, aState]) => invalidatedAtoms.get(a) === aState.n)
-      recomputeInvalidatedAtoms(relevantInvalidated)
+      if (invalidatedAtoms.get(a) === aState.n) {
+        const atomAndDependencies = new Map<AnyAtom, AtomState>([
+          [a, aState],
+          ...getMountedOrPendingDependents(aState),
+        ])
+        const relevantInvalidated = Array.from(
+          atomAndDependencies.entries(),
+        ).filter(([a, aState]) => invalidatedAtoms.get(a) === aState.n)
+        recomputeInvalidatedAtoms(relevantInvalidated)
+      }
       return returnAtomValue(readAtomState(a))
     }
     const setter: Setter = <V, As extends unknown[], R>(

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -516,7 +516,7 @@ const buildStore = (...storeArgs: StoreArgs): Store => {
   ): Result => {
     let isSync = true
     const getter: Getter = <V>(a: Atom<V>) => {
-      recomputeInvalidatedAtoms()
+      recomputeInvalidatedAtoms([[a, ensureAtomState(a)]])
       return returnAtomValue(readAtomState(a))
     }
     const setter: Setter = <V, As extends unknown[], R>(

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -1223,3 +1223,22 @@ it('updates with reading derived atoms (#2959)', () => {
   store.set(countUpAtom)
   expect(store.get(countDerivedAtom)).toBe(2)
 })
+
+it('updates dependents when it eagerly recomputes dirty atoms', () => {
+  const countAtom = atom(0)
+  const isActiveAtom = atom(false)
+  const activeCountAtom = atom((get) =>
+    get(isActiveAtom) ? get(countAtom) : undefined,
+  )
+  const activateAction = atom(null, (get, set, value: boolean) => {
+    set(isActiveAtom, value)
+    get(activeCountAtom)
+  })
+
+  const store = createStore()
+  store.sub(activeCountAtom, () => {})
+  store.set(activateAction, true)
+  store.set(countAtom, 1)
+
+  expect(store.get(activeCountAtom)).toBe(1)
+})


### PR DESCRIPTION
## Related Bug Reports or Discussions
https://github.com/pmndrs/jotai/discussions/2964

## Summary
When writeAtomState on activateAction is called, setter is called on isActiveAtom which updates the value to true. isActiveAtom is marked as dirty along with all its dependents; since isActiveAtom is currently mounted, this includes activeCountAtom. Calling getter inside writeAtomState should cause an eager readAtomState on activeCountAtom. Since activeCountAtom is dirty, this should recursively reevaluate all dependencies. In this case, countAtom is conditional and is not yet a dependency of activeCountAtom. So the issue lies with not ~~doing a full readAtomState of activeCountAtom in which its read function is called again~~ calling recomputeDependents prior to calling readAtomState on activeCountAtom. Because the readAtomState was called on activeCountAtom, that atom and its dependencies are removed from dirty. Therefore the final recomputeDependents call from flushPending does not process those atoms.

~~I wonder if this was fixed in 2.11.2. There was a [similar issue](https://github.com/pmndrs/jotai/discussions/2959#discussion-7881285) reported that was caused by early returning from recursively marking dependents as dirty when the current atom was already dirty. That change was [reverted](https://github.com/pmndrs/jotai/pull/2960/files) in 2.11.2, so the full dependents tree is marked dirty whenever an atom is changed.~~ The issue is present in 2.11.2.

## Check List

- [x] `pnpm run fix:format` for formatting code and docs
