### PR TITLE
expose building blocks

### DIFF
--- a/.github/workflows/test-multiple-builds.yml
+++ b/.github/workflows/test-multiple-builds.yml
@@ -43,7 +43,7 @@ jobs:
           sed -i~ "s/resolve('\.\/src\(.*\)\.ts')/resolve('\.\/dist\1.js')/" vitest.config.mts
           sed -i~ "s/import { useResetAtom } from 'jotai\/react\/utils'/const { useResetAtom } = require('..\/..\/..\/dist\/react\/utils.js')/" tests/react/utils/useResetAtom.test.tsx
           sed -i~ "s/import { RESET, atomWithReducer, atomWithReset } from 'jotai\/vanilla\/utils'/const { RESET, atomWithReducer, atomWithReset } = require('..\/..\/..\/dist\/vanilla\/utils.js')/" tests/react/utils/useResetAtom.test.tsx
-          perl -i~ -0777 -pe "s/import {[^}]+} from 'jotai\/vanilla\/internals'/const { INTERNAL_buildStore, INTERNAL_createStoreArgs, INTERNAL_initializeStoreHooks, INTERNAL_getStoreArgsRev1: INTERNAL_getStoreArgs } = require('..\/..\/dist\/vanilla\/internals.js')/g" tests/vanilla/store.test.tsx tests/vanilla/derive.test.tsx tests/vanilla/effect.test.ts
+          perl -i~ -0777 -pe "s/import {[^}]+} from 'jotai\/vanilla\/internals'/const { INTERNAL_buildStore, INTERNAL_createStoreArgsRev1: INTERNAL_createStoreArgs, INTERNAL_initializeStoreHooks, INTERNAL_getStoreArgsRev1: INTERNAL_getStoreArgs, INTERNAL_createBuildingBlocksRev1: INTERNAL_createBuildingBlocks } = require('..\/..\/dist\/vanilla\/internals.js')/g" tests/vanilla/store.test.tsx tests/vanilla/derive.test.tsx tests/vanilla/effect.test.ts
       - name: Patch for ESM
         if: ${{ matrix.build == 'esm' }}
         run: |

--- a/.github/workflows/test-multiple-builds.yml
+++ b/.github/workflows/test-multiple-builds.yml
@@ -43,7 +43,7 @@ jobs:
           sed -i~ "s/resolve('\.\/src\(.*\)\.ts')/resolve('\.\/dist\1.js')/" vitest.config.mts
           sed -i~ "s/import { useResetAtom } from 'jotai\/react\/utils'/const { useResetAtom } = require('..\/..\/..\/dist\/react\/utils.js')/" tests/react/utils/useResetAtom.test.tsx
           sed -i~ "s/import { RESET, atomWithReducer, atomWithReset } from 'jotai\/vanilla\/utils'/const { RESET, atomWithReducer, atomWithReset } = require('..\/..\/..\/dist\/vanilla\/utils.js')/" tests/react/utils/useResetAtom.test.tsx
-          perl -i~ -0777 -pe "s/import {[^}]+} from 'jotai\/vanilla\/internals'/const { INTERNAL_buildStore, INTERNAL_createStoreArgsRev1: INTERNAL_createStoreArgs, INTERNAL_initializeStoreHooks, INTERNAL_getStoreArgsRev1: INTERNAL_getStoreArgs, INTERNAL_createBuildingBlocksRev1: INTERNAL_createBuildingBlocks } = require('..\/..\/dist\/vanilla\/internals.js')/g" tests/vanilla/store.test.tsx tests/vanilla/derive.test.tsx tests/vanilla/effect.test.ts
+          perl -i~ -0777 -pe "s/import {[^}]+} from 'jotai\/vanilla\/internals'/const { INTERNAL_buildStore, INTERNAL_initializeStoreHooks, INTERNAL_getBuildingBlocksRev1: INTERNAL_getBuildingBlocks, INTERNAL_createBuildingBlocksRev1: INTERNAL_createBuildingBlocks } = require('..\/..\/dist\/vanilla\/internals.js')/g" tests/vanilla/store.test.tsx tests/vanilla/derive.test.tsx tests/vanilla/effect.test.ts
       - name: Patch for ESM
         if: ${{ matrix.build == 'esm' }}
         run: |

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -227,7 +227,7 @@ type BuildingBlocks = readonly [
 
 const createBuildingBlocks = (
   getStore: () => Store,
-  [
+  ...[
     atomStateMap = new WeakMap(),
     mountedAtoms = new WeakMap(),
     invalidatedAtoms = new WeakMap(),
@@ -235,13 +235,11 @@ const createBuildingBlocks = (
     mountCallbacks = new Set(),
     unmountCallbacks = new Set(),
     storeHooks = {},
-  ]: Partial<StoreState>,
-  [
     atomRead = (atom, ...params) => atom.read(...params),
     atomWrite = (atom, ...params) => atom.write(...params),
     atomOnInit = (atom, ...params) => atom.unstable_onInit?.(...params),
     atomOnMount = (atom, ...params) => atom.onMount?.(...params),
-  ]: Partial<StoreIntercepters> = [],
+  ]: Partial<[...StoreState, ...StoreIntercepters]>
 ): BuildingBlocks => {
   const readAtom = <Value>(atom: Atom<Value>): Value =>
     returnAtomValue(readAtomState(atom))

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -822,16 +822,17 @@ const createStoreArgs: (...storeArgs: Partial<StoreArgs>) => StoreArgs = (
   atomOnMount,
 ]
 
-const buildStore = (...storeArgs: StoreArgs): Store => {
-  const [
+const buildStore = (
+  storeArgs: StoreArgs,
+  [
     flushCallbacks,
     recomputeInvalidatedAtoms,
     readAtomState,
     writeAtomState,
     mountAtom,
     unmountAtom,
-  ] = createBuildingBlocks(storeArgs, () => store as Store)
-
+  ]: BuildingBlocks,
+): Store => {
   const readAtom = <Value>(atom: Atom<Value>): Value =>
     returnAtomValue(readAtomState(atom))
 
@@ -872,11 +873,12 @@ const buildStore = (...storeArgs: StoreArgs): Store => {
 // Export internal functions
 //
 
-export const INTERNAL_createStoreArgs: typeof createStoreArgs = createStoreArgs
 export const INTERNAL_buildStore: typeof buildStore = buildStore
-export const INTERNAL_getStoreArgsRev1: typeof getStoreArgs = getStoreArgs
 export const INTERNAL_createBuildingBlocksRev1: typeof createBuildingBlocks =
   createBuildingBlocks
+export const INTERNAL_createStoreArgsRev1: typeof createStoreArgs =
+  createStoreArgs
+export const INTERNAL_getStoreArgsRev1: typeof getStoreArgs = getStoreArgs
 export const INTERNAL_initializeStoreHooks: typeof initializeStoreHooks =
   initializeStoreHooks
 

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -43,16 +43,12 @@ const createDevStoreRev4 = (): INTERNAL_PrdStore & INTERNAL_DevStoreRev4 => {
     }
     return atom.write(get, set, ...args)
   }
-  const storeState: Partial<StoreState> = [
-    atomStateMap,
-    mountedAtoms,
-    ,
-    ,
-    ,
-    ,
-    storeHooks,
-  ]
-  const storeInterceptors: Partial<StoreInterceptors> = [, atomWrite]
+  const storeState: Partial<StoreState> = []
+  storeState[0] = atomStateMap
+  storeState[1] = mountedAtoms
+  storeState[6] = storeHooks
+  const storeInterceptors: Partial<StoreInterceptors> = []
+  storeInterceptors[1] = atomWrite
   const buildingBlocks = INTERNAL_createBuildingBlocks(
     () => store,
     ...storeState,

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -33,22 +33,30 @@ const createDevStoreRev4 = (): INTERNAL_PrdStore & INTERNAL_DevStoreRev4 => {
   const storeHooks = INTERNAL_initializeStoreHooks({})
   const atomStateMap = new WeakMap()
   const mountedAtoms = new WeakMap()
-  const buildingBlocks = INTERNAL_createBuildingBlocks(
-    () => store,
+  type BuildingBlocks = ReturnType<typeof INTERNAL_createBuildingBlocks>
+  type StoreState = BuildingBlocks[0]
+  type StoreInterceptors = BuildingBlocks[1]
+  type AtomWrite = StoreInterceptors[1]
+  const atomWrite: AtomWrite = (atom, get, set, ...args) => {
+    if (inRestoreAtom) {
+      return set(atom, ...args)
+    }
+    return atom.write(get, set, ...args)
+  }
+  const storeState: Partial<StoreState> = [
     atomStateMap,
     mountedAtoms,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
+    ,
+    ,
+    ,
+    ,
     storeHooks,
-    undefined,
-    (atom, get, set, ...args) => {
-      if (inRestoreAtom) {
-        return set(atom, ...args)
-      }
-      return atom.write(get, set, ...args)
-    },
+  ]
+  const storeInterceptors: Partial<StoreInterceptors> = [, atomWrite]
+  const buildingBlocks = INTERNAL_createBuildingBlocks(
+    () => store,
+    ...storeState,
+    ...storeInterceptors,
   )
   const store = INTERNAL_buildStore(buildingBlocks)
   const debugMountedAtoms = new Set<Atom<unknown>>()

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -2,7 +2,6 @@ import type { Atom, WritableAtom } from './atom.ts'
 import {
   INTERNAL_buildStore,
   INTERNAL_createBuildingBlocksRev1 as INTERNAL_createBuildingBlocks,
-  INTERNAL_createStoreArgsRev1 as INTERNAL_createStoreArgs,
   INTERNAL_initializeStoreHooks,
 } from './internals.ts'
 import type { INTERNAL_AtomState } from './internals.ts'
@@ -34,26 +33,24 @@ const createDevStoreRev4 = (): INTERNAL_PrdStore & INTERNAL_DevStoreRev4 => {
   const storeHooks = INTERNAL_initializeStoreHooks({})
   const atomStateMap = new WeakMap()
   const mountedAtoms = new WeakMap()
-  const storeArgs = INTERNAL_createStoreArgs(
+  const buildingBlocks = INTERNAL_createBuildingBlocks(
+    () => store,
     atomStateMap,
     mountedAtoms,
-    new WeakMap(),
-    new Set(),
-    new Set(),
-    new Set(),
+    undefined,
+    undefined,
+    undefined,
+    undefined,
     storeHooks,
-    (atom, ...params) => atom.read(...params),
+    undefined,
     (atom, get, set, ...args) => {
       if (inRestoreAtom) {
         return set(atom, ...args)
       }
       return atom.write(get, set, ...args)
     },
-    (atom, ...params) => atom.unstable_onInit?.(...params),
-    (atom, ...params) => atom.onMount?.(...params),
   )
-  const buildingBlocks = INTERNAL_createBuildingBlocks(storeArgs, () => store)
-  const store = INTERNAL_buildStore(storeArgs, buildingBlocks)
+  const store = INTERNAL_buildStore(buildingBlocks)
   const debugMountedAtoms = new Set<Atom<unknown>>()
   storeHooks.m.add(undefined, (atom) => {
     debugMountedAtoms.add(atom)
@@ -101,9 +98,8 @@ export const createStore = (): PrdOrDevStore => {
   if (import.meta.env?.MODE !== 'production') {
     return createDevStoreRev4()
   }
-  const storeArgs = INTERNAL_createStoreArgs()
-  const buildingBlocks = INTERNAL_createBuildingBlocks(storeArgs, () => store)
-  const store = INTERNAL_buildStore(storeArgs, buildingBlocks)
+  const buildingBlocks = INTERNAL_createBuildingBlocks(() => store)
+  const store = INTERNAL_buildStore(buildingBlocks)
   return store
 }
 

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -1,7 +1,8 @@
 import type { Atom, WritableAtom } from './atom.ts'
 import {
   INTERNAL_buildStore,
-  INTERNAL_createStoreArgs,
+  INTERNAL_createBuildingBlocksRev1 as INTERNAL_createBuildingBlocks,
+  INTERNAL_createStoreArgsRev1 as INTERNAL_createStoreArgs,
   INTERNAL_initializeStoreHooks,
 } from './internals.ts'
 import type { INTERNAL_AtomState } from './internals.ts'
@@ -33,7 +34,7 @@ const createDevStoreRev4 = (): INTERNAL_PrdStore & INTERNAL_DevStoreRev4 => {
   const storeHooks = INTERNAL_initializeStoreHooks({})
   const atomStateMap = new WeakMap()
   const mountedAtoms = new WeakMap()
-  const store = INTERNAL_buildStore(
+  const storeArgs = INTERNAL_createStoreArgs(
     atomStateMap,
     mountedAtoms,
     new WeakMap(),
@@ -51,6 +52,8 @@ const createDevStoreRev4 = (): INTERNAL_PrdStore & INTERNAL_DevStoreRev4 => {
     (atom, ...params) => atom.unstable_onInit?.(...params),
     (atom, ...params) => atom.onMount?.(...params),
   )
+  const buildingBlocks = INTERNAL_createBuildingBlocks(storeArgs, () => store)
+  const store = INTERNAL_buildStore(storeArgs, buildingBlocks)
   const debugMountedAtoms = new Set<Atom<unknown>>()
   storeHooks.m.add(undefined, (atom) => {
     debugMountedAtoms.add(atom)
@@ -98,7 +101,9 @@ export const createStore = (): PrdOrDevStore => {
   if (import.meta.env?.MODE !== 'production') {
     return createDevStoreRev4()
   }
-  const store = INTERNAL_buildStore(...INTERNAL_createStoreArgs())
+  const storeArgs = INTERNAL_createStoreArgs()
+  const buildingBlocks = INTERNAL_createBuildingBlocks(storeArgs, () => store)
+  const store = INTERNAL_buildStore(storeArgs, buildingBlocks)
   return store
 }
 

--- a/tests/vanilla/derive.test.tsx
+++ b/tests/vanilla/derive.test.tsx
@@ -3,7 +3,8 @@ import { atom, createStore } from 'jotai/vanilla'
 import type { Atom } from 'jotai/vanilla'
 import {
   INTERNAL_buildStore,
-  INTERNAL_createStoreArgs,
+  INTERNAL_createBuildingBlocksRev1 as INTERNAL_createBuildingBlocks,
+  INTERNAL_createStoreArgsRev1 as INTERNAL_createStoreArgs,
   INTERNAL_getStoreArgsRev1 as INTERNAL_getStoreArgs,
 } from 'jotai/vanilla/internals'
 
@@ -18,7 +19,11 @@ const deriveStore = (
   const newStoreArgs = INTERNAL_createStoreArgs(
     enhanceAtomStateMap(atomStateMap),
   )
-  const derivedStore = (INTERNAL_buildStore as any)(...newStoreArgs)
+  const buildingBlocks = INTERNAL_createBuildingBlocks(
+    newStoreArgs,
+    () => derivedStore,
+  )
+  const derivedStore = INTERNAL_buildStore(newStoreArgs, buildingBlocks)
   return derivedStore
 }
 

--- a/tests/vanilla/derive.test.tsx
+++ b/tests/vanilla/derive.test.tsx
@@ -4,26 +4,22 @@ import type { Atom } from 'jotai/vanilla'
 import {
   INTERNAL_buildStore,
   INTERNAL_createBuildingBlocksRev1 as INTERNAL_createBuildingBlocks,
-  INTERNAL_createStoreArgsRev1 as INTERNAL_createStoreArgs,
-  INTERNAL_getStoreArgsRev1 as INTERNAL_getStoreArgs,
+  INTERNAL_getBuildingBlocksRev1 as INTERNAL_getBuildingBlocks,
 } from 'jotai/vanilla/internals'
 
-type AtomStateMapType = ReturnType<typeof INTERNAL_getStoreArgs>[0]
+type AtomStateMapType = ReturnType<typeof INTERNAL_getBuildingBlocks>[6]
 
 const deriveStore = (
   store: ReturnType<typeof createStore>,
   enhanceAtomStateMap: (atomStateMap: AtomStateMapType) => AtomStateMapType,
 ): ReturnType<typeof createStore> => {
-  const storeArgs = INTERNAL_getStoreArgs(store)
-  const atomStateMap = storeArgs[0]
-  const newStoreArgs = INTERNAL_createStoreArgs(
+  const buildingBlocks = INTERNAL_getBuildingBlocks(store)
+  const atomStateMap = buildingBlocks[6]
+  const newBuildingBlocks = INTERNAL_createBuildingBlocks(
+    () => derivedStore,
     enhanceAtomStateMap(atomStateMap),
   )
-  const buildingBlocks = INTERNAL_createBuildingBlocks(
-    newStoreArgs,
-    () => derivedStore,
-  )
-  const derivedStore = INTERNAL_buildStore(newStoreArgs, buildingBlocks)
+  const derivedStore = INTERNAL_buildStore(newBuildingBlocks)
   return derivedStore
 }
 

--- a/tests/vanilla/derive.test.tsx
+++ b/tests/vanilla/derive.test.tsx
@@ -7,14 +7,14 @@ import {
   INTERNAL_getBuildingBlocksRev1 as INTERNAL_getBuildingBlocks,
 } from 'jotai/vanilla/internals'
 
-type AtomStateMapType = ReturnType<typeof INTERNAL_getBuildingBlocks>[6]
+type AtomStateMapType = ReturnType<typeof INTERNAL_getBuildingBlocks>[0][0]
 
 const deriveStore = (
   store: ReturnType<typeof createStore>,
   enhanceAtomStateMap: (atomStateMap: AtomStateMapType) => AtomStateMapType,
 ): ReturnType<typeof createStore> => {
   const buildingBlocks = INTERNAL_getBuildingBlocks(store)
-  const atomStateMap = buildingBlocks[6]
+  const atomStateMap = buildingBlocks[0][0]
   const newBuildingBlocks = INTERNAL_createBuildingBlocks(
     () => derivedStore,
     enhanceAtomStateMap(atomStateMap),

--- a/tests/vanilla/effect.test.ts
+++ b/tests/vanilla/effect.test.ts
@@ -58,8 +58,8 @@ function syncEffect(effect: Effect): Atom<void> {
         deps.forEach(ref.get!)
       }
     }
-    const buildingBlocks = INTERNAL_getBuildingBlocks(store)
-    const storeHooks = INTERNAL_initializeStoreHooks(buildingBlocks[12])
+    const [storeState] = INTERNAL_getBuildingBlocks(store)
+    const storeHooks = INTERNAL_initializeStoreHooks(storeState[6])
     const syncEffectChannel = ensureSyncEffectChannel(store)
     storeHooks.m.add(internalAtom, () => {
       // mount
@@ -87,8 +87,8 @@ const syncEffectChannelSymbol = Symbol()
 function ensureSyncEffectChannel(store: any) {
   if (!store[syncEffectChannelSymbol]) {
     store[syncEffectChannelSymbol] = new Set<() => void>()
-    const buildingBlocks = INTERNAL_getBuildingBlocks(store)
-    const storeHooks = INTERNAL_initializeStoreHooks(buildingBlocks[12])
+    const [storeState] = INTERNAL_getBuildingBlocks(store)
+    const storeHooks = INTERNAL_initializeStoreHooks(storeState[6])
     storeHooks.f.add(() => {
       const syncEffectChannel = store[syncEffectChannelSymbol] as Set<
         () => void

--- a/tests/vanilla/effect.test.ts
+++ b/tests/vanilla/effect.test.ts
@@ -2,7 +2,7 @@ import { expect, it, vi } from 'vitest'
 import type { Atom, Getter, Setter, WritableAtom } from 'jotai/vanilla'
 import { atom, createStore } from 'jotai/vanilla'
 import {
-  INTERNAL_getStoreArgsRev1 as INTERNAL_getStoreArgs,
+  INTERNAL_getBuildingBlocksRev1 as INTERNAL_getBuildingBlocks,
   INTERNAL_initializeStoreHooks,
 } from 'jotai/vanilla/internals'
 
@@ -58,8 +58,8 @@ function syncEffect(effect: Effect): Atom<void> {
         deps.forEach(ref.get!)
       }
     }
-    const storeArgs = INTERNAL_getStoreArgs(store)
-    const storeHooks = INTERNAL_initializeStoreHooks(storeArgs[6])
+    const buildingBlocks = INTERNAL_getBuildingBlocks(store)
+    const storeHooks = INTERNAL_initializeStoreHooks(buildingBlocks[12])
     const syncEffectChannel = ensureSyncEffectChannel(store)
     storeHooks.m.add(internalAtom, () => {
       // mount
@@ -87,8 +87,8 @@ const syncEffectChannelSymbol = Symbol()
 function ensureSyncEffectChannel(store: any) {
   if (!store[syncEffectChannelSymbol]) {
     store[syncEffectChannelSymbol] = new Set<() => void>()
-    const storeArgs = INTERNAL_getStoreArgs(store)
-    const storeHooks = INTERNAL_initializeStoreHooks(storeArgs[6])
+    const buildingBlocks = INTERNAL_getBuildingBlocks(store)
+    const storeHooks = INTERNAL_initializeStoreHooks(buildingBlocks[12])
     storeHooks.f.add(() => {
       const syncEffectChannel = store[syncEffectChannelSymbol] as Set<
         () => void

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -5,26 +5,22 @@ import type { Atom, Getter, PrimitiveAtom } from 'jotai/vanilla'
 import {
   INTERNAL_buildStore,
   INTERNAL_createBuildingBlocksRev1 as INTERNAL_createBuildingBlocks,
-  INTERNAL_createStoreArgsRev1 as INTERNAL_createStoreArgs,
-  INTERNAL_getStoreArgsRev1 as INTERNAL_getStoreArgs,
+  INTERNAL_getBuildingBlocksRev1 as INTERNAL_getBuildingBlocks,
 } from 'jotai/vanilla/internals'
 
-type AtomStateMapType = ReturnType<typeof INTERNAL_getStoreArgs>[0]
+type AtomStateMapType = ReturnType<typeof INTERNAL_getBuildingBlocks>[6]
 
 const deriveStore = (
   store: ReturnType<typeof createStore>,
   enhanceAtomStateMap: (atomStateMap: AtomStateMapType) => AtomStateMapType,
 ): ReturnType<typeof createStore> => {
-  const storeArgs = INTERNAL_getStoreArgs(store)
-  const atomStateMap = storeArgs[0]
-  const newStoreArgs = INTERNAL_createStoreArgs(
+  const buildingBlocks = INTERNAL_getBuildingBlocks(store)
+  const atomStateMap = buildingBlocks[6]
+  const newBuildingBlocks = INTERNAL_createBuildingBlocks(
+    () => derivedStore,
     enhanceAtomStateMap(atomStateMap),
   )
-  const buildingBlocks = INTERNAL_createBuildingBlocks(
-    newStoreArgs,
-    () => derivedStore,
-  )
-  const derivedStore = INTERNAL_buildStore(newStoreArgs, buildingBlocks)
+  const derivedStore = INTERNAL_buildStore(newBuildingBlocks)
   return derivedStore
 }
 

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -4,7 +4,8 @@ import { atom, createStore } from 'jotai/vanilla'
 import type { Atom, Getter, PrimitiveAtom } from 'jotai/vanilla'
 import {
   INTERNAL_buildStore,
-  INTERNAL_createStoreArgs,
+  INTERNAL_createBuildingBlocksRev1 as INTERNAL_createBuildingBlocks,
+  INTERNAL_createStoreArgsRev1 as INTERNAL_createStoreArgs,
   INTERNAL_getStoreArgsRev1 as INTERNAL_getStoreArgs,
 } from 'jotai/vanilla/internals'
 
@@ -19,7 +20,11 @@ const deriveStore = (
   const newStoreArgs = INTERNAL_createStoreArgs(
     enhanceAtomStateMap(atomStateMap),
   )
-  const derivedStore = (INTERNAL_buildStore as any)(...newStoreArgs)
+  const buildingBlocks = INTERNAL_createBuildingBlocks(
+    newStoreArgs,
+    () => derivedStore,
+  )
+  const derivedStore = INTERNAL_buildStore(newStoreArgs, buildingBlocks)
   return derivedStore
 }
 

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -8,14 +8,14 @@ import {
   INTERNAL_getBuildingBlocksRev1 as INTERNAL_getBuildingBlocks,
 } from 'jotai/vanilla/internals'
 
-type AtomStateMapType = ReturnType<typeof INTERNAL_getBuildingBlocks>[6]
+type AtomStateMapType = ReturnType<typeof INTERNAL_getBuildingBlocks>[0][0]
 
 const deriveStore = (
   store: ReturnType<typeof createStore>,
   enhanceAtomStateMap: (atomStateMap: AtomStateMapType) => AtomStateMapType,
 ): ReturnType<typeof createStore> => {
   const buildingBlocks = INTERNAL_getBuildingBlocks(store)
-  const atomStateMap = buildingBlocks[6]
+  const atomStateMap = buildingBlocks[0][0]
   const newBuildingBlocks = INTERNAL_createBuildingBlocks(
     () => derivedStore,
     enhanceAtomStateMap(atomStateMap),


### PR DESCRIPTION
## Summary
Expose buildingBlocks by passing in to buildStore.

Background: We sometimes want to use a custom function in place of a building block when creating a new store. This PR is one approach that enables this functionality.

## Check List
- [x] `pnpm run fix:format` for formatting code and docs
