### PR TITLE
refactor(react/utils/useHydrateAtoms): use 'has' for explicit existence check in 'getHydratedSet'

### DIFF
--- a/src/react/utils/useHydrateAtoms.ts
+++ b/src/react/utils/useHydrateAtoms.ts
@@ -50,11 +50,8 @@ export function useHydrateAtoms<
   }
 }
 
-const getHydratedSet = (store: Store) => {
-  let hydratedSet = hydratedMap.get(store)
-  if (!hydratedSet) {
-    hydratedSet = new WeakSet()
-    hydratedMap.set(store, hydratedSet)
-  }
-  return hydratedSet
-}
+const getHydratedSet = (store: Store) =>
+  (hydratedMap.has(store)
+    ? hydratedMap
+    : hydratedMap.set(store, new WeakSet())
+  ).get(store)!


### PR DESCRIPTION
## Summary

Use `getCached`-style ternary pattern with `has` for explicit existence check and remove mutable `let` variable in `getHydratedSet`.

This pattern is already used across the codebase:
- [`splitAtom.ts#L11`](https://github.com/pmndrs/jotai/blob/main/src/vanilla/utils/splitAtom.ts#L11)
- [`unwrap.ts#L4`](https://github.com/pmndrs/jotai/blob/main/src/vanilla/utils/unwrap.ts#L4)
- [`selectAtom.ts#L4`](https://github.com/pmndrs/jotai/blob/main/src/vanilla/utils/selectAtom.ts#L4)
- [`loadable.ts#L6-L7`](https://github.com/pmndrs/jotai/blob/main/src/vanilla/utils/loadable.ts#L6-L7)

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs