### PR TITLE
refactor(internals): store state in store args

### DIFF
--- a/.github/workflows/test-multiple-builds.yml
+++ b/.github/workflows/test-multiple-builds.yml
@@ -43,7 +43,7 @@ jobs:
           sed -i~ "s/resolve('\.\/src\(.*\)\.ts')/resolve('\.\/dist\1.js')/" vitest.config.mts
           sed -i~ "s/import { useResetAtom } from 'jotai\/react\/utils'/const { useResetAtom } = require('..\/..\/..\/dist\/react\/utils.js')/" tests/react/utils/useResetAtom.test.tsx
           sed -i~ "s/import { RESET, atomWithReducer, atomWithReset } from 'jotai\/vanilla\/utils'/const { RESET, atomWithReducer, atomWithReset } = require('..\/..\/..\/dist\/vanilla\/utils.js')/" tests/react/utils/useResetAtom.test.tsx
-          perl -i~ -0777 -pe "s/import {[^}]+} from 'jotai\/vanilla\/internals'/const { INTERNAL_buildStore, INTERNAL_initializeStoreHooks, INTERNAL_getStoreStateRev1: INTERNAL_getStoreState } = require('..\/..\/dist\/vanilla\/internals.js')/g" tests/vanilla/store.test.tsx tests/vanilla/derive.test.tsx tests/vanilla/effect.test.ts
+          perl -i~ -0777 -pe "s/import {[^}]+} from 'jotai\/vanilla\/internals'/const { INTERNAL_buildStore, INTERNAL_initializeStoreHooks, INTERNAL_getStoreArgsRev1: INTERNAL_getStoreArgs } = require('..\/..\/dist\/vanilla\/internals.js')/g" tests/vanilla/store.test.tsx tests/vanilla/derive.test.tsx tests/vanilla/effect.test.ts
       - name: Patch for ESM
         if: ${{ matrix.build == 'esm' }}
         run: |

--- a/.github/workflows/test-multiple-builds.yml
+++ b/.github/workflows/test-multiple-builds.yml
@@ -43,7 +43,7 @@ jobs:
           sed -i~ "s/resolve('\.\/src\(.*\)\.ts')/resolve('\.\/dist\1.js')/" vitest.config.mts
           sed -i~ "s/import { useResetAtom } from 'jotai\/react\/utils'/const { useResetAtom } = require('..\/..\/..\/dist\/react\/utils.js')/" tests/react/utils/useResetAtom.test.tsx
           sed -i~ "s/import { RESET, atomWithReducer, atomWithReset } from 'jotai\/vanilla\/utils'/const { RESET, atomWithReducer, atomWithReset } = require('..\/..\/..\/dist\/vanilla\/utils.js')/" tests/react/utils/useResetAtom.test.tsx
-          perl -i~ -0777 -pe "s/import {[^}]+} from 'jotai\/vanilla\/internals'/const { INTERNAL_buildStore, INTERNAL_initializeStoreHooks, INTERNAL_getStoreArgsRev1: INTERNAL_getStoreArgs } = require('..\/..\/dist\/vanilla\/internals.js')/g" tests/vanilla/store.test.tsx tests/vanilla/derive.test.tsx tests/vanilla/effect.test.ts
+          perl -i~ -0777 -pe "s/import {[^}]+} from 'jotai\/vanilla\/internals'/const { INTERNAL_buildStore, INTERNAL_createStoreArgs, INTERNAL_initializeStoreHooks, INTERNAL_getStoreArgsRev1: INTERNAL_getStoreArgs } = require('..\/..\/dist\/vanilla\/internals.js')/g" tests/vanilla/store.test.tsx tests/vanilla/derive.test.tsx tests/vanilla/effect.test.ts
       - name: Patch for ESM
         if: ${{ matrix.build == 'esm' }}
         run: |

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -1,7 +1,6 @@
 import type { Atom, WritableAtom } from './atom.ts'
 import {
   INTERNAL_buildStore,
-  INTERNAL_getStoreStateRev1 as INTERNAL_getStoreState,
   INTERNAL_initializeStoreHooks,
 } from './internals.ts'
 import type { INTERNAL_AtomState } from './internals.ts'
@@ -30,6 +29,9 @@ export type INTERNAL_DevStoreRev4 = {
 
 const createDevStoreRev4 = (): INTERNAL_PrdStore & INTERNAL_DevStoreRev4 => {
   let inRestoreAtom = 0
+  const storeHooks = INTERNAL_initializeStoreHooks({})
+  const atomStateMap = new WeakMap()
+  const mountedAtoms = new WeakMap()
   const store = INTERNAL_buildStore(
     (atom, ...params) => atom.read(...params),
     (atom, get, set, ...args) => {
@@ -40,11 +42,14 @@ const createDevStoreRev4 = (): INTERNAL_PrdStore & INTERNAL_DevStoreRev4 => {
     },
     (atom, ...params) => atom.unstable_onInit?.(...params),
     (atom, ...params) => atom.onMount?.(...params),
+    storeHooks,
+    atomStateMap,
+    mountedAtoms,
+    new WeakMap(),
+    new Map(),
+    new Set(),
+    new Set(),
   )
-  const storeState = INTERNAL_getStoreState(store)
-  const storeHooks = INTERNAL_initializeStoreHooks(storeState)
-  const mountedAtoms = storeState[3]
-  const atomStateMap = storeState[7]
   const debugMountedAtoms = new Set<Atom<unknown>>()
   storeHooks.m.add(undefined, (atom) => {
     debugMountedAtoms.add(atom)
@@ -97,6 +102,13 @@ export const createStore = (): PrdOrDevStore => {
     (atom, ...params) => atom.write(...params),
     (atom, ...params) => atom.unstable_onInit?.(...params),
     (atom, ...params) => atom.onMount?.(...params),
+    {},
+    new WeakMap(),
+    new WeakMap(),
+    new WeakMap(),
+    new Map(),
+    new Set(),
+    new Set(),
   )
   return store
 }

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -1,6 +1,7 @@
 import type { Atom, WritableAtom } from './atom.ts'
 import {
   INTERNAL_buildStore,
+  INTERNAL_createStoreArgs,
   INTERNAL_initializeStoreHooks,
 } from './internals.ts'
 import type { INTERNAL_AtomState } from './internals.ts'
@@ -33,6 +34,13 @@ const createDevStoreRev4 = (): INTERNAL_PrdStore & INTERNAL_DevStoreRev4 => {
   const atomStateMap = new WeakMap()
   const mountedAtoms = new WeakMap()
   const store = INTERNAL_buildStore(
+    atomStateMap,
+    mountedAtoms,
+    new WeakMap(),
+    new Map(),
+    new Set(),
+    new Set(),
+    storeHooks,
     (atom, ...params) => atom.read(...params),
     (atom, get, set, ...args) => {
       if (inRestoreAtom) {
@@ -42,13 +50,6 @@ const createDevStoreRev4 = (): INTERNAL_PrdStore & INTERNAL_DevStoreRev4 => {
     },
     (atom, ...params) => atom.unstable_onInit?.(...params),
     (atom, ...params) => atom.onMount?.(...params),
-    storeHooks,
-    atomStateMap,
-    mountedAtoms,
-    new WeakMap(),
-    new Map(),
-    new Set(),
-    new Set(),
   )
   const debugMountedAtoms = new Set<Atom<unknown>>()
   storeHooks.m.add(undefined, (atom) => {
@@ -97,19 +98,7 @@ export const createStore = (): PrdOrDevStore => {
   if (import.meta.env?.MODE !== 'production') {
     return createDevStoreRev4()
   }
-  const store = INTERNAL_buildStore(
-    (atom, ...params) => atom.read(...params),
-    (atom, ...params) => atom.write(...params),
-    (atom, ...params) => atom.unstable_onInit?.(...params),
-    (atom, ...params) => atom.onMount?.(...params),
-    {},
-    new WeakMap(),
-    new WeakMap(),
-    new WeakMap(),
-    new Map(),
-    new Set(),
-    new Set(),
-  )
+  const store = INTERNAL_buildStore(...INTERNAL_createStoreArgs())
   return store
 }
 

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -37,7 +37,7 @@ const createDevStoreRev4 = (): INTERNAL_PrdStore & INTERNAL_DevStoreRev4 => {
     atomStateMap,
     mountedAtoms,
     new WeakMap(),
-    new Map(),
+    new Set(),
     new Set(),
     new Set(),
     storeHooks,

--- a/tests/vanilla/derive.test.tsx
+++ b/tests/vanilla/derive.test.tsx
@@ -3,27 +3,21 @@ import { atom, createStore } from 'jotai/vanilla'
 import type { Atom } from 'jotai/vanilla'
 import {
   INTERNAL_buildStore,
+  INTERNAL_createStoreArgs,
   INTERNAL_getStoreArgsRev1 as INTERNAL_getStoreArgs,
 } from 'jotai/vanilla/internals'
 
-type AtomStateMapType = ReturnType<typeof INTERNAL_getStoreArgs>[5]
+type AtomStateMapType = ReturnType<typeof INTERNAL_getStoreArgs>[0]
 
 const deriveStore = (
   store: ReturnType<typeof createStore>,
   enhanceAtomStateMap: (atomStateMap: AtomStateMapType) => AtomStateMapType,
 ): ReturnType<typeof createStore> => {
   const storeArgs = INTERNAL_getStoreArgs(store)
-  const atomStateMap = storeArgs[5]
-  const newStoreArgs = [
-    ...storeArgs.slice(0, 4),
-    {},
+  const atomStateMap = storeArgs[0]
+  const newStoreArgs = INTERNAL_createStoreArgs(
     enhanceAtomStateMap(atomStateMap),
-    new WeakMap(),
-    new WeakMap(),
-    new Map(),
-    new Set(),
-    new Set(),
-  ]
+  )
   const derivedStore = (INTERNAL_buildStore as any)(...newStoreArgs)
   return derivedStore
 }

--- a/tests/vanilla/derive.test.tsx
+++ b/tests/vanilla/derive.test.tsx
@@ -3,24 +3,28 @@ import { atom, createStore } from 'jotai/vanilla'
 import type { Atom } from 'jotai/vanilla'
 import {
   INTERNAL_buildStore,
-  INTERNAL_getStoreStateRev1 as INTERNAL_getStoreState,
+  INTERNAL_getStoreArgsRev1 as INTERNAL_getStoreArgs,
 } from 'jotai/vanilla/internals'
 
-type StoreArgs = Parameters<typeof INTERNAL_buildStore>
-type AtomStateMapType = ReturnType<typeof INTERNAL_getStoreState>[7]
+type AtomStateMapType = ReturnType<typeof INTERNAL_getStoreArgs>[5]
 
 const deriveStore = (
   store: ReturnType<typeof createStore>,
   enhanceAtomStateMap: (atomStateMap: AtomStateMapType) => AtomStateMapType,
-  enhanceStoreArgs: (...storeArgs: StoreArgs) => StoreArgs = (...args) => args,
 ): ReturnType<typeof createStore> => {
-  const storeState = INTERNAL_getStoreState(store)
-  const atomStateMap = storeState[7]
-  const storeArgs = storeState[0]
-  const newStoreArgs = (enhanceStoreArgs as any)(...storeArgs)
+  const storeArgs = INTERNAL_getStoreArgs(store)
+  const atomStateMap = storeArgs[5]
+  const newStoreArgs = [
+    ...storeArgs.slice(0, 4),
+    {},
+    enhanceAtomStateMap(atomStateMap),
+    new WeakMap(),
+    new WeakMap(),
+    new Map(),
+    new Set(),
+    new Set(),
+  ]
   const derivedStore = (INTERNAL_buildStore as any)(...newStoreArgs)
-  const derivedStoreState = INTERNAL_getStoreState(derivedStore)
-  derivedStoreState[7] = enhanceAtomStateMap(atomStateMap)
   return derivedStore
 }
 

--- a/tests/vanilla/effect.test.ts
+++ b/tests/vanilla/effect.test.ts
@@ -59,7 +59,7 @@ function syncEffect(effect: Effect): Atom<void> {
       }
     }
     const storeArgs = INTERNAL_getStoreArgs(store)
-    const storeHooks = INTERNAL_initializeStoreHooks(storeArgs[4])
+    const storeHooks = INTERNAL_initializeStoreHooks(storeArgs[6])
     const syncEffectChannel = ensureSyncEffectChannel(store)
     storeHooks.m.add(internalAtom, () => {
       // mount
@@ -88,7 +88,7 @@ function ensureSyncEffectChannel(store: any) {
   if (!store[syncEffectChannelSymbol]) {
     store[syncEffectChannelSymbol] = new Set<() => void>()
     const storeArgs = INTERNAL_getStoreArgs(store)
-    const storeHooks = INTERNAL_initializeStoreHooks(storeArgs[4])
+    const storeHooks = INTERNAL_initializeStoreHooks(storeArgs[6])
     storeHooks.f.add(() => {
       const syncEffectChannel = store[syncEffectChannelSymbol] as Set<
         () => void

--- a/tests/vanilla/effect.test.ts
+++ b/tests/vanilla/effect.test.ts
@@ -2,7 +2,7 @@ import { expect, it, vi } from 'vitest'
 import type { Atom, Getter, Setter, WritableAtom } from 'jotai/vanilla'
 import { atom, createStore } from 'jotai/vanilla'
 import {
-  INTERNAL_getStoreStateRev1 as INTERNAL_getStoreState,
+  INTERNAL_getStoreArgsRev1 as INTERNAL_getStoreArgs,
   INTERNAL_initializeStoreHooks,
 } from 'jotai/vanilla/internals'
 
@@ -58,8 +58,8 @@ function syncEffect(effect: Effect): Atom<void> {
         deps.forEach(ref.get!)
       }
     }
-    const storeState = INTERNAL_getStoreState(store)
-    const storeHooks = INTERNAL_initializeStoreHooks(storeState)
+    const storeArgs = INTERNAL_getStoreArgs(store)
+    const storeHooks = INTERNAL_initializeStoreHooks(storeArgs[4])
     const syncEffectChannel = ensureSyncEffectChannel(store)
     storeHooks.m.add(internalAtom, () => {
       // mount
@@ -87,8 +87,8 @@ const syncEffectChannelSymbol = Symbol()
 function ensureSyncEffectChannel(store: any) {
   if (!store[syncEffectChannelSymbol]) {
     store[syncEffectChannelSymbol] = new Set<() => void>()
-    const storeState = INTERNAL_getStoreState(store)
-    const storeHooks = INTERNAL_initializeStoreHooks(storeState)
+    const storeArgs = INTERNAL_getStoreArgs(store)
+    const storeHooks = INTERNAL_initializeStoreHooks(storeArgs[4])
     storeHooks.f.add(() => {
       const syncEffectChannel = store[syncEffectChannelSymbol] as Set<
         () => void

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -4,19 +4,21 @@ import { atom, createStore } from 'jotai/vanilla'
 import type { Atom, Getter, PrimitiveAtom } from 'jotai/vanilla'
 import {
   INTERNAL_buildStore,
+  INTERNAL_createStoreArgs,
   INTERNAL_getStoreArgsRev1 as INTERNAL_getStoreArgs,
 } from 'jotai/vanilla/internals'
 
-type AtomStateMapType = ReturnType<typeof INTERNAL_getStoreArgs>[5]
+type AtomStateMapType = ReturnType<typeof INTERNAL_getStoreArgs>[0]
 
 const deriveStore = (
   store: ReturnType<typeof createStore>,
   enhanceAtomStateMap: (atomStateMap: AtomStateMapType) => AtomStateMapType,
 ): ReturnType<typeof createStore> => {
   const storeArgs = INTERNAL_getStoreArgs(store)
-  const atomStateMap = storeArgs[5]
-  const newStoreArgs = [...storeArgs]
-  newStoreArgs[5] = enhanceAtomStateMap(atomStateMap)
+  const atomStateMap = storeArgs[0]
+  const newStoreArgs = INTERNAL_createStoreArgs(
+    enhanceAtomStateMap(atomStateMap),
+  )
   const derivedStore = (INTERNAL_buildStore as any)(...newStoreArgs)
   return derivedStore
 }

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -4,24 +4,20 @@ import { atom, createStore } from 'jotai/vanilla'
 import type { Atom, Getter, PrimitiveAtom } from 'jotai/vanilla'
 import {
   INTERNAL_buildStore,
-  INTERNAL_getStoreStateRev1 as INTERNAL_getStoreState,
+  INTERNAL_getStoreArgsRev1 as INTERNAL_getStoreArgs,
 } from 'jotai/vanilla/internals'
 
-type StoreArgs = Parameters<typeof INTERNAL_buildStore>
-type AtomStateMapType = ReturnType<typeof INTERNAL_getStoreState>[7]
+type AtomStateMapType = ReturnType<typeof INTERNAL_getStoreArgs>[5]
 
 const deriveStore = (
   store: ReturnType<typeof createStore>,
   enhanceAtomStateMap: (atomStateMap: AtomStateMapType) => AtomStateMapType,
-  enhanceStoreArgs: (...storeArgs: StoreArgs) => StoreArgs = (...args) => args,
 ): ReturnType<typeof createStore> => {
-  const storeState = INTERNAL_getStoreState(store)
-  const atomStateMap = storeState[7]
-  const storeArgs = storeState[0]
-  const newStoreArgs = (enhanceStoreArgs as any)(...storeArgs)
+  const storeArgs = INTERNAL_getStoreArgs(store)
+  const atomStateMap = storeArgs[5]
+  const newStoreArgs = [...storeArgs]
+  newStoreArgs[5] = enhanceAtomStateMap(atomStateMap)
   const derivedStore = (INTERNAL_buildStore as any)(...newStoreArgs)
-  const derivedStoreState = INTERNAL_getStoreState(derivedStore)
-  derivedStoreState[7] = enhanceAtomStateMap(atomStateMap)
   return derivedStore
 }
 


### PR DESCRIPTION
The reason we had `getAtomState` is for `unstable_derive` and to avoid having state. #2911 goes with a different approach and it has store state. ~We should have atomStateMap there too. Especially, having ensureAtomState function as store state seemed weird.~ Second take is to put everything in store args.