### PR TITLE
fix(unwrap): recover from errors

### DIFF
--- a/src/vanilla/utils/unwrap.ts
+++ b/src/vanilla/utils/unwrap.ts
@@ -58,7 +58,12 @@ export function unwrap<Value, Args extends unknown[], Result, PendingValue>(
       } = atom(
         (get, { setSelf }) => {
           get(refreshAtom)
-          const prev = get(promiseAndValueAtom) as PromiseAndValue | undefined
+          let prev: PromiseAndValue | undefined
+          try {
+            prev = get(promiseAndValueAtom) as PromiseAndValue | undefined
+          } catch {
+            // ignore previous errors to avoid getting stuck in error state
+          }
           const promise = get(anAtom)
           if (!isPromiseLike(promise)) {
             return { v: promise as Awaited<Value> }

--- a/tests/vanilla/utils/unwrap.test.ts
+++ b/tests/vanilla/utils/unwrap.test.ts
@@ -149,6 +149,21 @@ describe('unwrap', () => {
 
     expect(store.get(syncAtom)).toEqual('concrete')
   })
+
+  it('should throw an error if underlying promise is rejected', async () => {
+    const store = createStore()
+    const asyncAtom = atom(Promise.reject<number>('error'))
+    const syncAtom = unwrap(asyncAtom)
+    store.sub(syncAtom, () => {})
+
+    await new Promise((r) => setTimeout(r)) // wait for a tick
+    expect(() => store.get(syncAtom)).toThrow('error')
+
+    store.set(asyncAtom, Promise.resolve(3))
+
+    await new Promise((r) => setTimeout(r)) // wait for a tick
+    expect(store.get(syncAtom)).toBe(3)
+  })
 })
 
 it('should update dependents with the value of the unwrapped atom when the promise resolves', async () => {


### PR DESCRIPTION
When `unwrap` encountered an error, it would get stuck in the error state.  This commit fixes that.

## Related Bug Reports or Discussions

Discussion https://github.com/pmndrs/jotai/discussions/3162

## Summary

Discussion goes into more detail above, but basically an `unwrap` atom gets stuck in an error state via:

1. underlying `Promise` fails
2. the internal `promiseAndValueAtom` saves an error
3. then in the future, when `promiseAndValueAtom` reads it's previous value, the original error gets thrown
4. goes back to 2. above

To break this loop, added a try/catch around reading the previous value.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
