### PR TITLE
breaking: drop atom.unstable_is

### DIFF
--- a/src/vanilla/atom.ts
+++ b/src/vanilla/atom.ts
@@ -42,7 +42,6 @@ type OnMount<Args extends unknown[], Result> = <
 export interface Atom<Value> {
   toString: () => string
   read: Read<Value>
-  unstable_is?(a: Atom<unknown>): boolean
   debugLabel?: string
   /**
    * To ONLY be used by Jotai libraries to mark atoms as private. Subject to change.

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -214,11 +214,6 @@ export type {
 // Some util functions
 //
 
-// TODO this will be gone soon
-function isSelfAtom(atom: AnyAtom, a: AnyAtom): boolean {
-  return atom.unstable_is ? atom.unstable_is(a) : a === atom
-}
-
 function hasInitialValue<T extends Atom<AnyValue>>(
   atom: T,
 ): atom is T & (T extends Atom<infer Value> ? { init: Value } : never) {
@@ -578,7 +573,7 @@ const readAtomState: ReadAtomState = (store, atom) => {
     }
   }
   function getter<V>(a: Atom<V>) {
-    if (isSelfAtom(atom, a)) {
+    if (a === (atom as AnyAtom)) {
       const aState = ensureAtomState(store, a)
       if (!isAtomStateInitialized(aState)) {
         if (hasInitialValue(a)) {
@@ -703,7 +698,7 @@ const writeAtomState: WriteAtomState = (store, atom, ...args) => {
   ) => {
     const aState = ensureAtomState(store, a)
     try {
-      if (isSelfAtom(atom, a)) {
+      if (a === (atom as AnyAtom)) {
         if (!hasInitialValue(a)) {
           // NOTE technically possible but restricted as it may cause bugs
           throw new Error('atom not writable')
@@ -1002,7 +997,6 @@ export {
   //
   // Still experimental and some of them will be gone soon
   //
-  isSelfAtom as INTERNAL_isSelfAtom,
   hasInitialValue as INTERNAL_hasInitialValue,
   isActuallyWritableAtom as INTERNAL_isActuallyWritableAtom,
   isAtomStateInitialized as INTERNAL_isAtomStateInitialized,


### PR DESCRIPTION
It was an experimental feature of jotai-scope, which is no longer required.