### PR TITLE
refactor(unmountAtom): use atomStateMap.get instead of ensureAtomState

### DIFF
--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -838,7 +838,11 @@ const buildStore = (
   const unmountAtom =
     buildingBlockFunctions[8] ||
     ((atom) => {
-      const atomState = ensureAtomState(atom)
+      const atomState = atomStateMap.get(atom)
+      if (!atomState) {
+        return
+      }
+
       let mounted = mountedMap.get(atom)
       if (
         mounted &&


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

When unmounting an atom, we don't need to create atom state since we only care about already mounted atoms.
but ensureAtomState make new atom whenever there isn't atom.
I thought this process is kinda unnecessary

- Prevents unnecessary atom state creation
- Makes the unmounting logic clearer
- Returns early if atom state doesn't exist

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
