### PR TITLE
fix(tests): fix type testing for useHydrateAtoms for old typescript versions

### DIFF
--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -62,8 +62,8 @@ jobs:
         run: |
           ts_ver_esc=${{ matrix.typescript }}
           ts_ver_esc=${ts_ver_esc//./\\.}
-          sed -i~ "s/\/\/ @ts-expect-error.*\[SKIP-TS-${ts_ver_esc}\].*//" tests/*/*.tsx tests/*/*/*.tsx
-          sed -i~ "s/\/\/ \[ONLY-TS-${ts_ver_esc}\] @ts-ignore.*/\/\/ @ts-ignore/" tests/*/*.tsx tests/*/*/*.tsx
+          sed -i~ "s/\/\/ @ts-expect-error .*\[SKIP-TS-${ts_ver_esc}\].*//" tests/*/*.tsx tests/*/*/*.tsx
+          sed -i~ "s/\/\/ .*\[ONLY-TS-${ts_ver_esc}\].* @ts-ignore/\/\/ @ts-ignore/" tests/*/*.tsx tests/*/*/*.tsx
           cat tests/react/utils/types.test.tsx
       - name: Patch for Old TS
         if: ${{ matrix.typescript == '4.7.4' || matrix.typescript == '4.6.4' || matrix.typescript == '4.5.5' || matrix.typescript == '4.4.4' || matrix.typescript == '4.3.5' || matrix.typescript == '4.2.3' || matrix.typescript == '4.1.5' ||  matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -64,7 +64,6 @@ jobs:
           ts_ver_esc=${ts_ver_esc//./\\.}
           sed -i~ "s/\/\/ @ts-expect-error .*\[SKIP-TS-${ts_ver_esc}\].*//" tests/*/*.tsx tests/*/*/*.tsx
           sed -i~ "s/\/\/ .*\[ONLY-TS-${ts_ver_esc}\].* @ts-ignore/\/\/ @ts-ignore/" tests/*/*.tsx tests/*/*/*.tsx
-          cat tests/react/utils/types.test.tsx
       - name: Patch for Old TS
         if: ${{ matrix.typescript == '4.7.4' || matrix.typescript == '4.6.4' || matrix.typescript == '4.5.5' || matrix.typescript == '4.4.4' || matrix.typescript == '4.3.5' || matrix.typescript == '4.2.3' || matrix.typescript == '4.1.5' ||  matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -62,9 +62,7 @@ jobs:
         run: |
           ts_ver_esc=${{ matrix.typescript }}
           ts_ver_esc=${ts_ver_esc//./\\.}
-          echo "s/\/\/ @ts-expect-error.*\[SKIP-TS-${ts_ver_esc}\]//"
-          sed -i~ "s/\/\/ @ts-expect-error.*\[SKIP-TS-${ts_ver_esc}\]//" tests/*/*.tsx tests/*/*/*.tsx
-          cat tests/react/utils/types.test.tsx
+          sed -i~ "s/\/\/ @ts-expect-error.*\[SKIP-TS-${ts_ver_esc}\].*//" tests/*/*.tsx tests/*/*/*.tsx
       - name: Patch for Old TS
         if: ${{ matrix.typescript == '4.7.4' || matrix.typescript == '4.6.4' || matrix.typescript == '4.5.5' || matrix.typescript == '4.4.4' || matrix.typescript == '4.3.5' || matrix.typescript == '4.2.3' || matrix.typescript == '4.1.5' ||  matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -63,7 +63,6 @@ jobs:
           ts_ver_esc=${{ matrix.typescript }}
           ts_ver_esc=${ts_ver_esc//./\\.}
           sed -i~ "s/\/\/ @ts-expect-error.*\[SKIP-TS-${ts_ver_esc}\].*//" tests/*/*.tsx tests/*/*/*.tsx
-          sed -i~ "s/\/\/ \[ONLY-TS-${ts_ver_esc}\] @ts-ignore.*//" tests/*/*.tsx tests/*/*/*.tsx
           cat tests/react/utils/types.test.tsx
       - name: Patch for Old TS
         if: ${{ matrix.typescript == '4.7.4' || matrix.typescript == '4.6.4' || matrix.typescript == '4.5.5' || matrix.typescript == '4.4.4' || matrix.typescript == '4.3.5' || matrix.typescript == '4.2.3' || matrix.typescript == '4.1.5' ||  matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -63,6 +63,7 @@ jobs:
           ts_ver_esc=${{ matrix.typescript }}
           ts_ver_esc=${ts_ver_esc//./\\.}
           sed -i~ "s/\/\/ @ts-expect-error.*\[SKIP-TS-${ts_ver_esc}\].*//" tests/*/*.tsx tests/*/*/*.tsx
+          sed -i~ "s/\/\/ \[ONLY-TS-${ts_ver_esc}\] @ts-ignore.*//" tests/*/*.tsx tests/*/*/*.tsx
           cat tests/react/utils/types.test.tsx
       - name: Patch for Old TS
         if: ${{ matrix.typescript == '4.7.4' || matrix.typescript == '4.6.4' || matrix.typescript == '4.5.5' || matrix.typescript == '4.4.4' || matrix.typescript == '4.3.5' || matrix.typescript == '4.2.3' || matrix.typescript == '4.1.5' ||  matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -63,6 +63,7 @@ jobs:
           ts_ver_esc=${{ matrix.typescript }}
           ts_ver_esc=${ts_ver_esc//./\\.}
           sed -i~ "s/\/\/ @ts-expect-error.*\[SKIP-TS-${ts_ver_esc}\].*//" tests/*/*.tsx tests/*/*/*.tsx
+          sed -i~ "s/\/\/ \[ONLY-TS-${ts_ver_esc}\] @ts-ignore.*/\/\/ @ts-ignore/" tests/*/*.tsx tests/*/*/*.tsx
           cat tests/react/utils/types.test.tsx
       - name: Patch for Old TS
         if: ${{ matrix.typescript == '4.7.4' || matrix.typescript == '4.6.4' || matrix.typescript == '4.5.5' || matrix.typescript == '4.4.4' || matrix.typescript == '4.3.5' || matrix.typescript == '4.2.3' || matrix.typescript == '4.1.5' ||  matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -58,6 +58,11 @@ jobs:
           sed -i~ 's/"jotai": \["\.\/src\/index\.ts"\],/"jotai": [".\/dist\/index.d.ts"],/' tsconfig.json
           sed -i~ 's/"jotai\/\*": \["\.\/src\/\*\.ts"\]/"jotai\/*": [".\/dist\/*.d.ts"]/' tsconfig.json
           sed -i~ 's/"include": .*/"include": ["src\/types.d.ts", "dist\/**\/*", "tests\/**\/*"],/' tsconfig.json
+      - name: Patch for specific TS version
+        run: |
+          ts_ver_esc=${{ matrix.typescript }}
+          ts_ver_esc=${ts_ver_esc//./\\.}
+          sed -i~ 's/\/\/ @ts-expect-error.*\[SKIP-TS-'${ts_ver_esc}'\]//' tests/*/*.tsx tests/*/*/*.tsx
       - name: Patch for Old TS
         if: ${{ matrix.typescript == '4.7.4' || matrix.typescript == '4.6.4' || matrix.typescript == '4.5.5' || matrix.typescript == '4.4.4' || matrix.typescript == '4.3.5' || matrix.typescript == '4.2.3' || matrix.typescript == '4.1.5' ||  matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -63,6 +63,7 @@ jobs:
           ts_ver_esc=${{ matrix.typescript }}
           ts_ver_esc=${ts_ver_esc//./\\.}
           sed -i~ "s/\/\/ @ts-expect-error.*\[SKIP-TS-${ts_ver_esc}\].*//" tests/*/*.tsx tests/*/*/*.tsx
+          cat tests/react/utils/types.test.tsx
       - name: Patch for Old TS
         if: ${{ matrix.typescript == '4.7.4' || matrix.typescript == '4.6.4' || matrix.typescript == '4.5.5' || matrix.typescript == '4.4.4' || matrix.typescript == '4.3.5' || matrix.typescript == '4.2.3' || matrix.typescript == '4.1.5' ||  matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -62,11 +62,10 @@ jobs:
         run: |
           ts_ver_esc=${{ matrix.typescript }}
           ts_ver_esc=${ts_ver_esc//./\\.}
-          sed -i~ 's/\/\/ @ts-expect-error.*\[SKIP-TS-'${ts_ver_esc}'\]//' tests/*/*.tsx tests/*/*/*.tsx
+          sed -i~ "s/\/\/ @ts-expect-error.*\[SKIP-TS-${ts_ver_esc}\]//" tests/*/*.tsx tests/*/*/*.tsx
       - name: Patch for Old TS
         if: ${{ matrix.typescript == '4.7.4' || matrix.typescript == '4.6.4' || matrix.typescript == '4.5.5' || matrix.typescript == '4.4.4' || matrix.typescript == '4.3.5' || matrix.typescript == '4.2.3' || matrix.typescript == '4.1.5' ||  matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}
         run: |
-          sed -i~ 's/\/\/ @ts-expect-error.*\[LATEST-TS-ONLY\]//' tests/*/*.tsx tests/*/*/*.tsx
           sed -i~ 's/"target":/"skipLibCheck":true,"target":/' tsconfig.json
           sed -i~ 's/"exactOptionalPropertyTypes": true,//' tsconfig.json
           sed -i~ 's/"moduleResolution": "bundler",/"moduleResolution": "node",/' tsconfig.json

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -62,7 +62,9 @@ jobs:
         run: |
           ts_ver_esc=${{ matrix.typescript }}
           ts_ver_esc=${ts_ver_esc//./\\.}
+          echo "s/\/\/ @ts-expect-error.*\[SKIP-TS-${ts_ver_esc}\]//"
           sed -i~ "s/\/\/ @ts-expect-error.*\[SKIP-TS-${ts_ver_esc}\]//" tests/*/*.tsx tests/*/*/*.tsx
+          cat tests/react/utils/types.test.tsx
       - name: Patch for Old TS
         if: ${{ matrix.typescript == '4.7.4' || matrix.typescript == '4.6.4' || matrix.typescript == '4.5.5' || matrix.typescript == '4.4.4' || matrix.typescript == '4.3.5' || matrix.typescript == '4.2.3' || matrix.typescript == '4.1.5' ||  matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}
         run: |

--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -7,21 +7,10 @@ type Options = Parameters<typeof useStore>[0] & {
 }
 type AnyWritableAtom = WritableAtom<unknown, never[], unknown>
 
-type SpreadArgs<Args extends readonly unknown[]> = Args extends readonly [
-  infer First,
-  ...infer Rest,
-]
-  ? readonly [First, ...Rest]
-  : Args extends readonly [infer Single]
-    ? readonly [Single]
-    : readonly []
-
 type InferAtomTuples<T> = {
-  [K in keyof T]: T[K] extends readonly [infer A, ...infer _Rest]
+  [K in keyof T]: T[K] extends readonly [infer A, unknown]
     ? A extends WritableAtom<unknown, infer Args, infer _Result>
-      ? Args extends readonly unknown[]
-        ? readonly [A, ...SpreadArgs<Args>]
-        : readonly [A]
+      ? readonly [A, ...Args]
       : T[K]
     : never
 }
@@ -33,7 +22,7 @@ export type INTERNAL_InferAtomTuples<T> = InferAtomTuples<T>
 const hydratedMap: WeakMap<Store, WeakSet<AnyWritableAtom>> = new WeakMap()
 
 export function useHydrateAtoms<
-  T extends (readonly [AnyWritableAtom, ...any[]])[],
+  T extends (readonly [AnyWritableAtom, ...unknown[]])[],
 >(values: InferAtomTuples<T>, options?: Options): void
 
 export function useHydrateAtoms<T extends Map<AnyWritableAtom, unknown>>(
@@ -42,11 +31,11 @@ export function useHydrateAtoms<T extends Map<AnyWritableAtom, unknown>>(
 ): void
 
 export function useHydrateAtoms<
-  T extends Iterable<readonly [AnyWritableAtom, ...any[]]>,
+  T extends Iterable<readonly [AnyWritableAtom, ...unknown[]]>,
 >(values: InferAtomTuples<T>, options?: Options): void
 
 export function useHydrateAtoms<
-  T extends Iterable<readonly [AnyWritableAtom, ...any[]]>,
+  T extends Iterable<readonly [AnyWritableAtom, ...unknown[]]>,
 >(values: T, options?: Options) {
   const store = useStore(options)
 

--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -10,7 +10,7 @@ type AnyWritableAtom = WritableAtom<unknown, never[], unknown>
 type InferAtomTuples<T> = {
   [K in keyof T]: T[K] extends readonly [infer A, unknown]
     ? A extends WritableAtom<unknown, infer Args, infer _Result>
-      ? readonly [A, ...Args]
+      ? readonly [A, Args[0]]
       : T[K]
     : never
 }
@@ -22,7 +22,7 @@ export type INTERNAL_InferAtomTuples<T> = InferAtomTuples<T>
 const hydratedMap: WeakMap<Store, WeakSet<AnyWritableAtom>> = new WeakMap()
 
 export function useHydrateAtoms<
-  T extends (readonly [AnyWritableAtom, ...unknown[]])[],
+  T extends (readonly [AnyWritableAtom, unknown])[],
 >(values: InferAtomTuples<T>, options?: Options): void
 
 export function useHydrateAtoms<T extends Map<AnyWritableAtom, unknown>>(
@@ -31,19 +31,19 @@ export function useHydrateAtoms<T extends Map<AnyWritableAtom, unknown>>(
 ): void
 
 export function useHydrateAtoms<
-  T extends Iterable<readonly [AnyWritableAtom, ...unknown[]]>,
+  T extends Iterable<readonly [AnyWritableAtom, unknown]>,
 >(values: InferAtomTuples<T>, options?: Options): void
 
 export function useHydrateAtoms<
-  T extends Iterable<readonly [AnyWritableAtom, ...unknown[]]>,
+  T extends Iterable<readonly [AnyWritableAtom, unknown]>,
 >(values: T, options?: Options) {
   const store = useStore(options)
 
   const hydratedSet = getHydratedSet(store)
-  for (const [atom, ...args] of values) {
+  for (const [atom, value] of values) {
     if (!hydratedSet.has(atom) || options?.dangerouslyForceHydrate) {
       hydratedSet.add(atom)
-      store.set(atom, ...(args as never[]))
+      store.set(atom, value as never)
     }
   }
 }

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -6,23 +6,21 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
   function Component() {
     const countAtom = atom(0)
     const activeAtom = atom(true)
+    // [ONLY-TS-3.9.7] [ONLY-TS-3.8.3] @ts-ignore
     // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
     useHydrateAtoms([
-      // [ONLY-TS-3.9.7] [ONLY-TS-3.8.3] @ts-ignore
       [countAtom, 'foo'],
       [activeAtom, 0],
     ])
-    // [ONLY-TS-5.0.4] [ONLY-TS-4.9.5] [ONLY-TS-4.8.4] [ONLY-TS-4.7.4] [ONLY-TS-4.6.4] [ONLY-TS-4.5.5] [ONLY-TS-4.4.4] [ONLY-TS-4.3.5] [ONLY-TS-4.2.3] [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] @ts-ignore
+    // [ONLY-TS-5.0.4] [ONLY-TS-4.9.5] [ONLY-TS-4.8.4] [ONLY-TS-4.7.4] [ONLY-TS-4.6.4] [ONLY-TS-4.5.5] [ONLY-TS-4.4.4] [ONLY-TS-4.3.5] [ONLY-TS-4.2.3] [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] [ONLY-TS-3.9.7] [ONLY-TS-3.8.3] @ts-ignore
     // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.9.5] [SKIP-TS-4.8.4] [SKIP-TS-4.7.4] [SKIP-TS-4.6.4] [SKIP-TS-4.5.5] [SKIP-TS-4.4.4] [SKIP-TS-4.3.5] [SKIP-TS-4.2.3] [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
-      // [ONLY-TS-3.9.7] [ONLY-TS-3.8.3] @ts-ignore
       [countAtom, 1],
       [activeAtom, 0],
     ])
-    // [ONLY-TS-5.0.4] [ONLY-TS-4.9.5] [ONLY-TS-4.8.4] [ONLY-TS-4.7.4] [ONLY-TS-4.6.4] [ONLY-TS-4.5.5] [ONLY-TS-4.4.4] [ONLY-TS-4.3.5] [ONLY-TS-4.2.3] [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] @ts-ignore
+    // [ONLY-TS-5.0.4] [ONLY-TS-4.9.5] [ONLY-TS-4.8.4] [ONLY-TS-4.7.4] [ONLY-TS-4.6.4] [ONLY-TS-4.5.5] [ONLY-TS-4.4.4] [ONLY-TS-4.3.5] [ONLY-TS-4.2.3] [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] [ONLY-TS-3.9.7] [ONLY-TS-3.8.3] @ts-ignore
     // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.9.5] [SKIP-TS-4.8.4] [SKIP-TS-4.7.4] [SKIP-TS-4.6.4] [SKIP-TS-4.5.5] [SKIP-TS-4.4.4] [SKIP-TS-4.3.5] [SKIP-TS-4.2.3] [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
-      // [ONLY-TS-3.9.7] [ONLY-TS-3.8.3] @ts-ignore
       [countAtom, true],
       [activeAtom, false],
     ])

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -9,7 +9,7 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     // Adding @ts-ignore for typescript 3.8 support
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // @ts-expect-error TS2769
+    // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 'foo'],
       [activeAtom, 0],
@@ -17,7 +17,7 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     // Adding @ts-ignore for typescript 3.8 support
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // @ts-expect-error TS2769
+    // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 1],
       [activeAtom, 0],
@@ -25,10 +25,15 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     // Adding @ts-ignore for typescript 3.8 support
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // @ts-expect-error TS2769
+    // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, true],
       [activeAtom, false],
+    ])
+    // Valid case
+    useHydrateAtoms([
+      [countAtom, 1],
+      [activeAtom, true],
     ])
   }
   expect(Component).toBeDefined()

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -11,15 +11,15 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
       [countAtom, 'foo'],
       [activeAtom, 0],
     ])
-    // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
+    // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.9.5] [SKIP-TS-4.8.4] [SKIP-TS-4.7.4] [SKIP-TS-4.6.4] [SKIP-TS-4.5.5] [SKIP-TS-4.4.4] [SKIP-TS-4.3.5] [SKIP-TS-4.2.3] [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 1],
-      // [ONLY-TS-5.0.4] [ONLY-TS-4.0.5] @ts-ignore
+      // [ONLY-TS-5.0.4] [ONLY-TS-4.9.5] [ONLY-TS-4.8.4] [ONLY-TS-4.7.4] [ONLY-TS-4.6.4] [ONLY-TS-4.5.5] [ONLY-TS-4.4.4] [ONLY-TS-4.3.5] [ONLY-TS-4.2.3] [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] @ts-ignore
       [activeAtom, 0],
     ])
-    // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
+    // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.9.5] [SKIP-TS-4.8.4] [SKIP-TS-4.7.4] [SKIP-TS-4.6.4] [SKIP-TS-4.5.5] [SKIP-TS-4.4.4] [SKIP-TS-4.3.5] [SKIP-TS-4.2.3] [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
-      // [ONLY-TS-5.0.4] [ONLY-TS-4.0.5] @ts-ignore
+      // [ONLY-TS-5.0.4] [ONLY-TS-4.9.5] [ONLY-TS-4.8.4] [ONLY-TS-4.7.4] [ONLY-TS-4.6.4] [ONLY-TS-4.5.5] [ONLY-TS-4.4.4] [ONLY-TS-4.3.5] [ONLY-TS-4.2.3] [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] @ts-ignore
       [countAtom, true],
       [activeAtom, false],
     ])

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -6,21 +6,20 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
   function Component() {
     const countAtom = atom(0)
     const activeAtom = atom(true)
-    // [ONLY-TS-5.0.4] [ONLY-TS-4.0.5] @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
+    // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 'foo'],
       [activeAtom, 0],
     ])
-    // [ONLY-TS-5.0.4] [ONLY-TS-4.0.5] @ts-ignore
     // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 1],
+      // [ONLY-TS-5.0.4] [ONLY-TS-4.0.5] @ts-ignore
       [activeAtom, 0],
     ])
-    // [ONLY-TS-5.0.4] [ONLY-TS-4.0.5] @ts-ignore
     // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
+      // [ONLY-TS-5.0.4] [ONLY-TS-4.0.5] @ts-ignore
       [countAtom, true],
       [activeAtom, false],
     ])

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -9,7 +9,7 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     // Adding @ts-ignore for typescript 3.8 support
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-4.3.5] [SKIP-TS-4.2.3]
+    // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 'foo'],
       [activeAtom, 0],
@@ -17,7 +17,7 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     // Adding @ts-ignore for typescript 3.8 support
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-4.3.5] [SKIP-TS-4.2.3]
+    // @ts-expect-error TS2769 [SKIP-TS-4.3.5] [SKIP-TS-4.2.3] [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 1],
       [activeAtom, 0],
@@ -25,7 +25,7 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     // Adding @ts-ignore for typescript 3.8 support
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-4.3.5] [SKIP-TS-4.2.3]
+    // @ts-expect-error TS2769 [SKIP-TS-4.3.5] [SKIP-TS-4.2.3] [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, true],
       [activeAtom, false],

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -8,18 +8,20 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     const activeAtom = atom(true)
     // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
     useHydrateAtoms([
+      // [ONLY-TS-3.9.7] [ONLY-TS-3.8.3] @ts-ignore
       [countAtom, 'foo'],
       [activeAtom, 0],
     ])
     // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.9.5] [SKIP-TS-4.8.4] [SKIP-TS-4.7.4] [SKIP-TS-4.6.4] [SKIP-TS-4.5.5] [SKIP-TS-4.4.4] [SKIP-TS-4.3.5] [SKIP-TS-4.2.3] [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
+      // [ONLY-TS-3.9.7] [ONLY-TS-3.8.3] @ts-ignore
       [countAtom, 1],
       // [ONLY-TS-5.0.4] [ONLY-TS-4.9.5] [ONLY-TS-4.8.4] [ONLY-TS-4.7.4] [ONLY-TS-4.6.4] [ONLY-TS-4.5.5] [ONLY-TS-4.4.4] [ONLY-TS-4.3.5] [ONLY-TS-4.2.3] [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] @ts-ignore
       [activeAtom, 0],
     ])
     // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.9.5] [SKIP-TS-4.8.4] [SKIP-TS-4.7.4] [SKIP-TS-4.6.4] [SKIP-TS-4.5.5] [SKIP-TS-4.4.4] [SKIP-TS-4.3.5] [SKIP-TS-4.2.3] [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
-      // [ONLY-TS-5.0.4] [ONLY-TS-4.9.5] [ONLY-TS-4.8.4] [ONLY-TS-4.7.4] [ONLY-TS-4.6.4] [ONLY-TS-4.5.5] [ONLY-TS-4.4.4] [ONLY-TS-4.3.5] [ONLY-TS-4.2.3] [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] @ts-ignore
+      // [ONLY-TS-5.0.4] [ONLY-TS-4.9.5] [ONLY-TS-4.8.4] [ONLY-TS-4.7.4] [ONLY-TS-4.6.4] [ONLY-TS-4.5.5] [ONLY-TS-4.4.4] [ONLY-TS-4.3.5] [ONLY-TS-4.2.3] [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] [ONLY-TS-3.9.7] [ONLY-TS-3.8.3] @ts-ignore
       [countAtom, true],
       [activeAtom, false],
     ])

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -9,7 +9,7 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     // Adding @ts-ignore for typescript 3.8 support
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
+    // @ts-expect-error TS2769 [SKIP-TS-4.1.5] [SKIP-TS-4.0.5]
     useHydrateAtoms([
       [countAtom, 'foo'],
       [activeAtom, 0],
@@ -17,7 +17,7 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     // Adding @ts-ignore for typescript 3.8 support
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
+    // @ts-expect-error TS2769 [SKIP-TS-4.1.5] [SKIP-TS-4.0.5]
     useHydrateAtoms([
       [countAtom, 1],
       [activeAtom, 0],
@@ -25,7 +25,7 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     // Adding @ts-ignore for typescript 3.8 support
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
+    // @ts-expect-error TS2769 [SKIP-TS-4.1.5] [SKIP-TS-4.0.5]
     useHydrateAtoms([
       [countAtom, true],
       [activeAtom, false],

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -12,16 +12,17 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
       [countAtom, 'foo'],
       [activeAtom, 0],
     ])
+    // [ONLY-TS-5.0.4] [ONLY-TS-4.9.5] [ONLY-TS-4.8.4] [ONLY-TS-4.7.4] [ONLY-TS-4.6.4] [ONLY-TS-4.5.5] [ONLY-TS-4.4.4] [ONLY-TS-4.3.5] [ONLY-TS-4.2.3] [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] @ts-ignore
     // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.9.5] [SKIP-TS-4.8.4] [SKIP-TS-4.7.4] [SKIP-TS-4.6.4] [SKIP-TS-4.5.5] [SKIP-TS-4.4.4] [SKIP-TS-4.3.5] [SKIP-TS-4.2.3] [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
       // [ONLY-TS-3.9.7] [ONLY-TS-3.8.3] @ts-ignore
       [countAtom, 1],
-      // [ONLY-TS-5.0.4] [ONLY-TS-4.9.5] [ONLY-TS-4.8.4] [ONLY-TS-4.7.4] [ONLY-TS-4.6.4] [ONLY-TS-4.5.5] [ONLY-TS-4.4.4] [ONLY-TS-4.3.5] [ONLY-TS-4.2.3] [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] @ts-ignore
       [activeAtom, 0],
     ])
+    // [ONLY-TS-5.0.4] [ONLY-TS-4.9.5] [ONLY-TS-4.8.4] [ONLY-TS-4.7.4] [ONLY-TS-4.6.4] [ONLY-TS-4.5.5] [ONLY-TS-4.4.4] [ONLY-TS-4.3.5] [ONLY-TS-4.2.3] [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] @ts-ignore
     // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.9.5] [SKIP-TS-4.8.4] [SKIP-TS-4.7.4] [SKIP-TS-4.6.4] [SKIP-TS-4.5.5] [SKIP-TS-4.4.4] [SKIP-TS-4.3.5] [SKIP-TS-4.2.3] [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
-      // [ONLY-TS-5.0.4] [ONLY-TS-4.9.5] [ONLY-TS-4.8.4] [ONLY-TS-4.7.4] [ONLY-TS-4.6.4] [ONLY-TS-4.5.5] [ONLY-TS-4.4.4] [ONLY-TS-4.3.5] [ONLY-TS-4.2.3] [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] [ONLY-TS-3.9.7] [ONLY-TS-3.8.3] @ts-ignore
+      // [ONLY-TS-3.9.7] [ONLY-TS-3.8.3] @ts-ignore
       [countAtom, true],
       [activeAtom, false],
     ])

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -9,7 +9,7 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     // Adding @ts-ignore for typescript 3.8 support
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-4.1.5] [SKIP-TS-4.0.5]
+    // @ts-expect-error TS2769 [SKIP-TS-4.3.5] [SKIP-TS-4.2.3]
     useHydrateAtoms([
       [countAtom, 'foo'],
       [activeAtom, 0],
@@ -17,7 +17,7 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     // Adding @ts-ignore for typescript 3.8 support
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-4.1.5] [SKIP-TS-4.0.5]
+    // @ts-expect-error TS2769 [SKIP-TS-4.3.5] [SKIP-TS-4.2.3]
     useHydrateAtoms([
       [countAtom, 1],
       [activeAtom, 0],
@@ -25,7 +25,7 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     // Adding @ts-ignore for typescript 3.8 support
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-4.1.5] [SKIP-TS-4.0.5]
+    // @ts-expect-error TS2769 [SKIP-TS-4.3.5] [SKIP-TS-4.2.3]
     useHydrateAtoms([
       [countAtom, true],
       [activeAtom, false],

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -6,19 +6,20 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
   function Component() {
     const countAtom = atom(0)
     const activeAtom = atom(true)
-    // [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
+    // [ONLY-TS-5.0.4] [ONLY-TS-4.0.5] @ts-ignore
+    // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 'foo'],
       [activeAtom, 0],
     ])
-    // [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
+    // [ONLY-TS-5.0.4] [ONLY-TS-4.0.5] @ts-ignore
+    // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 1],
       [activeAtom, 0],
     ])
-    // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
+    // [ONLY-TS-5.0.4] [ONLY-TS-4.0.5] @ts-ignore
+    // @ts-expect-error TS2769 [SKIP-TS-5.0.4] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, true],
       [activeAtom, false],

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -6,6 +6,7 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
   function Component() {
     const countAtom = atom(0)
     const activeAtom = atom(true)
+    // [ONLY-TS-4.0.5] @ts-ignore
     // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 'foo'],

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -6,26 +6,19 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
   function Component() {
     const countAtom = atom(0)
     const activeAtom = atom(true)
-    // Adding @ts-ignore for typescript 3.8 support
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // [ONLY-TS-3.8.3] @ts-ignore
     // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 'foo'],
       [activeAtom, 0],
     ])
-    // Adding @ts-ignore for typescript 3.8 support
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
+    // [ONLY-TS-3.8.3] @ts-ignore
+    // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 1],
       [activeAtom, 0],
     ])
-    // Adding @ts-ignore for typescript 3.8 support
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-4.3.5] [SKIP-TS-4.2.3] [SKIP-TS-3.9.7]
+    // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, true],
       [activeAtom, false],

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -6,13 +6,14 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
   function Component() {
     const countAtom = atom(0)
     const activeAtom = atom(true)
-    // [ONLY-TS-4.0.5] @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
+    // [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] @ts-ignore
+    // @ts-expect-error TS2769 [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 'foo'],
       [activeAtom, 0],
     ])
-    // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
+    // [ONLY-TS-4.1.5] [ONLY-TS-4.0.5] @ts-ignore
+    // @ts-expect-error TS2769 [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 1],
       [activeAtom, 0],

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -6,13 +6,11 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
   function Component() {
     const countAtom = atom(0)
     const activeAtom = atom(true)
-    // [ONLY-TS-3.8.3] @ts-ignore
     // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 'foo'],
       [activeAtom, 0],
     ])
-    // [ONLY-TS-3.8.3] @ts-ignore
     // @ts-expect-error TS2769 [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 1],

--- a/tests/react/utils/types.test.tsx
+++ b/tests/react/utils/types.test.tsx
@@ -17,7 +17,7 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     // Adding @ts-ignore for typescript 3.8 support
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-4.3.5] [SKIP-TS-4.2.3] [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
+    // @ts-expect-error TS2769 [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, 1],
       [activeAtom, 0],
@@ -25,7 +25,7 @@ it('useHydrateAtoms should not allow invalid atom types when array is passed', (
     // Adding @ts-ignore for typescript 3.8 support
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // @ts-expect-error TS2769 [SKIP-TS-4.3.5] [SKIP-TS-4.2.3] [SKIP-TS-4.1.5] [SKIP-TS-4.0.5] [SKIP-TS-3.9.7]
+    // @ts-expect-error TS2769 [SKIP-TS-4.3.5] [SKIP-TS-4.2.3] [SKIP-TS-3.9.7]
     useHydrateAtoms([
       [countAtom, true],
       [activeAtom, false],


### PR DESCRIPTION
Problem: tests are broken for old typescript versions
Solution: granular SKIP- and ONLY- control for specific ts versions