### PR TITLE
Update "Preview in LiveCodes" to use pkg.pr.new

### DIFF
--- a/.livecodes/react.json
+++ b/.livecodes/react.json
@@ -16,12 +16,8 @@
   "customSettings": {
     "jotai commit sha": "{{LC::SHORT_SHA}}",
     "imports": {
-      "jotai": "{{LC::TO_DATA_URL(./dist/esm/index.mjs)}}",
-      "jotai/vanilla": "{{LC::TO_DATA_URL(./dist/esm/vanilla.mjs)}}",
-      "jotai/utils": "{{LC::TO_DATA_URL(./dist/esm/utils.mjs)}}",
-      "jotai/react": "{{LC::TO_DATA_URL(./dist/esm/react.mjs)}}",
-      "jotai/vanilla/utils": "{{LC::TO_DATA_URL(./dist/esm/vanilla/utils.mjs)}}",
-      "jotai/react/utils": "{{LC::TO_DATA_URL(./dist/esm/react/utils.mjs)}}"
+      "jotai": "https://esm.sh/pr/jotai@{{LC::SHORT_SHA}}",
+      "jotai/": "https://esm.sh/pr/jotai@{{LC::SHORT_SHA}}/"
     }
   }
 }


### PR DESCRIPTION
Hi,
I noticed you are using pkg.pr.new github action.

I updated the template for "Preview in LiveCodes" to use it (through esm.sh)
e.g. https://esm.sh/pr/jotai@de789bf

This is simpler and lighter-weight than using data URLs for all the build files.

By the way, I'm not sure if you have had a look on [LiveCodes](https://livecodes.io/) recently. Lots of things have changed!
Docs: https://livecodes.io/docs

Cheers
