### PR TITLE
deprecate loadable util

### DIFF
--- a/src/vanilla/utils/loadable.ts
+++ b/src/vanilla/utils/loadable.ts
@@ -29,7 +29,7 @@ let didWarnDeprecation = false
  *       }
  *       return { state: 'hasData', data }
  *     } catch (error) {
- *       return { state: 'hasError', error: e }
+ *       return { state: 'hasError', error }
  *     }
  *   })
  * }


### PR DESCRIPTION
`loadable` is deprecated infavor of `unwrap`.

Userland implementation of loadable:
```js
function loadable(anAtom) {
  const LOADING = { state: 'loading' }
  const unwrappedAtom = unwrap(anAtom, () => LOADING)
  return atom((get) => {
    try {
      const data = get(unwrappedAtom)
      if (data === LOADING) {
        return LOADING
      }
      return { state: 'hasData', data }
    } catch (error) {
      return { state: 'hasError', error }
    }
  })
}
```