### PR TITLE
docs: fix README build status badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 visit [jotai.org](https://jotai.org) or `npm i jotai`
 
-[![Build Status](https://img.shields.io/github/actions/workflow/status/pmndrs/jotai/test.yml?branch=main&style=flat&colorA=000000&colorB=000000)](https://github.com/pmndrs/jotai/actions?query=workflow%3ALint)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/pmndrs/jotai/test.yml?branch=main&style=flat&colorA=000000&colorB=000000)](https://github.com/pmndrs/jotai/actions/workflows/test.yml?query=branch%3Amain)
 [![Build Size](https://img.shields.io/bundlephobia/minzip/jotai?label=bundle%20size&style=flat&colorA=000000&colorB=000000)](https://bundlephobia.com/result?p=jotai)
 [![Version](https://img.shields.io/npm/v/jotai?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/jotai)
 [![Downloads](https://img.shields.io/npm/dt/jotai.svg?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/jotai)


### PR DESCRIPTION
## Related Bug Reports or Discussions

https://github.com/pmndrs/zustand/pull/3378

## Summary
The README “Build Status” badge linked to the Lint workflow query, but the badge is for test.yml (workflow name: Test).
Update the badge link to the Test workflow page filtered to main.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
