### PR TITLE
Docs: Remove 'published' metadata

### DIFF
--- a/docs/extensions/redux.mdx
+++ b/docs/extensions/redux.mdx
@@ -3,7 +3,6 @@ title: Redux
 description: This doc describes Redux extension.
 nav: 4.98
 keywords: redux
-published: false
 ---
 
 Jotai's state resides in React, but sometimes it would be nice

--- a/docs/extensions/relay.mdx
+++ b/docs/extensions/relay.mdx
@@ -3,7 +3,6 @@ title: Relay
 description: This doc describes Relay extension.
 nav: 4.98
 keywords: relay
-published: false
 ---
 
 You can use Jotai with [Relay](https://relay.dev).

--- a/docs/extensions/valtio.mdx
+++ b/docs/extensions/valtio.mdx
@@ -3,7 +3,6 @@ title: Valtio
 description: This doc describes Valtio extension.
 nav: 4.98
 keywords: valtio,proxy
-published: false
 ---
 
 Jotai's state resides in React, but sometimes it would be nice

--- a/docs/extensions/zustand.mdx
+++ b/docs/extensions/zustand.mdx
@@ -3,7 +3,6 @@ title: Zustand
 description: This doc describes Zustand extension.
 nav: 4.98
 keywords: zustand
-published: false
 ---
 
 Jotai's state resides in React, but sometimes it would be nice

--- a/docs/guides/async.mdx
+++ b/docs/guides/async.mdx
@@ -3,7 +3,6 @@ title: Async
 description: This doc describes about the behavior with async.
 nav: 8.99
 keywords: async
-published: false
 ---
 
 Using async atoms, you gain access to real-world data while still managing them directly from your atoms and with incredible ease.

--- a/docs/guides/resettable.mdx
+++ b/docs/guides/resettable.mdx
@@ -2,7 +2,6 @@
 title: Resettable
 description: How to use resettable atoms
 nav: 8.99
-published: false
 ---
 
 The Jotai core doesn't support resettable atoms.

--- a/docs/guides/using-store-outside-react.mdx
+++ b/docs/guides/using-store-outside-react.mdx
@@ -3,7 +3,6 @@ title: Using store outside React
 description: Using store outside React
 nav: 8.98
 keywords: state, outside, react
-published: false
 ---
 
 Jotai's state resides in React, but sometimes it would be nice

--- a/docs/guides/vite.mdx
+++ b/docs/guides/vite.mdx
@@ -3,7 +3,6 @@ title: Vite
 description: How to use Jotai with Vite
 nav: 8.99
 keywords: vite
-published: false
 ---
 
 You can use the plugins from the `jotai/babel` bundle to enhance your developer experience when using Vite and Jotai.

--- a/docs/utilities/callback.mdx
+++ b/docs/utilities/callback.mdx
@@ -2,7 +2,6 @@
 title: Callback
 nav: 3.99
 keywords: callback
-published: false
 ---
 
 ## useAtomCallback

--- a/docs/utilities/reducer.mdx
+++ b/docs/utilities/reducer.mdx
@@ -2,7 +2,6 @@
 title: Reducer
 nav: 3.99
 keywords: reducer,action,dispatch
-published: false
 ---
 
 ## atomWithReducer

--- a/docs/utilities/select.mdx
+++ b/docs/utilities/select.mdx
@@ -2,7 +2,6 @@
 title: Select
 nav: 3.99
 keywords: select
-published: false
 ---
 
 ## selectAtom

--- a/docs/utilities/split.mdx
+++ b/docs/utilities/split.mdx
@@ -2,7 +2,6 @@
 title: Split
 nav: 3.99
 keywords: select
-published: false
 ---
 
 ## splitAtom

--- a/website/src/components/docs.js
+++ b/website/src/components/docs.js
@@ -78,7 +78,6 @@ const staticQuery = graphql`
         meta: frontmatter {
           title
           nav
-          published
         }
       }
     }

--- a/website/src/components/toc.js
+++ b/website/src/components/toc.js
@@ -39,7 +39,6 @@ const staticQuery = graphql`
         meta: frontmatter {
           title
           nav
-          published
         }
       }
     }
@@ -73,12 +72,7 @@ const parseDocs = (docs, section) => {
       ...newDocs,
       {
         title: directory,
-        contents: [
-          ...docs.filter(
-            (doc) =>
-              doc.slug.startsWith(directory) && doc.meta.published !== false,
-          ),
-        ],
+        contents: [...docs.filter((doc) => doc.slug.startsWith(directory))],
       },
     ]
   })


### PR DESCRIPTION
## Summary
Missing documents were discovered in each section of https://jotai.org/docs

### Detail
![image](https://github.com/user-attachments/assets/274bfeba-744b-45c2-8ca1-0401ddcd2035)
In the Extensions section, documents for valtio, zustand, relay, and redux are not visible.
However, access to the detailed pages is possible.

The missing documents commonly had a ```'published: false'``` metadata, and once this was removed, the missing documents began to be exposed.

It was confirmed that the role of 'published' was solely to indicate document visibility, so related code was also removed.

If this is an intended behavior, please close these Pull Requests. 🙏


## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
