### PR TITLE
test(react/vanilla-utils/atomWithStorage): add test for 'getOnInit' option reading stored value on init

### DIFF
--- a/tests/react/vanilla-utils/atomWithStorage.test.tsx
+++ b/tests/react/vanilla-utils/atomWithStorage.test.tsx
@@ -121,22 +121,12 @@ describe('atomWithStorage (sync)', () => {
   })
 
   it('should get stored value on init with getOnInit option', () => {
+    const store = createStore()
     const countAtom = atomWithStorage('count', 0, dummyStorage, {
       getOnInit: true,
     })
 
-    const Counter = () => {
-      const [count] = useAtom(countAtom)
-      return <div>count: {count}</div>
-    }
-
-    render(
-      <StrictMode>
-        <Counter />
-      </StrictMode>,
-    )
-
-    expect(screen.getByText('count: 10')).toBeInTheDocument()
+    expect(store.get(countAtom)).toBe(10)
   })
 })
 


### PR DESCRIPTION
## Related Bug Reports or Discussions

N/A

## Summary

- Add test for `atomWithStorage` with `getOnInit: true` option
  - Verifies that stored value (`10`) is used as initial value instead of `initialValue` (`0`) on first render

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs