### PR TITLE
only throw AggregateError if more than one error was thrown in flushPending

### DIFF
--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -473,7 +473,7 @@ const buildStore = (
         mountCallbacks.size
       )
       if (errors.length) {
-        throw new AggregateError(errors)
+        throw errors.length === 1 ? errors[0] : new AggregateError(errors)
       }
     })
 


### PR DESCRIPTION
## Summary
Changes the error handling behavior of flushPending. Only throw AggregateError if more than one error was thrown during flushPending. 

- No errors: proceed as normal
- A single error: rethrow the error thrown
- Multiple errors: throw `AggregateError`

## Check List

- [X] `pnpm run fix` for formatting and linting code and docs
