### PR TITLE
fix(utils): allow undefined for atomWithStorage subscriber return

### DIFF
--- a/src/vanilla/utils/atomWithStorage.ts
+++ b/src/vanilla/utils/atomWithStorage.ts
@@ -11,12 +11,12 @@ type Subscribe<Value> = (
   key: string,
   callback: (value: Value) => void,
   initialValue: Value,
-) => Unsubscribe
+) => Unsubscribe | undefined
 
 type StringSubscribe = (
   key: string,
   callback: (value: string | null) => void,
-) => Unsubscribe
+) => Unsubscribe | undefined
 
 type SetStateActionWithReset<Value> =
   | Value


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #3054 

## Summary

This changes the return type of the `subscribe` function to allow undefined. Alternatively, the type of `Unsubscribe` could be changed to `() => void | undefined`, which may be preferable. This doesn't change the functionality of Jotai, and is a type-only issue, so no tests needed to be added or changed, and this simply encompasses the intended existing functionality.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
