### PR TITLE
test(react/vanilla-utils/atomWithObservable): add test for write error on non-subject observable

### DIFF
--- a/tests/react/vanilla-utils/atomWithObservable.test.tsx
+++ b/tests/react/vanilla-utils/atomWithObservable.test.tsx
@@ -806,6 +806,37 @@ describe('error handling', () => {
   })
 })
 
+it('should throw error when writing to non-subject observable', () => {
+  const observable = of(1)
+  const observableAtom = atomWithObservable(() => observable)
+
+  const Counter = () => {
+    const [state, dispatch] = useAtom(observableAtom as any)
+    return (
+      <>
+        count: {state}
+        <button
+          onClick={() => {
+            expect(() => dispatch(2)).toThrow('observable is not subject')
+          }}
+        >
+          button
+        </button>
+      </>
+    )
+  }
+
+  render(
+    <StrictMode>
+      <Counter />
+    </StrictMode>,
+  )
+
+  expect(screen.getByText('count: 1')).toBeInTheDocument()
+
+  fireEvent.click(screen.getByText('button'))
+})
+
 describe('wonka', () => {
   it('count state', () => {
     const source = fromValue(1)
@@ -917,6 +948,18 @@ describe('atomWithObservable vanilla tests', () => {
     expect(store.get(doubleAtom)).toBe(6)
 
     unsubs.forEach((unsub) => unsub())
+  })
+
+  it('should throw error when writing to non-subject observable', () => {
+    const store = createStore()
+    const observable = of(1)
+    const observableAtom = atomWithObservable(() => observable)
+
+    store.sub(observableAtom, () => {})
+
+    expect(() => store.set(observableAtom as any, 2)).toThrow(
+      'observable is not subject',
+    )
   })
 })
 


### PR DESCRIPTION
## Related Bug Reports or Discussions

N/A

## Summary

Add tests for `'observable is not subject'` error when writing to a read-only observable (without `next`) in both React and vanilla contexts.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs