### PR TITLE
Fix deepFreeze fails for boolean, number, string

### DIFF
--- a/src/vanilla/utils/freezeAtom.ts
+++ b/src/vanilla/utils/freezeAtom.ts
@@ -2,15 +2,17 @@ import type { Atom, WritableAtom } from '../../vanilla.ts'
 
 const frozenAtoms = new WeakSet<Atom<any>>()
 
-const deepFreeze = (obj: unknown) => {
-  if (typeof obj !== 'object' || obj === null) return
-  Object.freeze(obj)
-  const propNames = Object.getOwnPropertyNames(obj)
+const deepFreeze = (value: unknown) => {
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+  Object.freeze(value)
+  const propNames = Object.getOwnPropertyNames(value)
   for (const name of propNames) {
-    const value = (obj as never)[name]
+    const value = (value as never)[name]
     deepFreeze(value)
   }
-  return obj
+  return value
 }
 
 export function freezeAtom<AtomType extends Atom<unknown>>(


### PR DESCRIPTION
## Related Bug Reports or Discussions

Pull request to implement this fix from @Daishi: https://discord.com/channels/740090768164651008/752920140483526677/1347718875403391017

## Summary

if you do `freezeAtom(atom(false))` then check the value of the atom, it will be undefined not false. This update allows freeze to work with a non-object (i.e., boolean, number, or string)

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs