### PR TITLE
docs: use real fetch URLs in async examples

### DIFF
--- a/docs/guides/async.mdx
+++ b/docs/guides/async.mdx
@@ -81,7 +81,10 @@ const Component = () => {
 An interesting pattern that can be achieved with Jotai is switching from async to sync to trigger suspending when wanted.
 
 ```js
-const request = async () => fetch('https://...').then((res) => res.json())
+const request = async () =>
+  fetch('https://jsonplaceholder.typicode.com/todos/1').then((res) =>
+    res.json(),
+  )
 const baseAtom = atom(0)
 const Component = () => {
   const [value, setValue] = useAtom(baseAtom)

--- a/docs/guides/performance.mdx
+++ b/docs/guides/performance.mdx
@@ -35,9 +35,11 @@ Do's:
 const friendsAtom = atom([])
 const fetchFriendsAtom = atom(null, async (get, set, payload) => {
   // Fetch all friends
-  const res = await fetch('https://...')
+  const res = await fetch('https://jsonplaceholder.typicode.com/users')
+  const data = await res.json()
+
   // Make heavy computation once only
-  const computed = res.filter(heavyComputation)
+  const computed = data.filter(heavyComputation)
   set(friendsAtom, computed)
 })
 // Usage in components


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary
Updates the docs async examples to use real, working fetch URLs instead of the placeholder https://..., and fixes the performance guide example to parse JSON before filtering.

## Check List

- [ ] `pnpm run fix` for formatting and linting code and docs
