### PR TITLE
refactor(vanilla, react): change exported functions to 'function declarations' and non-exported ones to 'arrow functions'

### DIFF
--- a/src/react/Provider.ts
+++ b/src/react/Provider.ts
@@ -13,14 +13,14 @@ type Options = {
   store?: Store
 }
 
-export const useStore = (options?: Options): Store => {
+export function useStore(options?: Options): Store {
   const store = useContext(StoreContext)
   return options?.store || store || getDefaultStore()
 }
 
 /* eslint-disable react-compiler/react-compiler */
 // TODO should we consider using useState instead of useRef?
-export const Provider = ({
+export function Provider({
   children,
   store,
 }: {
@@ -29,7 +29,7 @@ export const Provider = ({
 }): ReactElement<
   { value: Store | undefined },
   FunctionComponent<{ value: Store | undefined }>
-> => {
+> {
   const storeRef = useRef<Store>(undefined)
   if (!store && !storeRef.current) {
     storeRef.current = createStore()

--- a/src/vanilla/store.ts
+++ b/src/vanilla/store.ts
@@ -84,7 +84,7 @@ type PrdOrDevStore =
   | INTERNAL_PrdStore
   | (INTERNAL_PrdStore & INTERNAL_DevStoreRev4)
 
-export const createStore = (): PrdOrDevStore => {
+export function createStore(): PrdOrDevStore {
   if (import.meta.env?.MODE !== 'production') {
     return createDevStoreRev4()
   }
@@ -94,7 +94,7 @@ export const createStore = (): PrdOrDevStore => {
 
 let defaultStore: PrdOrDevStore | undefined
 
-export const getDefaultStore = (): PrdOrDevStore => {
+export function getDefaultStore(): PrdOrDevStore {
   if (!defaultStore) {
     defaultStore = createStore()
     if (import.meta.env?.MODE !== 'production') {

--- a/src/vanilla/utils/atomFamily.ts
+++ b/src/vanilla/utils/atomFamily.ts
@@ -64,11 +64,11 @@ export function atomFamily<Param, AtomType extends Atom<unknown>>(
     return newAtom
   }
 
-  function notifyListeners(
+  const notifyListeners = (
     type: 'CREATE' | 'REMOVE',
     param: Param,
     atom: AtomType,
-  ) {
+  ) => {
     for (const listener of listeners) {
       listener({ type, param, atom })
     }


### PR DESCRIPTION
## Summary
* https://github.com/pmndrs/jotai/pull/3002#pullrequestreview-2640696617
  * for exported functions, use function declaration
  * for other functions, use const arrow function (and omit return statements if possible.)

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
