### PR TITLE
fix(react): experimental option to make attaching promise status controllable

### DIFF
--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -171,9 +171,6 @@ export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
   // `instanceof Promise` actually works fine in this case.
   if (isPromiseLike(value)) {
     const promise = createContinuablePromise(value, () => store.get(atom))
-    if (promiseStatus) {
-      attachPromiseStatus(promise)
-    }
     return use(promise)
   }
   return value as Awaited<Value>

--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -114,7 +114,8 @@ export function useAtomValue<AtomType extends Atom<unknown>>(
 ): Awaited<ExtractAtomValue<AtomType>>
 
 export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
-  const { delay, unstable_promiseStatus: promiseStatus } = options || {}
+  const { delay, unstable_promiseStatus: promiseStatus = !React.use } =
+    options || {}
   const store = useStore(options)
 
   const [[valueFromReducer, storeFromReducer, atomFromReducer], rerender] =

--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -144,9 +144,7 @@ export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
         if (!ReactExports.use) {
           const value = store.get(atom)
           if (isPromiseLike(value)) {
-            attachPromiseMeta(
-              createContinuablePromise(value, () => store.get(atom)),
-            )
+            createContinuablePromise(value, () => store.get(atom))
           }
         }
         // delay rerendering to wait a promise possibly to resolve

--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -1,6 +1,6 @@
 /// <reference types="react/experimental" />
 
-import ReactExports, { useDebugValue, useEffect, useReducer } from 'react'
+import React, { useDebugValue, useEffect, useReducer } from 'react'
 import { INTERNAL_registerAbortHandler as registerAbortHandler } from '../vanilla/internals.ts'
 import type { Atom, ExtractAtomValue } from '../vanilla.ts'
 import { useStore } from './Provider.ts'
@@ -31,7 +31,8 @@ const attachPromiseMeta = <T>(
 }
 
 const use =
-  ReactExports.use ||
+  React.use ||
+  // A shim for older React versions
   (<T>(
     promise: PromiseLike<T> & {
       status?: 'pending' | 'fulfilled' | 'rejected'
@@ -141,7 +142,8 @@ export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
   useEffect(() => {
     const unsub = store.sub(atom, () => {
       if (typeof delay === 'number') {
-        if (!ReactExports.use) {
+        if (!React.use) {
+          // A hack for older React versions
           const value = store.get(atom)
           if (isPromiseLike(value)) {
             attachPromiseMeta(

--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -144,7 +144,9 @@ export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
         if (!ReactExports.use) {
           const value = store.get(atom)
           if (isPromiseLike(value)) {
-            createContinuablePromise(value, () => store.get(atom))
+            attachPromiseMeta(
+              createContinuablePromise(value, () => store.get(atom)),
+            )
           }
         }
         // delay rerendering to wait a promise possibly to resolve

--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -141,6 +141,14 @@ export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
   useEffect(() => {
     const unsub = store.sub(atom, () => {
       if (typeof delay === 'number') {
+        if (!ReactExports.use) {
+          const value = store.get(atom)
+          if (isPromiseLike(value)) {
+            attachPromiseMeta(
+              createContinuablePromise(value, () => store.get(atom)),
+            )
+          }
+        }
         // delay rerendering to wait a promise possibly to resolve
         setTimeout(rerender, delay)
         return

--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -141,12 +141,6 @@ export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
   useEffect(() => {
     const unsub = store.sub(atom, () => {
       if (typeof delay === 'number') {
-        const value = store.get(atom)
-        if (isPromiseLike(value)) {
-          attachPromiseMeta(
-            createContinuablePromise(value, () => store.get(atom)),
-          )
-        }
         // delay rerendering to wait a promise possibly to resolve
         setTimeout(rerender, delay)
         return

--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -17,17 +17,19 @@ const attachPromiseStatus = <T>(
     reason?: unknown
   },
 ) => {
-  promise.status = 'pending'
-  promise.then(
-    (v) => {
-      promise.status = 'fulfilled'
-      promise.value = v
-    },
-    (e) => {
-      promise.status = 'rejected'
-      promise.reason = e
-    },
-  )
+  if (!promise.status) {
+    promise.status = 'pending'
+    promise.then(
+      (v) => {
+        promise.status = 'fulfilled'
+        promise.value = v
+      },
+      (e) => {
+        promise.status = 'rejected'
+        promise.reason = e
+      },
+    )
+  }
 }
 
 const use =

--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -171,6 +171,9 @@ export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
   // `instanceof Promise` actually works fine in this case.
   if (isPromiseLike(value)) {
     const promise = createContinuablePromise(value, () => store.get(atom))
+    if (promiseStatus) {
+      attachPromiseStatus(promise)
+    }
     return use(promise)
   }
   return value as Awaited<Value>

--- a/tests/react/async2.test.tsx
+++ b/tests/react/async2.test.tsx
@@ -1,4 +1,4 @@
-import { StrictMode, Suspense } from 'react'
+import { StrictMode, Suspense, version as reactVersion } from 'react'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEventOrig from '@testing-library/user-event'
 import { assert, describe, expect, it } from 'vitest'
@@ -8,6 +8,8 @@ import { atom } from 'jotai/vanilla'
 const userEvent = {
   click: (element: Element) => act(() => userEventOrig.click(element)),
 }
+
+const IS_REACT19 = /^19\./.test(reactVersion)
 
 describe('useAtom delay option test', () => {
   // FIXME fireEvent.click doesn't work with the patched RTL and React 19-rc.1
@@ -63,7 +65,10 @@ describe('useAtom delay option test', () => {
     })
 
     const Component = () => {
-      const count = useAtomValue(asyncAtom, { delay: 0 })
+      const count = useAtomValue(asyncAtom, {
+        delay: 0,
+        unstable_promiseStatus: !IS_REACT19,
+      })
       return <div>count: {count}</div>
     }
 

--- a/tests/react/async2.test.tsx
+++ b/tests/react/async2.test.tsx
@@ -63,7 +63,7 @@ describe('useAtom delay option test', () => {
     })
 
     const Component = () => {
-      const count = useAtomValue(asyncAtom, { delay: 100 })
+      const count = useAtomValue(asyncAtom, { delay: 0 })
       return <div>count: {count}</div>
     }
 

--- a/tests/react/async2.test.tsx
+++ b/tests/react/async2.test.tsx
@@ -63,7 +63,7 @@ describe('useAtom delay option test', () => {
     })
 
     const Component = () => {
-      const count = useAtomValue(asyncAtom, { delay: 0 })
+      const count = useAtomValue(asyncAtom, { delay: 100 })
       return <div>count: {count}</div>
     }
 

--- a/tests/react/async2.test.tsx
+++ b/tests/react/async2.test.tsx
@@ -1,4 +1,4 @@
-import { StrictMode, Suspense, version as reactVersion } from 'react'
+import { StrictMode, Suspense } from 'react'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEventOrig from '@testing-library/user-event'
 import { assert, describe, expect, it } from 'vitest'
@@ -8,8 +8,6 @@ import { atom } from 'jotai/vanilla'
 const userEvent = {
   click: (element: Element) => act(() => userEventOrig.click(element)),
 }
-
-const IS_REACT19 = /^19\./.test(reactVersion)
 
 describe('useAtom delay option test', () => {
   // FIXME fireEvent.click doesn't work with the patched RTL and React 19-rc.1
@@ -65,10 +63,7 @@ describe('useAtom delay option test', () => {
     })
 
     const Component = () => {
-      const count = useAtomValue(asyncAtom, {
-        delay: 0,
-        unstable_promiseStatus: !IS_REACT19,
-      })
+      const count = useAtomValue(asyncAtom, { delay: 0 })
       return <div>count: {count}</div>
     }
 


### PR DESCRIPTION
And rename to `React`.