### PR TITLE
docs(LICENSE): keep only the initial copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2023 Poimandres
+Copyright (c) 2020 Poimandres
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

* Regularly updating the copyright year can be unnecessary and tedious.
* Keeping only the initial year makes maintenance easier.
* The MIT license does not require a specific year format.
* Listing just the first publication year is legally sufficient.
* This helps avoid unnecessary updates and keeps the license file clean and simple.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
