### PR TITLE
chore: upgrade pnpm to v10.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "url": "https://github.com/pmndrs/jotai/issues"
   },
   "homepage": "https://github.com/pmndrs/jotai",
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@10.15.0",
   "devDependencies": {
     "@babel/core": "^7.28.0",
     "@babel/plugin-transform-react-jsx": "^7.27.1",


### PR DESCRIPTION
## Related Bug Reports or Discussions

 N/A

## Summary

Upgrade pnpm from v9.15.5 to v10.15.0 to stay up-to-date with latest stable version.
The lockfile format remains compatible (v9.0) so no lockfile changes are needed.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs