### PR TITLE
test(react/vanilla-utils/atomWithStorage): add render test for sync 'withStorageValidator' failure returning 'initialValue'

### DIFF
--- a/tests/react/vanilla-utils/atomWithStorage.test.tsx
+++ b/tests/react/vanilla-utils/atomWithStorage.test.tsx
@@ -725,6 +725,33 @@ describe('withStorageValidator', () => {
     expect(store.get(numAtom)).toBe(42)
   })
 
+  it('should return initialValue when sync validator fails with render', () => {
+    const stringStorage: SyncStringStorage = {
+      getItem: () => JSON.stringify('not-a-number'),
+      setItem: () => {},
+      removeItem: () => {},
+    }
+    const storage = createJSONStorage(() => stringStorage)
+    const numAtom = atomWithStorage(
+      'my-number',
+      42,
+      withStorageValidator(isNumber)(storage),
+    )
+
+    const Counter = () => {
+      const [count] = useAtom(numAtom)
+      return <div>count: {count}</div>
+    }
+
+    render(
+      <StrictMode>
+        <Counter />
+      </StrictMode>,
+    )
+
+    expect(screen.getByText('count: 42')).toBeInTheDocument()
+  })
+
   it('should return initialValue when async validator fails', async () => {
     const asyncStringStorage = {
       getItem: async () => {


### PR DESCRIPTION
## Related Bug Reports or Discussions

N/A

## Summary

- Add render test for `withStorageValidator` with sync storage when validator fails
  - Verifies that `initialValue` is returned when sync storage provides an invalid value via component rendering
  - Covers `withStorageValidator` sync path (`return validate(value)` at line 78)

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs