### PR TITLE
docs: atomWithStorage getOnInit clarification for React Native

### DIFF
--- a/docs/utilities/storage.mdx
+++ b/docs/utilities/storage.mdx
@@ -45,7 +45,6 @@ The `atomWithStorage` function creates an atom with a value persisted in `localS
 
 - **getOnInit** (optional, by default **false**): A boolean value indicating whether to get item from storage on initialization. Note that in an SPA with `getOnInit` either not set or `false` you will always get the initial value instead of the stored value on initialization. If the stored value is preferred set `getOnInit` to `true`.
 
-
 If not specified, the default storage implementation uses `localStorage` for storage/retrieval, `JSON.stringify()`/`JSON.parse()` for serialization/deserialization, and subscribes to `storage` events for cross-tab synchronization.
 
 <Stackblitz id="vitejs-vite-wewrmi" file="src%2FApp.tsx" />
@@ -158,7 +157,7 @@ function App() {
 
   useEffect(() => {
     console.log('symbol', symbol)
-  },[symbol])
+  }, [symbol])
 
   return <div>{symbol}</div>
 }
@@ -177,7 +176,7 @@ function App() {
 
   useEffect(() => {
     console.log('symbol', symbol)
-  },[symbol])
+  }, [symbol])
 
   return <div>{symbol}</div>
 }
@@ -185,6 +184,7 @@ function App() {
 // Console output WITH getOnInit:
 // LOG "symbol" BTC_USDC  (gets stored value immediately)
 ```
+
 </details>
 
 #### Notes with AsyncStorage (since v2.2.0)


### PR DESCRIPTION
## Related Bug Reports or Discussions

Clarifies the confusing behavior of `getOnInit` that I felt wasn't properly clarified in the docs.

## Summary

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
