### PR TITLE
docs: fix atom-with-listeners usage example

### DIFF
--- a/docs/recipes/atom-with-listeners.mdx
+++ b/docs/recipes/atom-with-listeners.mdx
@@ -15,7 +15,7 @@ those state changes.
 
 ```ts
 import { useEffect } from 'react'
-import { atom, useSetAtom, Getter, Setter, SetStateAction } from 'jotai'
+import { atom, useAtom, useSetAtom, Getter, Setter, SetStateAction } from 'jotai'
 
 type Callback<Value> = (
   get: Getter,
@@ -59,7 +59,7 @@ In a component:
 const [countAtom, useCountListener] = atomWithListeners(0)
 
 function EvenCounter() {
-  const [evenCount, setEvenCount] = useState(0)
+  const [evenCount, setEvenCount] = useAtom(countAtom)
 
   useCountListener(
     useCallback(

--- a/docs/recipes/atom-with-listeners.mdx
+++ b/docs/recipes/atom-with-listeners.mdx
@@ -15,7 +15,14 @@ those state changes.
 
 ```ts
 import { useEffect } from 'react'
-import { atom, useAtom, useSetAtom, Getter, Setter, SetStateAction } from 'jotai'
+import {
+  atom,
+  useAtom,
+  useSetAtom,
+  Getter,
+  Setter,
+  SetStateAction,
+} from 'jotai'
 
 type Callback<Value> = (
   get: Getter,


### PR DESCRIPTION
I might be completely off but on first glance I think it should be `useAtom(countAtom)` instead of `useState(0)`, shouldn't it? 🤔