### PR TITLE
fix atomWithStorage stackblitz missing style

### DIFF
--- a/docs/utilities/storage.mdx
+++ b/docs/utilities/storage.mdx
@@ -47,7 +47,7 @@ The `atomWithStorage` function creates an atom with a value persisted in `localS
 
 If not specified, the default storage implementation uses `localStorage` for storage/retrieval, `JSON.stringify()`/`JSON.parse()` for serialization/deserialization, and subscribes to `storage` events for cross-tab synchronization.
 
-<Stackblitz id="vitejs-vite-wewrmi" file="src%2FApp.tsx" />
+<Stackblitz id="vitejs-vite-xvlgfxrk" file="src%2FApp.tsx" />
 
 ### `createJSONStorage` util
 


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #3134

## Summary

changed stackblitz project id from

```react
<Stackblitz id="vitejs-vite-wewrmi" file="src%2FApp.tsx" />
```

to a new project id 

```react
<Stackblitz id="vitejs-vite-xvlgfxrk" file="src%2FApp.tsx" />
```

which has added the missing style content.

You can preview at [vitejs-vite-xvlgfxrk](https://stackblitz.com/edit/vitejs-vite-xvlgfxrk?file=src%2FApp.tsx), compared to [old one](https://stackblitz.com/edit/vitejs-vite-wewrmi?file=src%2FApp.tsx).

