### PR TITLE
feat: add allowTearing option in useAtom and useAtomValue to avoid double render on initial mount. (fix #1137)

### DIFF
--- a/tests/react/optimization.test.tsx
+++ b/tests/react/optimization.test.tsx
@@ -270,3 +270,34 @@ it('no extra rerenders after commit with derived atoms (#1213)', async () => {
   expect(screen.getByText('count2: 1')).toBeInTheDocument()
   expect(viewCount1).toBe(viewCount1AfterCommit)
 })
+
+it('no double renders on initial mount with allowTearing option', async () => {
+  const count1Atom = atom(0)
+
+  let viewCount = 0
+
+  const Counter1 = () => {
+    const [count, setCount] = useAtom(count1Atom, { allowTearing: true })
+    ++viewCount
+    return (
+      <>
+        <div>count: {count}</div>
+        <button onClick={() => setCount((c) => c + 1)}>button1</button>
+      </>
+    )
+  }
+
+  render(
+    <>
+      <Counter1 />
+    </>,
+  )
+
+  expect(screen.getByText('count: 0')).toBeInTheDocument()
+  expect(viewCount).toBe(1)
+
+  await userEvent.click(screen.getByText('button1'))
+
+  expect(screen.getByText('count: 1')).toBeInTheDocument()
+  expect(viewCount).toBe(2)
+})


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #1137

## Summary

I guess rerender here is to handle atom value changing between initial render and subscribe in useEffect, also avoid tearing in concurrent mode.

However some app just care performance more than tearing. 
For me, I use some [craft.js](https://craft.js.org/) like component to support UI edit. All component do `useAtomValue(enableUIEditorAtom)` to switch on editing, so all components double render will cause a big impact.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
