### PR TITLE
test(react/vanilla-utils/atomWithStorage): add test for 'withStorageValidator' returning 'initialValue' when validator fails

### DIFF
--- a/tests/react/vanilla-utils/atomWithStorage.test.tsx
+++ b/tests/react/vanilla-utils/atomWithStorage.test.tsx
@@ -694,10 +694,11 @@ describe('atomWithStorage (with non-browser storage)', () => {
 })
 
 describe('withStorageValidator', () => {
+  const isNumber = (v: unknown): v is number => typeof v === 'number'
+
   it('should use withStorageValidator with isNumber', () => {
     const store = createStore()
     const storage = createJSONStorage()
-    const isNumber = (v: unknown): v is number => typeof v === 'number'
     const numAtom = atomWithStorage(
       'my-number',
       0,
@@ -705,6 +706,23 @@ describe('withStorageValidator', () => {
     )
 
     expect(store.get(numAtom)).toBe(0)
+  })
+
+  it('should return initialValue when validator fails', () => {
+    const store = createStore()
+    const stringStorage: SyncStringStorage = {
+      getItem: () => JSON.stringify('not-a-number'),
+      setItem: () => {},
+      removeItem: () => {},
+    }
+    const storage = createJSONStorage(() => stringStorage)
+    const numAtom = atomWithStorage(
+      'my-number',
+      42,
+      withStorageValidator(isNumber)(storage),
+    )
+
+    expect(store.get(numAtom)).toBe(42)
   })
 })
 


### PR DESCRIPTION
## Related Bug Reports or Discussions

N/A

## Summary

Add test case for `withStorageValidator` to verify it returns `initialValue` when validator fails.

This test simulates a scenario where storage contains an invalid value (e.g., a string `'not-a-number'` when expecting a number), ensuring the validator correctly falls back to `initialValue`.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs