### PR TITLE
strict mount twice?

### DIFF
--- a/tests/vanilla/internals.test.tsx
+++ b/tests/vanilla/internals.test.tsx
@@ -1,9 +1,12 @@
-import { describe, expect, it } from 'vitest'
-import { createStore } from 'jotai'
+import { describe, expect, it, vi } from 'vitest'
+import { atom, createStore, useAtomValue } from 'jotai'
 import {
   INTERNAL_buildStoreRev1 as INTERNAL_buildStore,
   INTERNAL_getBuildingBlocksRev1 as INTERNAL_getBuildingBlocks,
+  INTERNAL_initializeStoreHooks,
 } from 'jotai/vanilla/internals'
+import { renderHook } from '@testing-library/react'
+import { StrictMode } from 'react'
 
 describe('internals', () => {
   it('should not return a sparse building blocks array', () => {
@@ -22,5 +25,28 @@ describe('internals', () => {
       expect(buildingBlocks.length).toBe(20)
       expect(isSparse(buildingBlocks)).toBe(false)
     }
+  })
+
+  it('should call onMount and onUnmount once in strict mode', () => {
+    const onMountHook = vi.fn()
+    const onUnmountHook = vi.fn()
+    const countAtom = atom(0)
+    const onUnmount = vi.fn()
+    const onMount = vi.fn(() => onUnmount)
+    countAtom.onMount = onMount
+    const store = createStore()
+    const buildingBlocks = INTERNAL_getBuildingBlocks(store)
+    const storeHooks = INTERNAL_initializeStoreHooks(buildingBlocks[6])
+    storeHooks.m.add(countAtom, onMountHook)
+    storeHooks.u.add(countAtom, onUnmountHook)
+    const useMountAtom = () => useAtomValue(countAtom, { store })
+    const { unmount } = renderHook(useMountAtom, { wrapper: StrictMode })
+    expect(onMount).toHaveBeenCalledTimes(1)
+    expect(onUnmount).toHaveBeenCalledTimes(0)
+    expect(onMountHook).toHaveBeenCalledTimes(1)
+    expect(onUnmountHook).toHaveBeenCalledTimes(0)
+    unmount()
+    expect(onUnmount).toHaveBeenCalledTimes(1)
+    expect(onUnmountHook).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
Should onMount, onUnmount, mount hooks, and unmount hooks fire once in StrictMode?

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
