### PR TITLE
store hooks tweaks

### DIFF
--- a/.github/workflows/test-multiple-builds.yml
+++ b/.github/workflows/test-multiple-builds.yml
@@ -43,7 +43,7 @@ jobs:
           sed -i~ "s/resolve('\.\/src\(.*\)\.ts')/resolve('\.\/dist\1.js')/" vitest.config.mts
           sed -i~ "s/import { useResetAtom } from 'jotai\/react\/utils'/const { useResetAtom } = require('..\/..\/..\/dist\/react\/utils.js')/" tests/react/utils/useResetAtom.test.tsx
           sed -i~ "s/import { RESET, atomWithReducer, atomWithReset } from 'jotai\/vanilla\/utils'/const { RESET, atomWithReducer, atomWithReset } = require('..\/..\/..\/dist\/vanilla\/utils.js')/" tests/react/utils/useResetAtom.test.tsx
-          perl -i~ -0777 -pe "s/import {[^}]+} from 'jotai\/vanilla\/internals'/const { INTERNAL_buildStore, INTERNAL_createStoreHookForAtom, INTERNAL_getStoreStateRev1: INTERNAL_getStoreState } = require('..\/..\/dist\/vanilla\/internals.js')/g" tests/vanilla/store.test.tsx tests/vanilla/derive.test.tsx tests/vanilla/effect.test.ts
+          perl -i~ -0777 -pe "s/import {[^}]+} from 'jotai\/vanilla\/internals'/const { INTERNAL_buildStore, INTERNAL_initializeStoreHooks, INTERNAL_getStoreStateRev1: INTERNAL_getStoreState } = require('..\/..\/dist\/vanilla\/internals.js')/g" tests/vanilla/store.test.tsx tests/vanilla/derive.test.tsx tests/vanilla/effect.test.ts
       - name: Patch for ESM
         if: ${{ matrix.build == 'esm' }}
         run: |

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -181,7 +181,9 @@ const flushCallbacks = (storeState: StoreState): void => {
     }
   }
   do {
-    call(storeHooks.f)
+    if (storeHooks.f) {
+      call(storeHooks.f)
+    }
     const callbacks = new Set<() => void>()
     const add = callbacks.add.bind(callbacks)
     changedAtoms.forEach((atomState) => atomState.m?.l.forEach(add))
@@ -266,7 +268,7 @@ const recomputeInvalidatedAtoms = (storeState: StoreState): void => {
       mountDependencies(storeState, a)
       if (prevEpochNumber !== aState.n) {
         changedAtoms.set(a, aState)
-        storeHooks.c(a)
+        storeHooks.c?.(a)
       }
     }
     invalidatedAtoms.delete(a)
@@ -427,7 +429,7 @@ const readAtomState = <Value>(
     ) {
       invalidatedAtoms.set(atom, atomState.n)
       changedAtoms.set(atom, atomState)
-      storeHooks.c(atom)
+      storeHooks.c?.(atom)
     }
   }
 }
@@ -492,7 +494,7 @@ const writeAtomState = <Value, Args extends unknown[], Result>(
         mountDependencies(storeState, a)
         if (prevEpochNumber !== aState.n) {
           changedAtoms.set(a, aState)
-          storeHooks.c(a)
+          storeHooks.c?.(a)
           invalidateDependents(storeState, a)
         }
         return undefined as R
@@ -525,7 +527,7 @@ const mountDependencies = (storeState: StoreState, atom: AnyAtom): void => {
         atomState.m.d.add(a)
         if (n !== aState.n) {
           changedAtoms.set(a, aState)
-          storeHooks.c(a)
+          storeHooks.c?.(a)
           invalidateDependents(storeState, a)
         }
       }
@@ -567,7 +569,7 @@ const mountAtom = <Value>(
       d: new Set(atomState.d.keys()),
       t: new Set(),
     }
-    storeHooks.m(atom)
+    storeHooks.m?.(atom)
     if (isActuallyWritableAtom(atom)) {
       const mounted = atomState.m
       const processOnMount = () => {
@@ -621,7 +623,7 @@ const unmountAtom = <Value>(
       unmountCallbacks.add(onUnmount)
     }
     delete atomState.m
-    storeHooks.u(atom)
+    storeHooks.u?.(atom)
     // unmount dependencies
     for (const a of atomState.d.keys()) {
       const aMounted = unmountAtom(storeState, a)
@@ -655,22 +657,22 @@ type StoreHooks = Readonly<{
    * Listener to notify when the atom value is changed.
    * This is an experimental API.
    */
-  c: StoreHookForAtoms
+  c?: StoreHookForAtoms
   /**
    * Listener to notify when the atom is mounted.
    * This is an experimental API.
    */
-  m: StoreHookForAtoms
+  m?: StoreHookForAtoms
   /**
    * Listener to notify when the atom is unmounted.
    * This is an experimental API.
    */
-  u: StoreHookForAtoms
+  u?: StoreHookForAtoms
   /**
    * Listener to notify when callbacks are being flushed.
    * This is an experimental API.
    */
-  f: StoreHook
+  f?: StoreHook
 }>
 
 const createStoreHook = (): StoreHook => {
@@ -715,6 +717,16 @@ const createStoreHookForAtoms = (): StoreHookForAtoms => {
     }
   }
   return notify as never
+}
+
+const initializeStoreHooks = (storeState: StoreState): Required<StoreHooks> => {
+  type Mutable<T> = { -readonly [P in keyof T]: T[P] }
+  const storeHooks = storeState[1] as Mutable<Required<StoreHooks>>
+  storeHooks.c ||= createStoreHookForAtoms()
+  storeHooks.m ||= createStoreHookForAtoms()
+  storeHooks.u ||= createStoreHookForAtoms()
+  storeHooks.f ||= createStoreHook()
+  return storeHooks
 }
 
 type StoreArgs = [
@@ -767,24 +779,7 @@ export const INTERNAL_getStoreStateRev1 = (store: unknown): StoreState =>
 
 export const INTERNAL_buildStore = (...storeArgs: StoreArgs): Store => {
   const [getAtomState, setAtomState, , , atomOnInit] = storeArgs
-  let changedHook: StoreHookForAtoms | undefined
-  let mountHook: StoreHookForAtoms | undefined
-  let unmountHook: StoreHookForAtoms | undefined
-  let flushHook: StoreHook | undefined
-  const storeHooks: StoreHooks = {
-    get c() {
-      return (changedHook ||= createStoreHookForAtoms())
-    },
-    get m() {
-      return (mountHook ||= createStoreHookForAtoms())
-    },
-    get u() {
-      return (unmountHook ||= createStoreHookForAtoms())
-    },
-    get f() {
-      return (flushHook ||= createStoreHook())
-    },
-  }
+  const storeHooks: StoreHooks = {}
   const ensureAtomState = <Value>(atom: Atom<Value>) => {
     if (import.meta.env?.MODE !== 'production' && !atom) {
       throw new Error('Atom is undefined or null')
@@ -866,6 +861,8 @@ export const INTERNAL_mountDependencies: typeof mountDependencies =
   mountDependencies
 export const INTERNAL_mountAtom: typeof mountAtom = mountAtom
 export const INTERNAL_unmountAtom: typeof unmountAtom = unmountAtom
+export const INTERNAL_initializeStoreHooks: typeof initializeStoreHooks =
+  initializeStoreHooks
 
 //
 // Still experimental and some of them will be gone soon

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -2,6 +2,7 @@ import type { Atom, WritableAtom } from './atom.ts'
 import {
   INTERNAL_buildStore,
   INTERNAL_getStoreStateRev1 as INTERNAL_getStoreState,
+  INTERNAL_initializeStoreHooks,
 } from './internals.ts'
 import type { INTERNAL_AtomState } from './internals.ts'
 
@@ -43,7 +44,8 @@ const createDevStoreRev4 = (): INTERNAL_PrdStore & INTERNAL_DevStoreRev4 => {
     (atom, ...params) => atom.unstable_onInit?.(...params),
     (atom, ...params) => atom.onMount?.(...params),
   )
-  const [, storeHooks] = INTERNAL_getStoreState(store)
+  const storeState = INTERNAL_getStoreState(store)
+  const storeHooks = INTERNAL_initializeStoreHooks(storeState)
   const debugMountedAtoms = new Set<Atom<unknown>>()
   storeHooks.m.add(undefined, (atom) => {
     debugMountedAtoms.add(atom)

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -1,7 +1,6 @@
 import type { Atom, WritableAtom } from './atom.ts'
 import {
   INTERNAL_buildStore,
-  INTERNAL_createStoreHookForAtom,
   INTERNAL_getStoreStateRev1 as INTERNAL_getStoreState,
 } from './internals.ts'
 import type { INTERNAL_AtomState } from './internals.ts'
@@ -46,18 +45,12 @@ const createDevStoreRev4 = (): INTERNAL_PrdStore & INTERNAL_DevStoreRev4 => {
   )
   const [, storeHooks] = INTERNAL_getStoreState(store)
   const debugMountedAtoms = new Set<Atom<unknown>>()
-  ;(storeHooks.m ||= INTERNAL_createStoreHookForAtom()).add(
-    undefined,
-    (atom) => {
-      debugMountedAtoms.add(atom)
-    },
-  )
-  ;(storeHooks.u ||= INTERNAL_createStoreHookForAtom()).add(
-    undefined,
-    (atom) => {
-      debugMountedAtoms.delete(atom)
-    },
-  )
+  storeHooks.m.add(undefined, (atom) => {
+    debugMountedAtoms.add(atom)
+  })
+  storeHooks.u.add(undefined, (atom) => {
+    debugMountedAtoms.delete(atom)
+  })
   const devStore: INTERNAL_DevStoreRev4 = {
     // store dev methods (these are tentative and subject to change without notice)
     dev4_get_internal_weak_map: () => atomStateMap,

--- a/tests/vanilla/effect.test.ts
+++ b/tests/vanilla/effect.test.ts
@@ -1,7 +1,10 @@
 import { expect, it, vi } from 'vitest'
 import type { Atom, Getter, Setter, WritableAtom } from 'jotai/vanilla'
 import { atom, createStore } from 'jotai/vanilla'
-import { INTERNAL_getStoreStateRev1 as INTERNAL_getStoreState } from 'jotai/vanilla/internals'
+import {
+  INTERNAL_getStoreStateRev1 as INTERNAL_getStoreState,
+  INTERNAL_initializeStoreHooks,
+} from 'jotai/vanilla/internals'
 
 type Cleanup = () => void
 type Effect = (get: Getter, set: Setter) => Cleanup | void
@@ -55,7 +58,8 @@ function syncEffect(effect: Effect): Atom<void> {
         deps.forEach(ref.get!)
       }
     }
-    const [, storeHooks] = INTERNAL_getStoreState(store)
+    const storeState = INTERNAL_getStoreState(store)
+    const storeHooks = INTERNAL_initializeStoreHooks(storeState)
     storeHooks.m.add(internalAtom, () => {
       // mount
       store.set(refreshAtom, (v) => v + 1)
@@ -84,7 +88,8 @@ const syncEffectChannelSymbol = Symbol()
 function ensureSyncEffectChannel(store: any) {
   if (!store[syncEffectChannelSymbol]) {
     store[syncEffectChannelSymbol] = new Set<() => void>()
-    const [, storeHooks] = INTERNAL_getStoreState(store)
+    const storeState = INTERNAL_getStoreState(store)
+    const storeHooks = INTERNAL_initializeStoreHooks(storeState)
     storeHooks.f.add(() => {
       const syncEffectChannel = store[syncEffectChannelSymbol] as Set<
         () => void


### PR DESCRIPTION
## Summary
- fix type typo
- use WeakMap instead of Map for storing callbacks
- export initializeStoreHooks to centralize storeHook callback registration
- createStoreHook for flushHook

## Check List

- [x] `pnpm run fix:format` for formatting code and docs
