### PR TITLE
feat: add `unstable_defaultUse`

### DIFF
--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -102,22 +102,25 @@ const createContinuablePromise = <T>(
 
 type Options = Parameters<typeof useStore>[0] & {
   delay?: number
+  unstable_defaultUse?: boolean
   unstable_promiseStatus?: boolean
 }
 
-export function useAtomValue<Value>(
+export function useAtomValue<Value, O extends Options = Options>(
   atom: Atom<Value>,
-  options?: Options,
-): Awaited<Value>
-
-export function useAtomValue<AtomType extends Atom<unknown>>(
-  atom: AtomType,
-  options?: Options,
-): Awaited<ExtractAtomValue<AtomType>>
+  options?: O,
+): O extends { unstable_defaultUse: true } ? Awaited<Value> : Value
+export function useAtomValue<Value, O extends Options = Options>(
+  atom: Atom<Value>,
+  options?: O,
+): O extends { unstable_defaultUse: true } ? Awaited<Value> : Value
 
 export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
-  const { delay, unstable_promiseStatus: promiseStatus = !React.use } =
-    options || {}
+  const {
+    delay,
+    unstable_promiseStatus: promiseStatus = !React.use,
+    unstable_defaultUse = true,
+  } = options || {}
   const store = useStore(options)
 
   const [[valueFromReducer, storeFromReducer, atomFromReducer], rerender] =
@@ -174,7 +177,7 @@ export function useAtomValue<Value>(atom: Atom<Value>, options?: Options) {
     if (promiseStatus) {
       attachPromiseStatus(promise)
     }
-    return use(promise)
+    return unstable_defaultUse ? use(promise) : promise
   }
   return value as Awaited<Value>
 }

--- a/tests/react/useAtomValue.test.tsx
+++ b/tests/react/useAtomValue.test.tsx
@@ -1,8 +1,8 @@
-import { Component, StrictMode, Suspense } from 'react'
+import { Component, StrictMode, Suspense, use } from 'react'
 import type { ReactNode } from 'react'
 import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { expect, it } from 'vitest'
+import { expect, expectTypeOf, it } from 'vitest'
 import { useAtomValue, useSetAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
 
@@ -119,4 +119,25 @@ it('useAtomValue with atom returning object', async () => {
   )
 
   expect(await screen.findByText('obj: 1,2')).toBeInTheDocument()
+})
+
+it('useAtomValue with unstable_defaultUse', async () => {
+  const numberAtom = atom(Promise.resolve(1 as const))
+
+  const ObjComponent = () => {
+    const value = useAtomValue(numberAtom, { unstable_defaultUse: false })
+    expectTypeOf(value).toEqualTypeOf<Promise<1>>()
+
+    return <div>number: {use(value)}</div>
+  }
+
+  await act(() =>
+    render(
+      <StrictMode>
+        <ObjComponent />
+      </StrictMode>,
+    ),
+  )
+
+  expect(await screen.findByText('number: 1')).toBeInTheDocument()
 })


### PR DESCRIPTION
From v3 discussion https://github.com/pmndrs/jotai/discussions/2889

```
Do not use use in useAtomValue (migration path: add { use: true } option which is true by default in v2, and warns it)
```