### PR TITLE
chore: use default reporter in vitest and fix TS error

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -30,11 +30,12 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     dir: 'tests',
-    reporters: 'basic',
+    reporters: process.env.GITHUB_ACTIONS ? ['default', 'github-actions'] : ['default'],
     setupFiles: ['tests/setup.ts'],
     coverage: {
       reporter: ['text', 'json', 'html', 'text-summary'],
       reportsDirectory: './coverage/',
+      provider: 'v8',
       include: ['src/**'],
     },
     onConsoleLog(log) {


### PR DESCRIPTION
## Summary

Vitest 3 suggest to migrate from 'basic' reporter to 'default'

```
DEPRECATED  'basic' reporter is deprecated and will be removed in Vitest v3.
Remove 'basic' from 'reporters' option. To match 'basic' reporter 100%, use configuration:
{
  "test": {
    "reporters": [
      [
        "default",
        {
          "summary": false
        }
      ]
    ]
  }
}
```

Secondly, `provider` in `coverage` is required and produces TypeScript error when not defined explicitly.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
