### PR TITLE
fix: examples/mega-form remove itemAtom;

### DIFF
--- a/examples/mega-form/src/useAtomSlice.ts
+++ b/examples/mega-form/src/useAtomSlice.ts
@@ -6,7 +6,11 @@ import { splitAtom } from 'jotai/utils'
 const useAtomSlice = <Item>(arrAtom: PrimitiveAtom<Item[]>) => {
   const [atoms, remove] = useAtom(useMemo(() => splitAtom(arrAtom), [arrAtom]))
   return useMemo(
-    () => atoms.map((itemAtom) => [itemAtom, () => remove(itemAtom)] as const),
+    () =>
+      atoms.map(
+        (itemAtom) =>
+          [itemAtom, () => remove({ type: 'remove', atom: itemAtom })] as const,
+      ),
     [atoms, remove],
   )
 }

--- a/examples/mega-form/src/useAtomSlice.ts
+++ b/examples/mega-form/src/useAtomSlice.ts
@@ -4,14 +4,19 @@ import type { PrimitiveAtom } from 'jotai'
 import { splitAtom } from 'jotai/utils'
 
 const useAtomSlice = <Item>(arrAtom: PrimitiveAtom<Item[]>) => {
-  const [atoms, remove] = useAtom(useMemo(() => splitAtom(arrAtom), [arrAtom]))
+  const [atoms, dispatch] = useAtom(
+    useMemo(() => splitAtom(arrAtom), [arrAtom]),
+  )
   return useMemo(
     () =>
       atoms.map(
         (itemAtom) =>
-          [itemAtom, () => remove({ type: 'remove', atom: itemAtom })] as const,
+          [
+            itemAtom,
+            () => dispatch({ type: 'remove', atom: itemAtom }),
+          ] as const,
       ),
-    [atoms, remove],
+    [atoms, dispatch],
   )
 }
 


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

* examples/mega-form remove itemAtom.

I really love Jotai's coding style, but there's a small issue in examples/mega-form that caused me some trouble when getting started with Jotai. I've fixed it.

## Check List

- [X] `pnpm run fix` for formatting and linting code and docs
