### PR TITLE
breaking(internals): pass buildingBlockContext directly to internals

### DIFF
--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -1,7 +1,5 @@
 import React, { useDebugValue, useEffect, useReducer } from 'react'
-import {
-  INTERNAL_getBuildingBlocksRev2 as INTERNAL_getBuildingBlocks,
-} from '../vanilla/internals.ts'
+import { INTERNAL_getBuildingBlocksRev2 as INTERNAL_getBuildingBlocks } from '../vanilla/internals.ts'
 import type { Atom, ExtractAtomValue } from '../vanilla.ts'
 import { useStore } from './Provider.ts'
 

--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -85,7 +85,7 @@ const createContinuablePromise = <T>(
             continuablePromiseMap.set(nextValue, continuablePromise!)
             curr = nextValue
             nextValue.then(onFulfilled(nextValue), onRejected(nextValue))
-            registerAbortHandler(store, nextValue, onAbort)
+            registerAbortHandler(buildingBlocks, nextValue, onAbort)
           } else {
             resolve(nextValue)
           }
@@ -94,7 +94,7 @@ const createContinuablePromise = <T>(
         }
       }
       promise.then(onFulfilled(promise), onRejected(promise))
-      registerAbortHandler(store, promise, onAbort)
+      registerAbortHandler(buildingBlocks, promise, onAbort)
     })
     continuablePromiseMap.set(promise, continuablePromise)
   }

--- a/src/react/useAtomValue.ts
+++ b/src/react/useAtomValue.ts
@@ -1,5 +1,7 @@
 import React, { useDebugValue, useEffect, useReducer } from 'react'
-import { INTERNAL_getBuildingBlocksRev2 as INTERNAL_getBuildingBlocks } from '../vanilla/internals.ts'
+import {
+  INTERNAL_getBuildingBlocksRev2 as INTERNAL_getBuildingBlocks,
+} from '../vanilla/internals.ts'
 import type { Atom, ExtractAtomValue } from '../vanilla.ts'
 import { useStore } from './Provider.ts'
 
@@ -64,6 +66,7 @@ const createContinuablePromise = <T>(
 ) => {
   const buildingBlocks = INTERNAL_getBuildingBlocks(store)
   const registerAbortHandler = buildingBlocks[26]
+  const ctx = [...buildingBlocks, store] as const
   let continuablePromise = continuablePromiseMap.get(promise)
   if (!continuablePromise) {
     continuablePromise = new Promise<T>((resolve, reject) => {
@@ -85,7 +88,7 @@ const createContinuablePromise = <T>(
             continuablePromiseMap.set(nextValue, continuablePromise!)
             curr = nextValue
             nextValue.then(onFulfilled(nextValue), onRejected(nextValue))
-            registerAbortHandler(buildingBlocks, nextValue, onAbort)
+            registerAbortHandler(ctx, nextValue, onAbort)
           } else {
             resolve(nextValue)
           }
@@ -94,7 +97,7 @@ const createContinuablePromise = <T>(
         }
       }
       promise.then(onFulfilled(promise), onRejected(promise))
-      registerAbortHandler(buildingBlocks, promise, onAbort)
+      registerAbortHandler(ctx, promise, onAbort)
     })
     continuablePromiseMap.set(promise, continuablePromise)
   }

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -90,60 +90,63 @@ type ChangedAtoms = SetLike<AnyAtom>
 type Callbacks = SetLike<() => void>
 
 type AtomRead = <Value>(
-  ctx: Readonly<Context>,
+  ctx: BuildingBlockContext,
   atom: Atom<Value>,
   ...params: Parameters<Atom<Value>['read']>
 ) => Value
 type AtomWrite = <Value, Args extends unknown[], Result>(
-  ctx: Readonly<Context>,
+  ctx: BuildingBlockContext,
   atom: WritableAtom<Value, Args, Result>,
   ...params: Parameters<WritableAtom<Value, Args, Result>['write']>
 ) => Result
 type AtomOnInit = <Value>(
-  ctx: Readonly<Context>,
+  ctx: BuildingBlockContext,
   atom: Atom<Value> & WithOnInit,
 ) => void
 type AtomOnMount = <Value, Args extends unknown[], Result>(
-  ctx: Readonly<Context>,
+  ctx: BuildingBlockContext,
   atom: WritableAtom<Value, Args, Result> & WithOnMount<Args, Result>,
   setAtom: (...args: Args) => Result,
 ) => OnUnmount | void
 
 type EnsureAtomState = <Value>(
-  ctx: Readonly<Context>,
+  ctx: BuildingBlockContext,
   atom: Atom<Value>,
 ) => AtomState<Value>
-type FlushCallbacks = (ctx: Readonly<Context>) => void
-type RecomputeInvalidatedAtoms = (ctx: Readonly<Context>) => void
+type FlushCallbacks = (ctx: BuildingBlockContext) => void
+type RecomputeInvalidatedAtoms = (ctx: BuildingBlockContext) => void
 type ReadAtomState = <Value>(
-  ctx: Readonly<Context>,
+  ctx: BuildingBlockContext,
   atom: Atom<Value>,
 ) => AtomState<Value>
-type InvalidateDependents = (ctx: Readonly<Context>, atom: AnyAtom) => void
+type InvalidateDependents = (ctx: BuildingBlockContext, atom: AnyAtom) => void
 type WriteAtomState = <Value, Args extends unknown[], Result>(
-  ctx: Readonly<Context>,
+  ctx: BuildingBlockContext,
   atom: WritableAtom<Value, Args, Result>,
   ...args: Args
 ) => Result
-type MountDependencies = (ctx: Readonly<Context>, atom: AnyAtom) => void
-type MountAtom = <Value>(ctx: Readonly<Context>, atom: Atom<Value>) => Mounted
+type MountDependencies = (ctx: BuildingBlockContext, atom: AnyAtom) => void
+type MountAtom = <Value>(
+  ctx: BuildingBlockContext,
+  atom: Atom<Value>,
+) => Mounted
 type UnmountAtom = <Value>(
-  ctx: Readonly<Context>,
+  ctx: BuildingBlockContext,
   atom: Atom<Value>,
 ) => Mounted | undefined
 type SetAtomStateValueOrPromise = <Value>(
-  ctx: Readonly<Context>,
+  ctx: BuildingBlockContext,
   atom: Atom<Value>,
   valueOrPromise: Value,
 ) => void
-type StoreGet = <Value>(ctx: Readonly<Context>, atom: Atom<Value>) => Value
+type StoreGet = <Value>(ctx: BuildingBlockContext, atom: Atom<Value>) => Value
 type StoreSet = <Value, Args extends unknown[], Result>(
-  ctx: Readonly<Context>,
+  ctx: BuildingBlockContext,
   atom: WritableAtom<Value, Args, Result>,
   ...args: Args
 ) => Result
 type StoreSub = (
-  ctx: Readonly<Context>,
+  ctx: BuildingBlockContext,
   atom: AnyAtom,
   listener: () => void,
 ) => () => void
@@ -152,11 +155,14 @@ type EnhanceBuildingBlocks = (
 ) => Readonly<BuildingBlocks>
 type AbortHandlersMap = WeakMapLike<PromiseLike<unknown>, Set<() => void>>
 type RegisterAbortHandler = <T>(
-  ctx: Readonly<Context>,
+  ctx: BuildingBlockContext,
   promise: PromiseLike<T>,
   abortHandler: () => void,
 ) => void
-type AbortPromise = <T>(ctx: Readonly<Context>, promise: PromiseLike<T>) => void
+type AbortPromise = <T>(
+  ctx: BuildingBlockContext,
+  promise: PromiseLike<T>,
+) => void
 type StoreEpochHolder = [n: EpochNumber]
 
 type Store = {
@@ -206,7 +212,7 @@ type BuildingBlocks = [
   storeEpochHolder: StoreEpochHolder, //                       28
 ]
 
-type Context = [
+type BuildingBlockContext = readonly [
   ...BuildingBlocks,
   Store, //                                                    29
 ]
@@ -234,7 +240,6 @@ export type {
   UnmountAtom as INTERNAL_UnmountAtom,
   Store as INTERNAL_Store,
   BuildingBlocks as INTERNAL_BuildingBlocks,
-  Context as INTERNAL_Context,
   StoreHooks as INTERNAL_StoreHooks,
 }
 
@@ -1120,8 +1125,8 @@ function buildStore(...buildArgs: Partial<BuildingBlocks>): Store {
     BUILDING_BLOCK_abortPromise,
     [0], // store epoch
   ].map((bb, i) => buildArgs[i] || bb) as BuildingBlocks
-  const ctx: Context = [...buildingBlocks, store]
   buildingBlockMap.set(store, Object.freeze(buildingBlocks))
+  const ctx: BuildingBlockContext = Object.freeze([...buildingBlocks, store])
   const storeGet = ctx[21]
   const storeSet = ctx[22]
   const storeSub = ctx[23]

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -244,9 +244,7 @@ function hasInitialValue<T extends Atom<AnyValue>>(
   return 'init' in atom
 }
 
-function hasOnInit(
-  atom: AnyAtom,
-): atom is AnyAtom & {
+function hasOnInit(atom: AnyAtom): atom is AnyAtom & {
   INTERNAL_onInit: NonNullable<AnyAtom['INTERNAL_onInit']>
 } {
   return 'INTERNAL_onInit' in atom

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -145,7 +145,7 @@ type StoreSub = (
 ) => () => void
 type EnhanceBuildingBlocks = (
   buildingBlocks: Readonly<BuildingBlocks>,
-) => BuildingBlocks
+) => Readonly<BuildingBlocks>
 type AbortHandlersMap = WeakMapLike<PromiseLike<unknown>, Set<() => void>>
 type RegisterAbortHandler = <T>(
   ctx: Readonly<Context>,

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -244,6 +244,12 @@ function hasInitialValue<T extends Atom<AnyValue>>(
   return 'init' in atom
 }
 
+function hasOnInit<T extends Atom<AnyValue>>(
+  atom: T,
+): atom is T & { INTERNAL_onInit: Atom<AnyValue>['INTERNAL_onInit'] } {
+  return 'INTERNAL_onInit' in atom
+}
+
 function isActuallyWritableAtom(atom: AnyAtom): atom is AnyWritableAtom {
   return !!(atom as AnyWritableAtom).write
 }
@@ -403,17 +409,19 @@ const BUILDING_BLOCK_atomOnMount: AtomOnMount = (_ctx, atom, setAtom) =>
 
 const BUILDING_BLOCK_ensureAtomState: EnsureAtomState = (ctx, atom) => {
   const atomStateMap = ctx[0]
-  const storeHooks = ctx[6]
-  const atomOnInit = ctx[9]
   if (import.meta.env?.MODE !== 'production' && !atom) {
     throw new Error('Atom is undefined or null')
   }
   let atomState = atomStateMap.get(atom)
   if (!atomState) {
+    const storeHooks = ctx[6]
+    const atomOnInit = ctx[9]
     atomState = { d: new Map(), p: new Set(), n: 0 }
     atomStateMap.set(atom, atomState)
     storeHooks.i?.(atom)
-    atomOnInit?.(ctx, atom)
+    if (hasOnInit(atom)) {
+      atomOnInit(ctx, atom)
+    }
   }
   return atomState as never
 }

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -123,7 +123,7 @@ type InvalidateDependents = (ctx: BuildingBlockContext, atom: AnyAtom) => void
 type WriteAtomState = <Value, Args extends unknown[], Result>(
   ctx: BuildingBlockContext,
   atom: WritableAtom<Value, Args, Result>,
-  ...args: Args
+  args: Args
 ) => Result
 type MountDependencies = (ctx: BuildingBlockContext, atom: AnyAtom) => void
 type MountAtom = <Value>(
@@ -714,7 +714,7 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (ctx, atom) => {
           }
           if (!isSync) {
             try {
-              return writeAtomState(ctx, atom, ...args)
+              return writeAtomState(ctx, atom, args)
             } finally {
               recomputeInvalidatedAtoms(ctx)
               flushCallbacks(ctx)
@@ -788,7 +788,7 @@ const BUILDING_BLOCK_invalidateDependents: InvalidateDependents = (
   }
 }
 
-const BUILDING_BLOCK_writeAtomState: WriteAtomState = (ctx, atom, ...args) => {
+const BUILDING_BLOCK_writeAtomState: WriteAtomState = (ctx, atom, args) => {
   const store = ctx[29]
   const changedAtoms = ctx[3]
   const storeHooks = ctx[6]
@@ -831,7 +831,7 @@ const BUILDING_BLOCK_writeAtomState: WriteAtomState = (ctx, atom, ...args) => {
         }
         return undefined as R
       } else {
-        return writeAtomState(ctx, a, ...args)
+        return writeAtomState(ctx, a, args)
       }
     } finally {
       if (!isSync) {
@@ -914,7 +914,7 @@ const BUILDING_BLOCK_mountAtom: MountAtom = (ctx, atom) => {
         let isSync = true
         const setAtom = (...args: unknown[]) => {
           try {
-            return writeAtomState(ctx, atom, ...args)
+            return writeAtomState(ctx, atom, args)
           } finally {
             if (!isSync) {
               recomputeInvalidatedAtoms(ctx)
@@ -1022,7 +1022,7 @@ const BUILDING_BLOCK_storeSet: StoreSet = (ctx, atom, ...args) => {
   const writeAtomState = ctx[16]
   const prevChangedAtomsSize = changedAtoms.size
   try {
-    return writeAtomState(ctx, atom, ...args)
+    return writeAtomState(ctx, atom, args)
   } finally {
     if (changedAtoms.size !== prevChangedAtomsSize) {
       recomputeInvalidatedAtoms(ctx)

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -123,7 +123,7 @@ type InvalidateDependents = (ctx: BuildingBlockContext, atom: AnyAtom) => void
 type WriteAtomState = <Value, Args extends unknown[], Result>(
   ctx: BuildingBlockContext,
   atom: WritableAtom<Value, Args, Result>,
-  args: Args
+  args: Args,
 ) => Result
 type MountDependencies = (ctx: BuildingBlockContext, atom: AnyAtom) => void
 type MountAtom = <Value>(
@@ -241,6 +241,7 @@ export type {
   Store as INTERNAL_Store,
   BuildingBlocks as INTERNAL_BuildingBlocks,
   StoreHooks as INTERNAL_StoreHooks,
+  BuildingBlockContext as INTERNAL_BuildingBlockContext,
 }
 
 //
@@ -1084,7 +1085,7 @@ function getBuildingBlocks(store: Store): Readonly<BuildingBlocks> {
   return buildingBlocks
 }
 
-function buildStore(...buildArgs: Partial<BuildingBlocks>): Store {
+function buildStore(...partialBuildingBlocks: Partial<BuildingBlocks>): Store {
   const store: Store = {
     get: (atom) => storeGet(ctx, atom),
     set: (atom, ...args) => storeSet(ctx, atom, ...args),
@@ -1124,7 +1125,7 @@ function buildStore(...buildArgs: Partial<BuildingBlocks>): Store {
     BUILDING_BLOCK_registerAbortHandler,
     BUILDING_BLOCK_abortPromise,
     [0], // store epoch
-  ].map((bb, i) => buildArgs[i] || bb) as BuildingBlocks
+  ].map((bb, i) => partialBuildingBlocks[i] || bb) as BuildingBlocks
   buildingBlockMap.set(store, Object.freeze(buildingBlocks))
   const ctx: BuildingBlockContext = Object.freeze([...buildingBlocks, store])
   const storeGet = ctx[21]

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -89,74 +89,57 @@ type ChangedAtoms = SetLike<AnyAtom>
 type Callbacks = SetLike<() => void>
 
 type AtomRead = <Value>(
-  buildingBlocks: Readonly<BuildingBlocks>,
+  ctx: Readonly<Context>,
   atom: Atom<Value>,
   ...params: Parameters<Atom<Value>['read']>
 ) => Value
 type AtomWrite = <Value, Args extends unknown[], Result>(
-  buildingBlocks: Readonly<BuildingBlocks>,
+  ctx: Readonly<Context>,
   atom: WritableAtom<Value, Args, Result>,
   ...params: Parameters<WritableAtom<Value, Args, Result>['write']>
 ) => Result
-type AtomOnInit = <Value>(
-  buildingBlocks: Readonly<BuildingBlocks>,
-  atom: Atom<Value>,
-) => void
+type AtomOnInit = <Value>(ctx: Readonly<Context>, atom: Atom<Value>) => void
 type AtomOnMount = <Value, Args extends unknown[], Result>(
-  buildingBlocks: Readonly<BuildingBlocks>,
+  ctx: Readonly<Context>,
   atom: WritableAtomWithOnMount<Value, Args, Result>,
   setAtom: (...args: Args) => Result,
 ) => OnUnmount | void
 
 type EnsureAtomState = <Value>(
-  buildingBlocks: Readonly<BuildingBlocks>,
+  ctx: Readonly<Context>,
   atom: Atom<Value>,
 ) => AtomState<Value>
-type FlushCallbacks = (buildingBlocks: Readonly<BuildingBlocks>) => void
-type RecomputeInvalidatedAtoms = (
-  buildingBlocks: Readonly<BuildingBlocks>,
-) => void
+type FlushCallbacks = (ctx: Readonly<Context>) => void
+type RecomputeInvalidatedAtoms = (ctx: Readonly<Context>) => void
 type ReadAtomState = <Value>(
-  buildingBlocks: Readonly<BuildingBlocks>,
+  ctx: Readonly<Context>,
   atom: Atom<Value>,
 ) => AtomState<Value>
-type InvalidateDependents = (
-  buildingBlocks: Readonly<BuildingBlocks>,
-  atom: AnyAtom,
-) => void
+type InvalidateDependents = (ctx: Readonly<Context>, atom: AnyAtom) => void
 type WriteAtomState = <Value, Args extends unknown[], Result>(
-  buildingBlocks: Readonly<BuildingBlocks>,
+  ctx: Readonly<Context>,
   atom: WritableAtom<Value, Args, Result>,
   ...args: Args
 ) => Result
-type MountDependencies = (
-  buildingBlocks: Readonly<BuildingBlocks>,
-  atom: AnyAtom,
-) => void
-type MountAtom = <Value>(
-  buildingBlocks: Readonly<BuildingBlocks>,
-  atom: Atom<Value>,
-) => Mounted
+type MountDependencies = (ctx: Readonly<Context>, atom: AnyAtom) => void
+type MountAtom = <Value>(ctx: Readonly<Context>, atom: Atom<Value>) => Mounted
 type UnmountAtom = <Value>(
-  buildingBlocks: Readonly<BuildingBlocks>,
+  ctx: Readonly<Context>,
   atom: Atom<Value>,
 ) => Mounted | undefined
 type SetAtomStateValueOrPromise = <Value>(
-  buildingBlocks: Readonly<BuildingBlocks>,
+  ctx: Readonly<Context>,
   atom: Atom<Value>,
   valueOrPromise: Value,
 ) => void
-type StoreGet = <Value>(
-  buildingBlocks: Readonly<BuildingBlocks>,
-  atom: Atom<Value>,
-) => Value
+type StoreGet = <Value>(ctx: Readonly<Context>, atom: Atom<Value>) => Value
 type StoreSet = <Value, Args extends unknown[], Result>(
-  buildingBlocks: Readonly<BuildingBlocks>,
+  ctx: Readonly<Context>,
   atom: WritableAtom<Value, Args, Result>,
   ...args: Args
 ) => Result
 type StoreSub = (
-  buildingBlocks: Readonly<BuildingBlocks>,
+  ctx: Readonly<Context>,
   atom: AnyAtom,
   listener: () => void,
 ) => () => void
@@ -165,14 +148,11 @@ type EnhanceBuildingBlocks = (
 ) => BuildingBlocks
 type AbortHandlersMap = WeakMapLike<PromiseLike<unknown>, Set<() => void>>
 type RegisterAbortHandler = <T>(
-  buildingBlocks: Readonly<BuildingBlocks>,
+  ctx: Readonly<Context>,
   promise: PromiseLike<T>,
   abortHandler: () => void,
 ) => void
-type AbortPromise = <T>(
-  buildingBlocks: Readonly<BuildingBlocks>,
-  promise: PromiseLike<T>,
-) => void
+type AbortPromise = <T>(ctx: Readonly<Context>, promise: PromiseLike<T>) => void
 type StoreEpochHolder = [n: EpochNumber]
 
 type Store = {
@@ -220,7 +200,11 @@ type BuildingBlocks = [
   abortPromise: AbortPromise, //                               27
   // store epoch
   storeEpochHolder: StoreEpochHolder, //                       28
-  store: Store, //                                             29
+]
+
+type Context = [
+  ...BuildingBlocks,
+  Store, //                                                    29
 ]
 
 export type {
@@ -246,6 +230,7 @@ export type {
   UnmountAtom as INTERNAL_UnmountAtom,
   Store as INTERNAL_Store,
   BuildingBlocks as INTERNAL_BuildingBlocks,
+  Context as INTERNAL_Context,
   StoreHooks as INTERNAL_StoreHooks,
 }
 
@@ -405,30 +390,21 @@ function initializeStoreHooks(storeHooks: StoreHooks): Required<StoreHooks> {
 // Main functions
 //
 
-const BUILDING_BLOCK_atomRead: AtomRead = (_buildingBlocks, atom, ...params) =>
+const BUILDING_BLOCK_atomRead: AtomRead = (_ctx, atom, ...params) =>
   atom.read(...params)
-const BUILDING_BLOCK_atomWrite: AtomWrite = (
-  _buildingBlocks,
-  atom,
-  ...params
-) => atom.write(...params)
-const BUILDING_BLOCK_atomOnInit: AtomOnInit = (buildingBlocks, atom) => {
-  const store = buildingBlocks[29]
+const BUILDING_BLOCK_atomWrite: AtomWrite = (_ctx, atom, ...params) =>
+  atom.write(...params)
+const BUILDING_BLOCK_atomOnInit: AtomOnInit = (ctx, atom) => {
+  const store = ctx[29]
   atom.INTERNAL_onInit?.(store)
 }
-const BUILDING_BLOCK_atomOnMount: AtomOnMount = (
-  _buildingBlocks,
-  atom,
-  setAtom,
-) => atom.onMount?.(setAtom)
+const BUILDING_BLOCK_atomOnMount: AtomOnMount = (_ctx, atom, setAtom) =>
+  atom.onMount(setAtom)
 
-const BUILDING_BLOCK_ensureAtomState: EnsureAtomState = (
-  buildingBlocks,
-  atom,
-) => {
-  const atomStateMap = buildingBlocks[0]
-  const storeHooks = buildingBlocks[6]
-  const atomOnInit = buildingBlocks[9]
+const BUILDING_BLOCK_ensureAtomState: EnsureAtomState = (ctx, atom) => {
+  const atomStateMap = ctx[0]
+  const storeHooks = ctx[6]
+  const atomOnInit = ctx[9]
   if (import.meta.env?.MODE !== 'production' && !atom) {
     throw new Error('Atom is undefined or null')
   }
@@ -437,18 +413,18 @@ const BUILDING_BLOCK_ensureAtomState: EnsureAtomState = (
     atomState = { d: new Map(), p: new Set(), n: 0 }
     atomStateMap.set(atom, atomState)
     storeHooks.i?.(atom)
-    atomOnInit?.(buildingBlocks, atom)
+    atomOnInit?.(ctx, atom)
   }
   return atomState as never
 }
 
-const BUILDING_BLOCK_flushCallbacks: FlushCallbacks = (buildingBlocks) => {
-  const mountedMap = buildingBlocks[1]
-  const changedAtoms = buildingBlocks[3]
-  const mountCallbacks = buildingBlocks[4]
-  const unmountCallbacks = buildingBlocks[5]
-  const storeHooks = buildingBlocks[6]
-  const recomputeInvalidatedAtoms = buildingBlocks[13]
+const BUILDING_BLOCK_flushCallbacks: FlushCallbacks = (ctx) => {
+  const mountedMap = ctx[1]
+  const changedAtoms = ctx[3]
+  const mountCallbacks = ctx[4]
+  const unmountCallbacks = ctx[5]
+  const storeHooks = ctx[6]
+  const recomputeInvalidatedAtoms = ctx[13]
   if (
     !storeHooks.f &&
     !changedAtoms.size &&
@@ -491,7 +467,7 @@ const BUILDING_BLOCK_flushCallbacks: FlushCallbacks = (buildingBlocks) => {
       call(fn)
     }
     if (changedAtoms.size) {
-      recomputeInvalidatedAtoms(buildingBlocks)
+      recomputeInvalidatedAtoms(ctx)
     }
   } while (changedAtoms.size || unmountCallbacks.size || mountCallbacks.size)
   if (errors.length) {
@@ -500,14 +476,14 @@ const BUILDING_BLOCK_flushCallbacks: FlushCallbacks = (buildingBlocks) => {
 }
 
 const BUILDING_BLOCK_recomputeInvalidatedAtoms: RecomputeInvalidatedAtoms = (
-  buildingBlocks,
+  ctx,
 ) => {
-  const mountedMap = buildingBlocks[1]
-  const invalidatedAtoms = buildingBlocks[2]
-  const changedAtoms = buildingBlocks[3]
-  const ensureAtomState = buildingBlocks[11]
-  const readAtomState = buildingBlocks[14]
-  const mountDependencies = buildingBlocks[17]
+  const mountedMap = ctx[1]
+  const invalidatedAtoms = ctx[2]
+  const changedAtoms = ctx[3]
+  const ensureAtomState = ctx[11]
+  const readAtomState = ctx[14]
+  const mountDependencies = ctx[17]
   if (!changedAtoms.size) {
     return
   }
@@ -526,7 +502,7 @@ const BUILDING_BLOCK_recomputeInvalidatedAtoms: RecomputeInvalidatedAtoms = (
   // without incoming edges, which is one reason we can simplify the algorithm
   for (const atom of changedAtoms) {
     stackAtoms.push(atom)
-    stackStates.push(ensureAtomState(buildingBlocks, atom))
+    stackStates.push(ensureAtomState(ctx, atom))
   }
   while (stackAtoms.length) {
     const top = stackAtoms.length - 1
@@ -562,7 +538,7 @@ const BUILDING_BLOCK_recomputeInvalidatedAtoms: RecomputeInvalidatedAtoms = (
     for (const d of getMountedOrPendingDependents(a, aState, mountedMap)) {
       if (!visiting.has(d)) {
         stackAtoms.push(d)
-        stackStates.push(ensureAtomState(buildingBlocks, d))
+        stackStates.push(ensureAtomState(ctx, d))
       }
     }
   }
@@ -580,8 +556,8 @@ const BUILDING_BLOCK_recomputeInvalidatedAtoms: RecomputeInvalidatedAtoms = (
     }
     if (hasChangedDeps) {
       invalidatedAtoms.set(a, aState.n)
-      readAtomState(buildingBlocks, a)
-      mountDependencies(buildingBlocks, a)
+      readAtomState(ctx, a)
+      mountDependencies(ctx, a)
     }
     invalidatedAtoms.delete(a)
   }
@@ -590,23 +566,23 @@ const BUILDING_BLOCK_recomputeInvalidatedAtoms: RecomputeInvalidatedAtoms = (
 // Dev only
 const storeMutationSet = new WeakSet<Store>()
 
-const BUILDING_BLOCK_readAtomState: ReadAtomState = (buildingBlocks, atom) => {
-  const store = buildingBlocks[29]
-  const mountedMap = buildingBlocks[1]
-  const invalidatedAtoms = buildingBlocks[2]
-  const changedAtoms = buildingBlocks[3]
-  const storeHooks = buildingBlocks[6]
-  const atomRead = buildingBlocks[7]
-  const ensureAtomState = buildingBlocks[11]
-  const flushCallbacks = buildingBlocks[12]
-  const recomputeInvalidatedAtoms = buildingBlocks[13]
-  const readAtomState = buildingBlocks[14]
-  const writeAtomState = buildingBlocks[16]
-  const mountDependencies = buildingBlocks[17]
-  const setAtomStateValueOrPromise = buildingBlocks[20]
-  const registerAbortHandler = buildingBlocks[26]
-  const storeEpochHolder = buildingBlocks[28]
-  const atomState = ensureAtomState(buildingBlocks, atom)
+const BUILDING_BLOCK_readAtomState: ReadAtomState = (ctx, atom) => {
+  const store = ctx[29]
+  const mountedMap = ctx[1]
+  const invalidatedAtoms = ctx[2]
+  const changedAtoms = ctx[3]
+  const storeHooks = ctx[6]
+  const atomRead = ctx[7]
+  const ensureAtomState = ctx[11]
+  const flushCallbacks = ctx[12]
+  const recomputeInvalidatedAtoms = ctx[13]
+  const readAtomState = ctx[14]
+  const writeAtomState = ctx[16]
+  const mountDependencies = ctx[17]
+  const setAtomStateValueOrPromise = ctx[20]
+  const registerAbortHandler = ctx[26]
+  const storeEpochHolder = ctx[28]
+  const atomState = ensureAtomState(ctx, atom)
   const storeEpochNumber = storeEpochHolder[0]
   // See if we can skip recomputing this atom.
   if (isAtomStateInitialized(atomState)) {
@@ -626,7 +602,7 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (buildingBlocks, atom) => {
     // If all dependencies haven't changed, we can use the cache.
     let hasChangedDeps = false
     for (const [a, n] of atomState.d) {
-      if (readAtomState(buildingBlocks, a).n !== n) {
+      if (readAtomState(ctx, a).n !== n) {
         hasChangedDeps = true
         break
       }
@@ -648,19 +624,19 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (buildingBlocks, atom) => {
     if (mountedMap.has(atom)) {
       // If changedAtoms is already populated, an outer recompute cycle will handle it
       const shouldRecompute = !changedAtoms.size
-      mountDependencies(buildingBlocks, atom)
+      mountDependencies(ctx, atom)
       if (shouldRecompute) {
-        recomputeInvalidatedAtoms(buildingBlocks)
-        flushCallbacks(buildingBlocks)
+        recomputeInvalidatedAtoms(ctx)
+        flushCallbacks(ctx)
       }
     }
   }
   const getter = <V>(a: Atom<V>) => {
     if (a === (atom as AnyAtom)) {
-      const aState = ensureAtomState(buildingBlocks, a)
+      const aState = ensureAtomState(ctx, a)
       if (!isAtomStateInitialized(aState)) {
         if (hasInitialValue(a)) {
-          setAtomStateValueOrPromise(buildingBlocks, a, a.init)
+          setAtomStateValueOrPromise(ctx, a, a.init)
         } else {
           // NOTE invalid derived atoms can reach here
           throw new Error('no atom init')
@@ -669,7 +645,7 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (buildingBlocks, atom) => {
       return returnAtomValue(aState)
     }
     // a !== atom
-    const aState = readAtomState(buildingBlocks, a)
+    const aState = readAtomState(ctx, a)
     try {
       return returnAtomValue(aState)
     } finally {
@@ -715,10 +691,10 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (buildingBlocks, atom) => {
           }
           if (!isSync) {
             try {
-              return writeAtomState(buildingBlocks, atom, ...args)
+              return writeAtomState(ctx, atom, ...args)
             } finally {
-              recomputeInvalidatedAtoms(buildingBlocks)
-              flushCallbacks(buildingBlocks)
+              recomputeInvalidatedAtoms(ctx)
+              flushCallbacks(ctx)
             }
           }
         }
@@ -732,22 +708,15 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (buildingBlocks, atom) => {
     if (import.meta.env?.MODE !== 'production') {
       storeMutationSet.delete(store)
     }
-    const valueOrPromise = atomRead(
-      buildingBlocks,
-      atom,
-      getter,
-      options as never,
-    )
+    const valueOrPromise = atomRead(ctx, atom, getter, options as never)
     if (import.meta.env?.MODE !== 'production' && storeMutationSet.has(store)) {
       console.warn(
         'Detected store mutation during atom read. This is not supported.',
       )
     }
-    setAtomStateValueOrPromise(buildingBlocks, atom, valueOrPromise)
+    setAtomStateValueOrPromise(ctx, atom, valueOrPromise)
     if (isPromiseLike(valueOrPromise)) {
-      registerAbortHandler(buildingBlocks, valueOrPromise, () =>
-        controller?.abort(),
-      )
+      registerAbortHandler(ctx, valueOrPromise, () => controller?.abort())
       const settle = () => {
         pruneDependencies()
         mountDependenciesIfAsync()
@@ -776,18 +745,18 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (buildingBlocks, atom) => {
 }
 
 const BUILDING_BLOCK_invalidateDependents: InvalidateDependents = (
-  buildingBlocks,
+  ctx,
   atom,
 ) => {
-  const mountedMap = buildingBlocks[1]
-  const invalidatedAtoms = buildingBlocks[2]
-  const ensureAtomState = buildingBlocks[11]
+  const mountedMap = ctx[1]
+  const invalidatedAtoms = ctx[2]
+  const ensureAtomState = ctx[11]
   const stack: AnyAtom[] = [atom]
   while (stack.length) {
     const a = stack.pop()!
-    const aState = ensureAtomState(buildingBlocks, a)
+    const aState = ensureAtomState(ctx, a)
     for (const d of getMountedOrPendingDependents(a, aState, mountedMap)) {
-      const dState = ensureAtomState(buildingBlocks, d)
+      const dState = ensureAtomState(ctx, d)
       if (invalidatedAtoms.get(d) !== dState.n) {
         invalidatedAtoms.set(d, dState.n)
         stack.push(d)
@@ -796,32 +765,28 @@ const BUILDING_BLOCK_invalidateDependents: InvalidateDependents = (
   }
 }
 
-const BUILDING_BLOCK_writeAtomState: WriteAtomState = (
-  buildingBlocks,
-  atom,
-  ...args
-) => {
-  const store = buildingBlocks[29]
-  const changedAtoms = buildingBlocks[3]
-  const storeHooks = buildingBlocks[6]
-  const atomWrite = buildingBlocks[8]
-  const ensureAtomState = buildingBlocks[11]
-  const flushCallbacks = buildingBlocks[12]
-  const recomputeInvalidatedAtoms = buildingBlocks[13]
-  const readAtomState = buildingBlocks[14]
-  const invalidateDependents = buildingBlocks[15]
-  const writeAtomState = buildingBlocks[16]
-  const mountDependencies = buildingBlocks[17]
-  const setAtomStateValueOrPromise = buildingBlocks[20]
-  const storeEpochHolder = buildingBlocks[28]
+const BUILDING_BLOCK_writeAtomState: WriteAtomState = (ctx, atom, ...args) => {
+  const store = ctx[29]
+  const changedAtoms = ctx[3]
+  const storeHooks = ctx[6]
+  const atomWrite = ctx[8]
+  const ensureAtomState = ctx[11]
+  const flushCallbacks = ctx[12]
+  const recomputeInvalidatedAtoms = ctx[13]
+  const readAtomState = ctx[14]
+  const invalidateDependents = ctx[15]
+  const writeAtomState = ctx[16]
+  const mountDependencies = ctx[17]
+  const setAtomStateValueOrPromise = ctx[20]
+  const storeEpochHolder = ctx[28]
   let isSync = true
   const getter: Getter = <V>(a: Atom<V>) =>
-    returnAtomValue(readAtomState(buildingBlocks, a))
+    returnAtomValue(readAtomState(ctx, a))
   const setter: Setter = <V, As extends unknown[], R>(
     a: WritableAtom<V, As, R>,
     ...args: As
   ) => {
-    const aState = ensureAtomState(buildingBlocks, a)
+    const aState = ensureAtomState(ctx, a)
     try {
       if (a === (atom as AnyAtom)) {
         if (!hasInitialValue(a)) {
@@ -833,55 +798,52 @@ const BUILDING_BLOCK_writeAtomState: WriteAtomState = (
         }
         const prevEpochNumber = aState.n
         const v = args[0] as V
-        setAtomStateValueOrPromise(buildingBlocks, a, v)
-        mountDependencies(buildingBlocks, a)
+        setAtomStateValueOrPromise(ctx, a, v)
+        mountDependencies(ctx, a)
         if (prevEpochNumber !== aState.n) {
           ++storeEpochHolder[0]
           changedAtoms.add(a)
-          invalidateDependents(buildingBlocks, a)
+          invalidateDependents(ctx, a)
           storeHooks.c?.(a)
         }
         return undefined as R
       } else {
-        return writeAtomState(buildingBlocks, a, ...args)
+        return writeAtomState(ctx, a, ...args)
       }
     } finally {
       if (!isSync) {
-        recomputeInvalidatedAtoms(buildingBlocks)
-        flushCallbacks(buildingBlocks)
+        recomputeInvalidatedAtoms(ctx)
+        flushCallbacks(ctx)
       }
     }
   }
   try {
-    return atomWrite(buildingBlocks, atom, getter, setter, ...args)
+    return atomWrite(ctx, atom, getter, setter, ...args)
   } finally {
     isSync = false
   }
 }
 
-const BUILDING_BLOCK_mountDependencies: MountDependencies = (
-  buildingBlocks,
-  atom,
-) => {
-  const mountedMap = buildingBlocks[1]
-  const changedAtoms = buildingBlocks[3]
-  const storeHooks = buildingBlocks[6]
-  const ensureAtomState = buildingBlocks[11]
-  const invalidateDependents = buildingBlocks[15]
-  const mountAtom = buildingBlocks[18]
-  const unmountAtom = buildingBlocks[19]
-  const atomState = ensureAtomState(buildingBlocks, atom)
+const BUILDING_BLOCK_mountDependencies: MountDependencies = (ctx, atom) => {
+  const mountedMap = ctx[1]
+  const changedAtoms = ctx[3]
+  const storeHooks = ctx[6]
+  const ensureAtomState = ctx[11]
+  const invalidateDependents = ctx[15]
+  const mountAtom = ctx[18]
+  const unmountAtom = ctx[19]
+  const atomState = ensureAtomState(ctx, atom)
   const mounted = mountedMap.get(atom)
   if (mounted && atomState.d.size > 0) {
     for (const [a, n] of atomState.d) {
       if (!mounted.d.has(a)) {
-        const aState = ensureAtomState(buildingBlocks, a)
-        const aMounted = mountAtom(buildingBlocks, a)
+        const aState = ensureAtomState(ctx, a)
+        const aMounted = mountAtom(ctx, a)
         aMounted.t.add(atom)
         mounted.d.add(a)
         if (n !== aState.n) {
           changedAtoms.add(a)
-          invalidateDependents(buildingBlocks, a)
+          invalidateDependents(ctx, a)
           storeHooks.c?.(a)
         }
       }
@@ -889,32 +851,32 @@ const BUILDING_BLOCK_mountDependencies: MountDependencies = (
     for (const a of mounted.d) {
       if (!atomState.d.has(a)) {
         mounted.d.delete(a)
-        const aMounted = unmountAtom(buildingBlocks, a)
+        const aMounted = unmountAtom(ctx, a)
         aMounted?.t.delete(atom)
       }
     }
   }
 }
 
-const BUILDING_BLOCK_mountAtom: MountAtom = (buildingBlocks, atom) => {
-  const mountedMap = buildingBlocks[1]
-  const mountCallbacks = buildingBlocks[4]
-  const storeHooks = buildingBlocks[6]
-  const atomOnMount = buildingBlocks[10]
-  const ensureAtomState = buildingBlocks[11]
-  const flushCallbacks = buildingBlocks[12]
-  const recomputeInvalidatedAtoms = buildingBlocks[13]
-  const readAtomState = buildingBlocks[14]
-  const writeAtomState = buildingBlocks[16]
-  const mountAtom = buildingBlocks[18]
-  const atomState = ensureAtomState(buildingBlocks, atom)
+const BUILDING_BLOCK_mountAtom: MountAtom = (ctx, atom) => {
+  const mountedMap = ctx[1]
+  const mountCallbacks = ctx[4]
+  const storeHooks = ctx[6]
+  const atomOnMount = ctx[10]
+  const ensureAtomState = ctx[11]
+  const flushCallbacks = ctx[12]
+  const recomputeInvalidatedAtoms = ctx[13]
+  const readAtomState = ctx[14]
+  const writeAtomState = ctx[16]
+  const mountAtom = ctx[18]
+  const atomState = ensureAtomState(ctx, atom)
   let mounted = mountedMap.get(atom)
   if (!mounted) {
     // recompute atom state
-    readAtomState(buildingBlocks, atom)
+    readAtomState(ctx, atom)
     // mount dependencies first
     for (const a of atomState.d.keys()) {
-      const aMounted = mountAtom(buildingBlocks, a)
+      const aMounted = mountAtom(ctx, a)
       aMounted.t.add(atom)
     }
     // mount self
@@ -929,16 +891,16 @@ const BUILDING_BLOCK_mountAtom: MountAtom = (buildingBlocks, atom) => {
         let isSync = true
         const setAtom = (...args: unknown[]) => {
           try {
-            return writeAtomState(buildingBlocks, atom, ...args)
+            return writeAtomState(ctx, atom, ...args)
           } finally {
             if (!isSync) {
-              recomputeInvalidatedAtoms(buildingBlocks)
-              flushCallbacks(buildingBlocks)
+              recomputeInvalidatedAtoms(ctx)
+              flushCallbacks(ctx)
             }
           }
         }
         try {
-          const onUnmount = atomOnMount(buildingBlocks, atom, setAtom)
+          const onUnmount = atomOnMount(ctx, atom, setAtom)
           if (onUnmount) {
             mounted!.u = () => {
               isSync = true
@@ -960,13 +922,13 @@ const BUILDING_BLOCK_mountAtom: MountAtom = (buildingBlocks, atom) => {
   return mounted
 }
 
-const BUILDING_BLOCK_unmountAtom: UnmountAtom = (buildingBlocks, atom) => {
-  const mountedMap = buildingBlocks[1]
-  const unmountCallbacks = buildingBlocks[5]
-  const storeHooks = buildingBlocks[6]
-  const ensureAtomState = buildingBlocks[11]
-  const unmountAtom = buildingBlocks[19]
-  const atomState = ensureAtomState(buildingBlocks, atom)
+const BUILDING_BLOCK_unmountAtom: UnmountAtom = (ctx, atom) => {
+  const mountedMap = ctx[1]
+  const unmountCallbacks = ctx[5]
+  const storeHooks = ctx[6]
+  const ensureAtomState = ctx[11]
+  const unmountAtom = ctx[19]
+  const atomState = ensureAtomState(ctx, atom)
   let mounted = mountedMap.get(atom)
   if (!mounted || mounted.l.size) {
     return mounted
@@ -987,7 +949,7 @@ const BUILDING_BLOCK_unmountAtom: UnmountAtom = (buildingBlocks, atom) => {
     mountedMap.delete(atom)
     // unmount dependencies
     for (const a of atomState.d.keys()) {
-      const aMounted = unmountAtom(buildingBlocks, a)
+      const aMounted = unmountAtom(ctx, a)
       aMounted?.t.delete(atom)
     }
     storeHooks.u?.(atom)
@@ -997,13 +959,13 @@ const BUILDING_BLOCK_unmountAtom: UnmountAtom = (buildingBlocks, atom) => {
 }
 
 const BUILDING_BLOCK_setAtomStateValueOrPromise: SetAtomStateValueOrPromise = (
-  buildingBlocks,
+  ctx,
   atom,
   valueOrPromise,
 ) => {
-  const ensureAtomState = buildingBlocks[11]
-  const abortPromise = buildingBlocks[27]
-  const atomState = ensureAtomState(buildingBlocks, atom)
+  const ensureAtomState = ctx[11]
+  const abortPromise = ctx[27]
+  const atomState = ensureAtomState(ctx, atom)
   const hasPrevValue = 'v' in atomState
   const prevValue = atomState.v
   if (isPromiseLike(valueOrPromise)) {
@@ -1011,7 +973,7 @@ const BUILDING_BLOCK_setAtomStateValueOrPromise: SetAtomStateValueOrPromise = (
       addPendingPromiseToDependency(
         atom,
         valueOrPromise,
-        ensureAtomState(buildingBlocks, a),
+        ensureAtomState(ctx, a),
       )
     }
   }
@@ -1020,53 +982,53 @@ const BUILDING_BLOCK_setAtomStateValueOrPromise: SetAtomStateValueOrPromise = (
   if (!hasPrevValue || !Object.is(prevValue, atomState.v)) {
     ++atomState.n
     if (isPromiseLike(prevValue)) {
-      abortPromise(buildingBlocks, prevValue)
+      abortPromise(ctx, prevValue)
     }
   }
 }
 
-const BUILDING_BLOCK_storeGet: StoreGet = (buildingBlocks, atom) => {
-  const readAtomState = buildingBlocks[14]
-  return returnAtomValue(readAtomState(buildingBlocks, atom))
+const BUILDING_BLOCK_storeGet: StoreGet = (ctx, atom) => {
+  const readAtomState = ctx[14]
+  return returnAtomValue(readAtomState(ctx, atom))
 }
 
-const BUILDING_BLOCK_storeSet: StoreSet = (buildingBlocks, atom, ...args) => {
-  const changedAtoms = buildingBlocks[3]
-  const flushCallbacks = buildingBlocks[12]
-  const recomputeInvalidatedAtoms = buildingBlocks[13]
-  const writeAtomState = buildingBlocks[16]
+const BUILDING_BLOCK_storeSet: StoreSet = (ctx, atom, ...args) => {
+  const changedAtoms = ctx[3]
+  const flushCallbacks = ctx[12]
+  const recomputeInvalidatedAtoms = ctx[13]
+  const writeAtomState = ctx[16]
   const prevChangedAtomsSize = changedAtoms.size
   try {
-    return writeAtomState(buildingBlocks, atom, ...args)
+    return writeAtomState(ctx, atom, ...args)
   } finally {
     if (changedAtoms.size !== prevChangedAtomsSize) {
-      recomputeInvalidatedAtoms(buildingBlocks)
-      flushCallbacks(buildingBlocks)
+      recomputeInvalidatedAtoms(ctx)
+      flushCallbacks(ctx)
     }
   }
 }
 
-const BUILDING_BLOCK_storeSub: StoreSub = (buildingBlocks, atom, listener) => {
-  const flushCallbacks = buildingBlocks[12]
-  const mountAtom = buildingBlocks[18]
-  const unmountAtom = buildingBlocks[19]
-  const mounted = mountAtom(buildingBlocks, atom)
+const BUILDING_BLOCK_storeSub: StoreSub = (ctx, atom, listener) => {
+  const flushCallbacks = ctx[12]
+  const mountAtom = ctx[18]
+  const unmountAtom = ctx[19]
+  const mounted = mountAtom(ctx, atom)
   const listeners = mounted.l
   listeners.add(listener)
-  flushCallbacks(buildingBlocks)
+  flushCallbacks(ctx)
   return () => {
     listeners.delete(listener)
-    unmountAtom(buildingBlocks, atom)
-    flushCallbacks(buildingBlocks)
+    unmountAtom(ctx, atom)
+    flushCallbacks(ctx)
   }
 }
 
 const BUILDING_BLOCK_registerAbortHandler: RegisterAbortHandler = (
-  buildingBlocks,
+  ctx,
   promise,
   abortHandler,
 ) => {
-  const abortHandlersMap = buildingBlocks[25]
+  const abortHandlersMap = ctx[25]
   let abortHandlers = abortHandlersMap.get(promise)
   if (!abortHandlers) {
     abortHandlers = new Set()
@@ -1077,8 +1039,8 @@ const BUILDING_BLOCK_registerAbortHandler: RegisterAbortHandler = (
   abortHandlers.add(abortHandler)
 }
 
-const BUILDING_BLOCK_abortPromise: AbortPromise = (buildingBlocks, promise) => {
-  const abortHandlersMap = buildingBlocks[25]
+const BUILDING_BLOCK_abortPromise: AbortPromise = (ctx, promise) => {
+  const abortHandlersMap = ctx[25]
   const abortHandlers = abortHandlersMap.get(promise)
   abortHandlers?.forEach((fn) => fn())
 }
@@ -1101,9 +1063,9 @@ function getBuildingBlocks(store: Store): BuildingBlocks {
 
 function buildStore(...buildArgs: Partial<BuildingBlocks>): Store {
   const store: Store = {
-    get: (atom) => storeGet(buildingBlocks, atom),
-    set: (atom, ...args) => storeSet(buildingBlocks, atom, ...args),
-    sub: (atom, listener) => storeSub(buildingBlocks, atom, listener),
+    get: (atom) => storeGet(ctx, atom),
+    set: (atom, ...args) => storeSet(ctx, atom, ...args),
+    sub: (atom, listener) => storeSub(ctx, atom, listener),
   }
   const buildingBlocks = [
     // store state
@@ -1140,11 +1102,11 @@ function buildStore(...buildArgs: Partial<BuildingBlocks>): Store {
     BUILDING_BLOCK_abortPromise,
     [0], // store epoch
   ].map((bb, i) => buildArgs[i] || bb) as BuildingBlocks
-  buildingBlocks[29] = store // overwrite the store slot with the actual store
+  const ctx: Context = [...buildingBlocks, store]
   buildingBlockMap.set(store, Object.freeze(buildingBlocks))
-  const storeGet = buildingBlocks[21]
-  const storeSet = buildingBlocks[22]
-  const storeSub = buildingBlocks[23]
+  const storeGet = ctx[21]
+  const storeSet = ctx[22]
+  const storeSub = ctx[23]
   return store
 }
 

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -1055,7 +1055,7 @@ const BUILDING_BLOCK_abortPromise: AbortPromise = (ctx, promise) => {
 
 const buildingBlockMap = new WeakMap<Store, Readonly<BuildingBlocks>>()
 
-function getBuildingBlocks(store: Store): BuildingBlocks {
+function getBuildingBlocks(store: Store): Readonly<BuildingBlocks> {
   const buildingBlocks = buildingBlockMap.get(store)!
   if (import.meta.env?.MODE !== 'production' && !buildingBlocks) {
     throw new Error(
@@ -1066,7 +1066,7 @@ function getBuildingBlocks(store: Store): BuildingBlocks {
   if (enhanceBuildingBlocks) {
     return enhanceBuildingBlocks(buildingBlocks)
   }
-  return [...buildingBlocks]
+  return buildingBlocks
 }
 
 function buildStore(...buildArgs: Partial<BuildingBlocks>): Store {

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -89,70 +89,90 @@ type ChangedAtoms = SetLike<AnyAtom>
 type Callbacks = SetLike<() => void>
 
 type AtomRead = <Value>(
-  store: Store,
+  buildingBlocks: Readonly<BuildingBlocks>,
   atom: Atom<Value>,
   ...params: Parameters<Atom<Value>['read']>
 ) => Value
 type AtomWrite = <Value, Args extends unknown[], Result>(
-  store: Store,
+  buildingBlocks: Readonly<BuildingBlocks>,
   atom: WritableAtom<Value, Args, Result>,
   ...params: Parameters<WritableAtom<Value, Args, Result>['write']>
 ) => Result
-type AtomOnInit = <Value>(store: Store, atom: Atom<Value>) => void
+type AtomOnInit = <Value>(
+  buildingBlocks: Readonly<BuildingBlocks>,
+  atom: Atom<Value>,
+) => void
 type AtomOnMount = <Value, Args extends unknown[], Result>(
-  store: Store,
+  buildingBlocks: Readonly<BuildingBlocks>,
   atom: WritableAtomWithOnMount<Value, Args, Result>,
   setAtom: (...args: Args) => Result,
 ) => OnUnmount | void
 
 type EnsureAtomState = <Value>(
-  store: Store,
+  buildingBlocks: Readonly<BuildingBlocks>,
   atom: Atom<Value>,
 ) => AtomState<Value>
-type FlushCallbacks = (store: Store) => void
-type RecomputeInvalidatedAtoms = (store: Store) => void
+type FlushCallbacks = (buildingBlocks: Readonly<BuildingBlocks>) => void
+type RecomputeInvalidatedAtoms = (
+  buildingBlocks: Readonly<BuildingBlocks>,
+) => void
 type ReadAtomState = <Value>(
-  store: Store,
+  buildingBlocks: Readonly<BuildingBlocks>,
   atom: Atom<Value>,
 ) => AtomState<Value>
-type InvalidateDependents = (store: Store, atom: AnyAtom) => void
+type InvalidateDependents = (
+  buildingBlocks: Readonly<BuildingBlocks>,
+  atom: AnyAtom,
+) => void
 type WriteAtomState = <Value, Args extends unknown[], Result>(
-  store: Store,
+  buildingBlocks: Readonly<BuildingBlocks>,
   atom: WritableAtom<Value, Args, Result>,
   ...args: Args
 ) => Result
-type MountDependencies = (store: Store, atom: AnyAtom) => void
-type MountAtom = <Value>(store: Store, atom: Atom<Value>) => Mounted
+type MountDependencies = (
+  buildingBlocks: Readonly<BuildingBlocks>,
+  atom: AnyAtom,
+) => void
+type MountAtom = <Value>(
+  buildingBlocks: Readonly<BuildingBlocks>,
+  atom: Atom<Value>,
+) => Mounted
 type UnmountAtom = <Value>(
-  store: Store,
+  buildingBlocks: Readonly<BuildingBlocks>,
   atom: Atom<Value>,
 ) => Mounted | undefined
 type SetAtomStateValueOrPromise = <Value>(
-  store: Store,
+  buildingBlocks: Readonly<BuildingBlocks>,
   atom: Atom<Value>,
   valueOrPromise: Value,
 ) => void
-type StoreGet = <Value>(store: Store, atom: Atom<Value>) => Value
+type StoreGet = <Value>(
+  buildingBlocks: Readonly<BuildingBlocks>,
+  atom: Atom<Value>,
+) => Value
 type StoreSet = <Value, Args extends unknown[], Result>(
-  store: Store,
+  buildingBlocks: Readonly<BuildingBlocks>,
   atom: WritableAtom<Value, Args, Result>,
   ...args: Args
 ) => Result
 type StoreSub = (
-  store: Store,
+  buildingBlocks: Readonly<BuildingBlocks>,
   atom: AnyAtom,
   listener: () => void,
 ) => () => void
 type EnhanceBuildingBlocks = (
   buildingBlocks: Readonly<BuildingBlocks>,
-) => Readonly<BuildingBlocks>
+) => BuildingBlocks
 type AbortHandlersMap = WeakMapLike<PromiseLike<unknown>, Set<() => void>>
 type RegisterAbortHandler = <T>(
-  store: Store,
+  buildingBlocks: Readonly<BuildingBlocks>,
   promise: PromiseLike<T>,
   abortHandler: () => void,
 ) => void
-type AbortPromise = <T>(store: Store, promise: PromiseLike<T>) => void
+type AbortPromise = <T>(
+  buildingBlocks: Readonly<BuildingBlocks>,
+  promise: PromiseLike<T>,
+) => void
 type StoreEpochHolder = [n: EpochNumber]
 
 type Store = {
@@ -200,6 +220,7 @@ type BuildingBlocks = [
   abortPromise: AbortPromise, //                               27
   // store epoch
   storeEpochHolder: StoreEpochHolder, //                       28
+  store: Store, //                                             29
 ]
 
 export type {
@@ -384,17 +405,27 @@ function initializeStoreHooks(storeHooks: StoreHooks): Required<StoreHooks> {
 // Main functions
 //
 
-const BUILDING_BLOCK_atomRead: AtomRead = (_store, atom, ...params) =>
+const BUILDING_BLOCK_atomRead: AtomRead = (_buildingBlocks, atom, ...params) =>
   atom.read(...params)
-const BUILDING_BLOCK_atomWrite: AtomWrite = (_store, atom, ...params) =>
-  atom.write(...params)
-const BUILDING_BLOCK_atomOnInit: AtomOnInit = (store, atom) =>
+const BUILDING_BLOCK_atomWrite: AtomWrite = (
+  _buildingBlocks,
+  atom,
+  ...params
+) => atom.write(...params)
+const BUILDING_BLOCK_atomOnInit: AtomOnInit = (buildingBlocks, atom) => {
+  const store = buildingBlocks[29]
   atom.INTERNAL_onInit?.(store)
-const BUILDING_BLOCK_atomOnMount: AtomOnMount = (_store, atom, setAtom) =>
-  atom.onMount?.(setAtom)
+}
+const BUILDING_BLOCK_atomOnMount: AtomOnMount = (
+  _buildingBlocks,
+  atom,
+  setAtom,
+) => atom.onMount?.(setAtom)
 
-const BUILDING_BLOCK_ensureAtomState: EnsureAtomState = (store, atom) => {
-  const buildingBlocks = getInternalBuildingBlocks(store)
+const BUILDING_BLOCK_ensureAtomState: EnsureAtomState = (
+  buildingBlocks,
+  atom,
+) => {
   const atomStateMap = buildingBlocks[0]
   const storeHooks = buildingBlocks[6]
   const atomOnInit = buildingBlocks[9]
@@ -406,13 +437,12 @@ const BUILDING_BLOCK_ensureAtomState: EnsureAtomState = (store, atom) => {
     atomState = { d: new Map(), p: new Set(), n: 0 }
     atomStateMap.set(atom, atomState)
     storeHooks.i?.(atom)
-    atomOnInit?.(store, atom)
+    atomOnInit?.(buildingBlocks, atom)
   }
   return atomState as never
 }
 
-const BUILDING_BLOCK_flushCallbacks: FlushCallbacks = (store) => {
-  const buildingBlocks = getInternalBuildingBlocks(store)
+const BUILDING_BLOCK_flushCallbacks: FlushCallbacks = (buildingBlocks) => {
   const mountedMap = buildingBlocks[1]
   const changedAtoms = buildingBlocks[3]
   const mountCallbacks = buildingBlocks[4]
@@ -461,7 +491,7 @@ const BUILDING_BLOCK_flushCallbacks: FlushCallbacks = (store) => {
       call(fn)
     }
     if (changedAtoms.size) {
-      recomputeInvalidatedAtoms(store)
+      recomputeInvalidatedAtoms(buildingBlocks)
     }
   } while (changedAtoms.size || unmountCallbacks.size || mountCallbacks.size)
   if (errors.length) {
@@ -470,9 +500,8 @@ const BUILDING_BLOCK_flushCallbacks: FlushCallbacks = (store) => {
 }
 
 const BUILDING_BLOCK_recomputeInvalidatedAtoms: RecomputeInvalidatedAtoms = (
-  store,
+  buildingBlocks,
 ) => {
-  const buildingBlocks = getInternalBuildingBlocks(store)
   const mountedMap = buildingBlocks[1]
   const invalidatedAtoms = buildingBlocks[2]
   const changedAtoms = buildingBlocks[3]
@@ -497,7 +526,7 @@ const BUILDING_BLOCK_recomputeInvalidatedAtoms: RecomputeInvalidatedAtoms = (
   // without incoming edges, which is one reason we can simplify the algorithm
   for (const atom of changedAtoms) {
     stackAtoms.push(atom)
-    stackStates.push(ensureAtomState(store, atom))
+    stackStates.push(ensureAtomState(buildingBlocks, atom))
   }
   while (stackAtoms.length) {
     const top = stackAtoms.length - 1
@@ -533,7 +562,7 @@ const BUILDING_BLOCK_recomputeInvalidatedAtoms: RecomputeInvalidatedAtoms = (
     for (const d of getMountedOrPendingDependents(a, aState, mountedMap)) {
       if (!visiting.has(d)) {
         stackAtoms.push(d)
-        stackStates.push(ensureAtomState(store, d))
+        stackStates.push(ensureAtomState(buildingBlocks, d))
       }
     }
   }
@@ -551,8 +580,8 @@ const BUILDING_BLOCK_recomputeInvalidatedAtoms: RecomputeInvalidatedAtoms = (
     }
     if (hasChangedDeps) {
       invalidatedAtoms.set(a, aState.n)
-      readAtomState(store, a)
-      mountDependencies(store, a)
+      readAtomState(buildingBlocks, a)
+      mountDependencies(buildingBlocks, a)
     }
     invalidatedAtoms.delete(a)
   }
@@ -561,8 +590,8 @@ const BUILDING_BLOCK_recomputeInvalidatedAtoms: RecomputeInvalidatedAtoms = (
 // Dev only
 const storeMutationSet = new WeakSet<Store>()
 
-const BUILDING_BLOCK_readAtomState: ReadAtomState = (store, atom) => {
-  const buildingBlocks = getInternalBuildingBlocks(store)
+const BUILDING_BLOCK_readAtomState: ReadAtomState = (buildingBlocks, atom) => {
+  const store = buildingBlocks[29]
   const mountedMap = buildingBlocks[1]
   const invalidatedAtoms = buildingBlocks[2]
   const changedAtoms = buildingBlocks[3]
@@ -577,7 +606,7 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (store, atom) => {
   const setAtomStateValueOrPromise = buildingBlocks[20]
   const registerAbortHandler = buildingBlocks[26]
   const storeEpochHolder = buildingBlocks[28]
-  const atomState = ensureAtomState(store, atom)
+  const atomState = ensureAtomState(buildingBlocks, atom)
   const storeEpochNumber = storeEpochHolder[0]
   // See if we can skip recomputing this atom.
   if (isAtomStateInitialized(atomState)) {
@@ -597,7 +626,7 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (store, atom) => {
     // If all dependencies haven't changed, we can use the cache.
     let hasChangedDeps = false
     for (const [a, n] of atomState.d) {
-      if (readAtomState(store, a).n !== n) {
+      if (readAtomState(buildingBlocks, a).n !== n) {
         hasChangedDeps = true
         break
       }
@@ -619,19 +648,19 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (store, atom) => {
     if (mountedMap.has(atom)) {
       // If changedAtoms is already populated, an outer recompute cycle will handle it
       const shouldRecompute = !changedAtoms.size
-      mountDependencies(store, atom)
+      mountDependencies(buildingBlocks, atom)
       if (shouldRecompute) {
-        recomputeInvalidatedAtoms(store)
-        flushCallbacks(store)
+        recomputeInvalidatedAtoms(buildingBlocks)
+        flushCallbacks(buildingBlocks)
       }
     }
   }
   const getter = <V>(a: Atom<V>) => {
     if (a === (atom as AnyAtom)) {
-      const aState = ensureAtomState(store, a)
+      const aState = ensureAtomState(buildingBlocks, a)
       if (!isAtomStateInitialized(aState)) {
         if (hasInitialValue(a)) {
-          setAtomStateValueOrPromise(store, a, a.init)
+          setAtomStateValueOrPromise(buildingBlocks, a, a.init)
         } else {
           // NOTE invalid derived atoms can reach here
           throw new Error('no atom init')
@@ -640,7 +669,7 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (store, atom) => {
       return returnAtomValue(aState)
     }
     // a !== atom
-    const aState = readAtomState(store, a)
+    const aState = readAtomState(buildingBlocks, a)
     try {
       return returnAtomValue(aState)
     } finally {
@@ -686,10 +715,10 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (store, atom) => {
           }
           if (!isSync) {
             try {
-              return writeAtomState(store, atom, ...args)
+              return writeAtomState(buildingBlocks, atom, ...args)
             } finally {
-              recomputeInvalidatedAtoms(store)
-              flushCallbacks(store)
+              recomputeInvalidatedAtoms(buildingBlocks)
+              flushCallbacks(buildingBlocks)
             }
           }
         }
@@ -703,15 +732,22 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (store, atom) => {
     if (import.meta.env?.MODE !== 'production') {
       storeMutationSet.delete(store)
     }
-    const valueOrPromise = atomRead(store, atom, getter, options as never)
+    const valueOrPromise = atomRead(
+      buildingBlocks,
+      atom,
+      getter,
+      options as never,
+    )
     if (import.meta.env?.MODE !== 'production' && storeMutationSet.has(store)) {
       console.warn(
         'Detected store mutation during atom read. This is not supported.',
       )
     }
-    setAtomStateValueOrPromise(store, atom, valueOrPromise)
+    setAtomStateValueOrPromise(buildingBlocks, atom, valueOrPromise)
     if (isPromiseLike(valueOrPromise)) {
-      registerAbortHandler(store, valueOrPromise, () => controller?.abort())
+      registerAbortHandler(buildingBlocks, valueOrPromise, () =>
+        controller?.abort(),
+      )
       const settle = () => {
         pruneDependencies()
         mountDependenciesIfAsync()
@@ -740,19 +776,18 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (store, atom) => {
 }
 
 const BUILDING_BLOCK_invalidateDependents: InvalidateDependents = (
-  store,
+  buildingBlocks,
   atom,
 ) => {
-  const buildingBlocks = getInternalBuildingBlocks(store)
   const mountedMap = buildingBlocks[1]
   const invalidatedAtoms = buildingBlocks[2]
   const ensureAtomState = buildingBlocks[11]
   const stack: AnyAtom[] = [atom]
   while (stack.length) {
     const a = stack.pop()!
-    const aState = ensureAtomState(store, a)
+    const aState = ensureAtomState(buildingBlocks, a)
     for (const d of getMountedOrPendingDependents(a, aState, mountedMap)) {
-      const dState = ensureAtomState(store, d)
+      const dState = ensureAtomState(buildingBlocks, d)
       if (invalidatedAtoms.get(d) !== dState.n) {
         invalidatedAtoms.set(d, dState.n)
         stack.push(d)
@@ -762,11 +797,11 @@ const BUILDING_BLOCK_invalidateDependents: InvalidateDependents = (
 }
 
 const BUILDING_BLOCK_writeAtomState: WriteAtomState = (
-  store,
+  buildingBlocks,
   atom,
   ...args
 ) => {
-  const buildingBlocks = getInternalBuildingBlocks(store)
+  const store = buildingBlocks[29]
   const changedAtoms = buildingBlocks[3]
   const storeHooks = buildingBlocks[6]
   const atomWrite = buildingBlocks[8]
@@ -781,12 +816,12 @@ const BUILDING_BLOCK_writeAtomState: WriteAtomState = (
   const storeEpochHolder = buildingBlocks[28]
   let isSync = true
   const getter: Getter = <V>(a: Atom<V>) =>
-    returnAtomValue(readAtomState(store, a))
+    returnAtomValue(readAtomState(buildingBlocks, a))
   const setter: Setter = <V, As extends unknown[], R>(
     a: WritableAtom<V, As, R>,
     ...args: As
   ) => {
-    const aState = ensureAtomState(store, a)
+    const aState = ensureAtomState(buildingBlocks, a)
     try {
       if (a === (atom as AnyAtom)) {
         if (!hasInitialValue(a)) {
@@ -798,34 +833,36 @@ const BUILDING_BLOCK_writeAtomState: WriteAtomState = (
         }
         const prevEpochNumber = aState.n
         const v = args[0] as V
-        setAtomStateValueOrPromise(store, a, v)
-        mountDependencies(store, a)
+        setAtomStateValueOrPromise(buildingBlocks, a, v)
+        mountDependencies(buildingBlocks, a)
         if (prevEpochNumber !== aState.n) {
           ++storeEpochHolder[0]
           changedAtoms.add(a)
-          invalidateDependents(store, a)
+          invalidateDependents(buildingBlocks, a)
           storeHooks.c?.(a)
         }
         return undefined as R
       } else {
-        return writeAtomState(store, a, ...args)
+        return writeAtomState(buildingBlocks, a, ...args)
       }
     } finally {
       if (!isSync) {
-        recomputeInvalidatedAtoms(store)
-        flushCallbacks(store)
+        recomputeInvalidatedAtoms(buildingBlocks)
+        flushCallbacks(buildingBlocks)
       }
     }
   }
   try {
-    return atomWrite(store, atom, getter, setter, ...args)
+    return atomWrite(buildingBlocks, atom, getter, setter, ...args)
   } finally {
     isSync = false
   }
 }
 
-const BUILDING_BLOCK_mountDependencies: MountDependencies = (store, atom) => {
-  const buildingBlocks = getInternalBuildingBlocks(store)
+const BUILDING_BLOCK_mountDependencies: MountDependencies = (
+  buildingBlocks,
+  atom,
+) => {
   const mountedMap = buildingBlocks[1]
   const changedAtoms = buildingBlocks[3]
   const storeHooks = buildingBlocks[6]
@@ -833,18 +870,18 @@ const BUILDING_BLOCK_mountDependencies: MountDependencies = (store, atom) => {
   const invalidateDependents = buildingBlocks[15]
   const mountAtom = buildingBlocks[18]
   const unmountAtom = buildingBlocks[19]
-  const atomState = ensureAtomState(store, atom)
+  const atomState = ensureAtomState(buildingBlocks, atom)
   const mounted = mountedMap.get(atom)
   if (mounted && atomState.d.size > 0) {
     for (const [a, n] of atomState.d) {
       if (!mounted.d.has(a)) {
-        const aState = ensureAtomState(store, a)
-        const aMounted = mountAtom(store, a)
+        const aState = ensureAtomState(buildingBlocks, a)
+        const aMounted = mountAtom(buildingBlocks, a)
         aMounted.t.add(atom)
         mounted.d.add(a)
         if (n !== aState.n) {
           changedAtoms.add(a)
-          invalidateDependents(store, a)
+          invalidateDependents(buildingBlocks, a)
           storeHooks.c?.(a)
         }
       }
@@ -852,15 +889,14 @@ const BUILDING_BLOCK_mountDependencies: MountDependencies = (store, atom) => {
     for (const a of mounted.d) {
       if (!atomState.d.has(a)) {
         mounted.d.delete(a)
-        const aMounted = unmountAtom(store, a)
+        const aMounted = unmountAtom(buildingBlocks, a)
         aMounted?.t.delete(atom)
       }
     }
   }
 }
 
-const BUILDING_BLOCK_mountAtom: MountAtom = (store, atom) => {
-  const buildingBlocks = getInternalBuildingBlocks(store)
+const BUILDING_BLOCK_mountAtom: MountAtom = (buildingBlocks, atom) => {
   const mountedMap = buildingBlocks[1]
   const mountCallbacks = buildingBlocks[4]
   const storeHooks = buildingBlocks[6]
@@ -871,14 +907,14 @@ const BUILDING_BLOCK_mountAtom: MountAtom = (store, atom) => {
   const readAtomState = buildingBlocks[14]
   const writeAtomState = buildingBlocks[16]
   const mountAtom = buildingBlocks[18]
-  const atomState = ensureAtomState(store, atom)
+  const atomState = ensureAtomState(buildingBlocks, atom)
   let mounted = mountedMap.get(atom)
   if (!mounted) {
     // recompute atom state
-    readAtomState(store, atom)
+    readAtomState(buildingBlocks, atom)
     // mount dependencies first
     for (const a of atomState.d.keys()) {
-      const aMounted = mountAtom(store, a)
+      const aMounted = mountAtom(buildingBlocks, a)
       aMounted.t.add(atom)
     }
     // mount self
@@ -893,16 +929,16 @@ const BUILDING_BLOCK_mountAtom: MountAtom = (store, atom) => {
         let isSync = true
         const setAtom = (...args: unknown[]) => {
           try {
-            return writeAtomState(store, atom, ...args)
+            return writeAtomState(buildingBlocks, atom, ...args)
           } finally {
             if (!isSync) {
-              recomputeInvalidatedAtoms(store)
-              flushCallbacks(store)
+              recomputeInvalidatedAtoms(buildingBlocks)
+              flushCallbacks(buildingBlocks)
             }
           }
         }
         try {
-          const onUnmount = atomOnMount(store, atom, setAtom)
+          const onUnmount = atomOnMount(buildingBlocks, atom, setAtom)
           if (onUnmount) {
             mounted!.u = () => {
               isSync = true
@@ -924,14 +960,13 @@ const BUILDING_BLOCK_mountAtom: MountAtom = (store, atom) => {
   return mounted
 }
 
-const BUILDING_BLOCK_unmountAtom: UnmountAtom = (store, atom) => {
-  const buildingBlocks = getInternalBuildingBlocks(store)
+const BUILDING_BLOCK_unmountAtom: UnmountAtom = (buildingBlocks, atom) => {
   const mountedMap = buildingBlocks[1]
   const unmountCallbacks = buildingBlocks[5]
   const storeHooks = buildingBlocks[6]
   const ensureAtomState = buildingBlocks[11]
   const unmountAtom = buildingBlocks[19]
-  const atomState = ensureAtomState(store, atom)
+  const atomState = ensureAtomState(buildingBlocks, atom)
   let mounted = mountedMap.get(atom)
   if (!mounted || mounted.l.size) {
     return mounted
@@ -952,7 +987,7 @@ const BUILDING_BLOCK_unmountAtom: UnmountAtom = (store, atom) => {
     mountedMap.delete(atom)
     // unmount dependencies
     for (const a of atomState.d.keys()) {
-      const aMounted = unmountAtom(store, a)
+      const aMounted = unmountAtom(buildingBlocks, a)
       aMounted?.t.delete(atom)
     }
     storeHooks.u?.(atom)
@@ -962,14 +997,13 @@ const BUILDING_BLOCK_unmountAtom: UnmountAtom = (store, atom) => {
 }
 
 const BUILDING_BLOCK_setAtomStateValueOrPromise: SetAtomStateValueOrPromise = (
-  store,
+  buildingBlocks,
   atom,
   valueOrPromise,
 ) => {
-  const buildingBlocks = getInternalBuildingBlocks(store)
   const ensureAtomState = buildingBlocks[11]
   const abortPromise = buildingBlocks[27]
-  const atomState = ensureAtomState(store, atom)
+  const atomState = ensureAtomState(buildingBlocks, atom)
   const hasPrevValue = 'v' in atomState
   const prevValue = atomState.v
   if (isPromiseLike(valueOrPromise)) {
@@ -977,7 +1011,7 @@ const BUILDING_BLOCK_setAtomStateValueOrPromise: SetAtomStateValueOrPromise = (
       addPendingPromiseToDependency(
         atom,
         valueOrPromise,
-        ensureAtomState(store, a),
+        ensureAtomState(buildingBlocks, a),
       )
     }
   }
@@ -986,55 +1020,52 @@ const BUILDING_BLOCK_setAtomStateValueOrPromise: SetAtomStateValueOrPromise = (
   if (!hasPrevValue || !Object.is(prevValue, atomState.v)) {
     ++atomState.n
     if (isPromiseLike(prevValue)) {
-      abortPromise(store, prevValue)
+      abortPromise(buildingBlocks, prevValue)
     }
   }
 }
 
-const BUILDING_BLOCK_storeGet: StoreGet = (store, atom) => {
-  const readAtomState = getInternalBuildingBlocks(store)[14]
-  return returnAtomValue(readAtomState(store, atom))
+const BUILDING_BLOCK_storeGet: StoreGet = (buildingBlocks, atom) => {
+  const readAtomState = buildingBlocks[14]
+  return returnAtomValue(readAtomState(buildingBlocks, atom))
 }
 
-const BUILDING_BLOCK_storeSet: StoreSet = (store, atom, ...args) => {
-  const buildingBlocks = getInternalBuildingBlocks(store)
+const BUILDING_BLOCK_storeSet: StoreSet = (buildingBlocks, atom, ...args) => {
   const changedAtoms = buildingBlocks[3]
   const flushCallbacks = buildingBlocks[12]
   const recomputeInvalidatedAtoms = buildingBlocks[13]
   const writeAtomState = buildingBlocks[16]
   const prevChangedAtomsSize = changedAtoms.size
   try {
-    return writeAtomState(store, atom, ...args)
+    return writeAtomState(buildingBlocks, atom, ...args)
   } finally {
     if (changedAtoms.size !== prevChangedAtomsSize) {
-      recomputeInvalidatedAtoms(store)
-      flushCallbacks(store)
+      recomputeInvalidatedAtoms(buildingBlocks)
+      flushCallbacks(buildingBlocks)
     }
   }
 }
 
-const BUILDING_BLOCK_storeSub: StoreSub = (store, atom, listener) => {
-  const buildingBlocks = getInternalBuildingBlocks(store)
+const BUILDING_BLOCK_storeSub: StoreSub = (buildingBlocks, atom, listener) => {
   const flushCallbacks = buildingBlocks[12]
   const mountAtom = buildingBlocks[18]
   const unmountAtom = buildingBlocks[19]
-  const mounted = mountAtom(store, atom)
+  const mounted = mountAtom(buildingBlocks, atom)
   const listeners = mounted.l
   listeners.add(listener)
-  flushCallbacks(store)
+  flushCallbacks(buildingBlocks)
   return () => {
     listeners.delete(listener)
-    unmountAtom(store, atom)
-    flushCallbacks(store)
+    unmountAtom(buildingBlocks, atom)
+    flushCallbacks(buildingBlocks)
   }
 }
 
 const BUILDING_BLOCK_registerAbortHandler: RegisterAbortHandler = (
-  store,
+  buildingBlocks,
   promise,
   abortHandler,
 ) => {
-  const buildingBlocks = getInternalBuildingBlocks(store)
   const abortHandlersMap = buildingBlocks[25]
   let abortHandlers = abortHandlersMap.get(promise)
   if (!abortHandlers) {
@@ -1046,8 +1077,7 @@ const BUILDING_BLOCK_registerAbortHandler: RegisterAbortHandler = (
   abortHandlers.add(abortHandler)
 }
 
-const BUILDING_BLOCK_abortPromise: AbortPromise = (store, promise) => {
-  const buildingBlocks = getInternalBuildingBlocks(store)
+const BUILDING_BLOCK_abortPromise: AbortPromise = (buildingBlocks, promise) => {
   const abortHandlersMap = buildingBlocks[25]
   const abortHandlers = abortHandlersMap.get(promise)
   abortHandlers?.forEach((fn) => fn())
@@ -1055,80 +1085,66 @@ const BUILDING_BLOCK_abortPromise: AbortPromise = (store, promise) => {
 
 const buildingBlockMap = new WeakMap<Store, Readonly<BuildingBlocks>>()
 
-const getInternalBuildingBlocks = (store: Store): Readonly<BuildingBlocks> => {
+function getBuildingBlocks(store: Store): BuildingBlocks {
   const buildingBlocks = buildingBlockMap.get(store)!
   if (import.meta.env?.MODE !== 'production' && !buildingBlocks) {
     throw new Error(
       'Store must be created by buildStore to read its building blocks',
     )
   }
-  return buildingBlocks
-}
-
-function getBuildingBlocks(store: Store): Readonly<BuildingBlocks> {
-  const buildingBlocks = getInternalBuildingBlocks(store)
   const enhanceBuildingBlocks = buildingBlocks[24]
   if (enhanceBuildingBlocks) {
     return enhanceBuildingBlocks(buildingBlocks)
   }
-  return buildingBlocks
+  return [...buildingBlocks]
 }
 
 function buildStore(...buildArgs: Partial<BuildingBlocks>): Store {
-  const store = {
-    get(atom) {
-      const storeGet = getInternalBuildingBlocks(store)[21]
-      return storeGet(store, atom)
-    },
-    set(atom, ...args) {
-      const storeSet = getInternalBuildingBlocks(store)[22]
-      return storeSet(store, atom, ...args)
-    },
-    sub(atom, listener) {
-      const storeSub = getInternalBuildingBlocks(store)[23]
-      return storeSub(store, atom, listener)
-    },
-  } as Store
-
-  const buildingBlocks = (
-    [
-      // store state
-      new WeakMap(), // atomStateMap
-      new WeakMap(), // mountedMap
-      new WeakMap(), // invalidatedAtoms
-      new Set(), // changedAtoms
-      new Set(), // mountCallbacks
-      new Set(), // unmountCallbacks
-      {}, // storeHooks
-      // atom interceptors
-      BUILDING_BLOCK_atomRead,
-      BUILDING_BLOCK_atomWrite,
-      BUILDING_BLOCK_atomOnInit,
-      BUILDING_BLOCK_atomOnMount,
-      // building-block functions
-      BUILDING_BLOCK_ensureAtomState,
-      BUILDING_BLOCK_flushCallbacks,
-      BUILDING_BLOCK_recomputeInvalidatedAtoms,
-      BUILDING_BLOCK_readAtomState,
-      BUILDING_BLOCK_invalidateDependents,
-      BUILDING_BLOCK_writeAtomState,
-      BUILDING_BLOCK_mountDependencies,
-      BUILDING_BLOCK_mountAtom,
-      BUILDING_BLOCK_unmountAtom,
-      BUILDING_BLOCK_setAtomStateValueOrPromise,
-      BUILDING_BLOCK_storeGet,
-      BUILDING_BLOCK_storeSet,
-      BUILDING_BLOCK_storeSub,
-      undefined,
-      // abortable promise support
-      new WeakMap(), // abortHandlersMap
-      BUILDING_BLOCK_registerAbortHandler,
-      BUILDING_BLOCK_abortPromise,
-      // store epoch
-      [0],
-    ] satisfies BuildingBlocks
-  ).map((fn, i) => buildArgs[i] || fn) as BuildingBlocks
+  const store: Store = {
+    get: (atom) => storeGet(buildingBlocks, atom),
+    set: (atom, ...args) => storeSet(buildingBlocks, atom, ...args),
+    sub: (atom, listener) => storeSub(buildingBlocks, atom, listener),
+  }
+  const buildingBlocks = [
+    // store state
+    new WeakMap(), // atomStateMap
+    new WeakMap(), // mountedMap
+    new WeakMap(), // invalidatedAtoms
+    new Set(), // changedAtoms
+    new Set(), // mountCallbacks
+    new Set(), // unmountCallbacks
+    {}, // storeHooks
+    // atom interceptors
+    BUILDING_BLOCK_atomRead,
+    BUILDING_BLOCK_atomWrite,
+    BUILDING_BLOCK_atomOnInit,
+    BUILDING_BLOCK_atomOnMount,
+    // building-block functions
+    BUILDING_BLOCK_ensureAtomState,
+    BUILDING_BLOCK_flushCallbacks,
+    BUILDING_BLOCK_recomputeInvalidatedAtoms,
+    BUILDING_BLOCK_readAtomState,
+    BUILDING_BLOCK_invalidateDependents,
+    BUILDING_BLOCK_writeAtomState,
+    BUILDING_BLOCK_mountDependencies,
+    BUILDING_BLOCK_mountAtom,
+    BUILDING_BLOCK_unmountAtom,
+    BUILDING_BLOCK_setAtomStateValueOrPromise,
+    BUILDING_BLOCK_storeGet,
+    BUILDING_BLOCK_storeSet,
+    BUILDING_BLOCK_storeSub,
+    undefined,
+    // abortable promise support
+    new WeakMap(), // abortHandlersMap
+    BUILDING_BLOCK_registerAbortHandler,
+    BUILDING_BLOCK_abortPromise,
+    [0], // store epoch
+  ].map((bb, i) => buildArgs[i] || bb) as BuildingBlocks
+  buildingBlocks[29] = store // overwrite the store slot with the actual store
   buildingBlockMap.set(store, Object.freeze(buildingBlocks))
+  const storeGet = buildingBlocks[21]
+  const storeSet = buildingBlocks[22]
+  const storeSub = buildingBlocks[23]
   return store
 }
 

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -244,9 +244,11 @@ function hasInitialValue<T extends Atom<AnyValue>>(
   return 'init' in atom
 }
 
-function hasOnInit<T extends Atom<AnyValue>>(
-  atom: T,
-): atom is T & { INTERNAL_onInit: Atom<AnyValue>['INTERNAL_onInit'] } {
+function hasOnInit(
+  atom: AnyAtom,
+): atom is AnyAtom & {
+  INTERNAL_onInit: NonNullable<AnyAtom['INTERNAL_onInit']>
+} {
   return 'INTERNAL_onInit' in atom
 }
 
@@ -260,7 +262,7 @@ function hasOnMount<Value, Args extends unknown[], Result>(
   return !!atom.onMount
 }
 
-function isAtomStateInitialized<Value>(atomState: AtomState<Value>): boolean {
+function isAtomStateInitialized(atomState: AtomState<AnyValue>): boolean {
   return 'v' in atomState || 'e' in atomState
 }
 

--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -1,17 +1,18 @@
 // Internal functions (subject to change without notice)
 // In case you rely on them, be sure to pin the version
 
-import { type Atom, type WritableAtom } from './atom.ts'
+import type { Atom, WritableAtom } from './atom.ts'
+import type { ExtractAtomArgs, ExtractAtomResult } from './typeUtils.ts'
 
 type AnyValue = unknown
 type AnyError = unknown
 type AnyAtom = Atom<AnyValue>
 type AnyWritableAtom = WritableAtom<AnyValue, unknown[], unknown>
-type WritableAtomWithOnMount<Value, Args extends unknown[], Result> = Omit<
-  WritableAtom<Value, Args, Result>,
-  'onMount'
-> & {
-  onMount: NonNullable<WritableAtom<Value, Args, Result>['onMount']>
+type WithOnMount<Args extends unknown[], Result> = {
+  onMount: NonNullable<WritableAtom<AnyValue, Args, Result>['onMount']>
+}
+type WithOnInit = {
+  INTERNAL_onInit: NonNullable<Atom<AnyValue>['INTERNAL_onInit']>
 }
 type OnUnmount = () => void
 type Getter = Parameters<AnyAtom['read']>[0]
@@ -98,10 +99,13 @@ type AtomWrite = <Value, Args extends unknown[], Result>(
   atom: WritableAtom<Value, Args, Result>,
   ...params: Parameters<WritableAtom<Value, Args, Result>['write']>
 ) => Result
-type AtomOnInit = <Value>(ctx: Readonly<Context>, atom: Atom<Value>) => void
+type AtomOnInit = <Value>(
+  ctx: Readonly<Context>,
+  atom: Atom<Value> & WithOnInit,
+) => void
 type AtomOnMount = <Value, Args extends unknown[], Result>(
   ctx: Readonly<Context>,
-  atom: WritableAtomWithOnMount<Value, Args, Result>,
+  atom: WritableAtom<Value, Args, Result> & WithOnMount<Args, Result>,
   setAtom: (...args: Args) => Result,
 ) => OnUnmount | void
 
@@ -238,25 +242,32 @@ export type {
 // Some util functions
 //
 
-function hasInitialValue<T extends Atom<AnyValue>>(
+function hasInitialValue<T extends AnyAtom>(
   atom: T,
 ): atom is T & (T extends Atom<infer Value> ? { init: Value } : never) {
   return 'init' in atom
 }
 
-function hasOnInit(atom: AnyAtom): atom is AnyAtom & {
-  INTERNAL_onInit: NonNullable<AnyAtom['INTERNAL_onInit']>
-} {
-  return 'INTERNAL_onInit' in atom
+type ActuallyWritableAtom<T extends AnyAtom> =
+  T extends WritableAtom<infer V, infer A, infer R>
+    ? T & WritableAtom<V, A, R>
+    : T extends Atom<infer V>
+      ? T & WritableAtom<V, unknown[], unknown>
+      : never
+
+function isActuallyWritableAtom<T extends AnyAtom>(
+  atom: T,
+): atom is ActuallyWritableAtom<T> {
+  return typeof (atom as { write?: unknown }).write === 'function'
 }
 
-function isActuallyWritableAtom(atom: AnyAtom): atom is AnyWritableAtom {
-  return !!(atom as AnyWritableAtom).write
+function hasOnInit<T extends AnyAtom>(atom: T): atom is T & WithOnInit {
+  return !!atom.INTERNAL_onInit
 }
 
-function hasOnMount<Value, Args extends unknown[], Result>(
-  atom: WritableAtom<Value, Args, Result>,
-): atom is WritableAtomWithOnMount<Value, Args, Result> {
+function hasOnMount<T extends AnyWritableAtom>(
+  atom: T,
+): atom is T & WithOnMount<ExtractAtomArgs<T>, ExtractAtomResult<T>> {
   return !!atom.onMount
 }
 
@@ -402,11 +413,10 @@ const BUILDING_BLOCK_atomWrite: AtomWrite = (_ctx, atom, ...params) =>
   atom.write(...params)
 const BUILDING_BLOCK_atomOnInit: AtomOnInit = (ctx, atom) => {
   const store = ctx[29]
-  atom.INTERNAL_onInit?.(store)
+  atom.INTERNAL_onInit(store)
 }
 const BUILDING_BLOCK_atomOnMount: AtomOnMount = (_ctx, atom, setAtom) =>
   atom.onMount(setAtom)
-
 const BUILDING_BLOCK_ensureAtomState: EnsureAtomState = (ctx, atom) => {
   const atomStateMap = ctx[0]
   if (import.meta.env?.MODE !== 'production' && !atom) {

--- a/tests/vanilla/internals.test.tsx
+++ b/tests/vanilla/internals.test.tsx
@@ -4,7 +4,6 @@ import type {
   INTERNAL_AtomState,
   INTERNAL_AtomStateMap,
   INTERNAL_BuildingBlocks,
-  INTERNAL_Context,
   INTERNAL_InvalidatedAtoms,
 } from 'jotai/vanilla/internals'
 import {
@@ -216,7 +215,7 @@ describe('internals', () => {
     const unsub = store.sub(leafAtom, () => {})
     const internalBuildingBlocks = INTERNAL_getBuildingBlocks(store)
     const invalidateDependents = internalBuildingBlocks[15]
-    const ctx = [...internalBuildingBlocks, store] as INTERNAL_Context
+    const ctx = [...internalBuildingBlocks, store] as const
     expect(() => invalidateDependents(ctx, baseAtom)).not.toThrow()
     unsub()
   })

--- a/tests/vanilla/internals.test.tsx
+++ b/tests/vanilla/internals.test.tsx
@@ -12,7 +12,7 @@ import {
   INTERNAL_initializeStoreHooksRev2 as INTERNAL_initializeStoreHooks,
 } from 'jotai/vanilla/internals'
 
-const buildingBlockLength = 29
+const buildingBlockLength = 30
 
 describe('internals', () => {
   it('should not return a sparse building blocks array', () => {
@@ -213,8 +213,11 @@ describe('internals', () => {
     const leafAtom = atom((get) => get(midAtom1) + get(midAtom2))
 
     const unsub = store.sub(leafAtom, () => {})
-    const invalidateDependents = INTERNAL_getBuildingBlocks(store)[15]
-    expect(() => invalidateDependents(store, baseAtom)).not.toThrow()
+    const internalBuildingBlocks = INTERNAL_getBuildingBlocks(store)
+    const invalidateDependents = internalBuildingBlocks[15]
+    expect(() =>
+      invalidateDependents(internalBuildingBlocks, baseAtom),
+    ).not.toThrow()
     unsub()
   })
 })

--- a/tests/vanilla/internals.test.tsx
+++ b/tests/vanilla/internals.test.tsx
@@ -4,6 +4,7 @@ import type {
   INTERNAL_AtomState,
   INTERNAL_AtomStateMap,
   INTERNAL_BuildingBlocks,
+  INTERNAL_Context,
   INTERNAL_InvalidatedAtoms,
 } from 'jotai/vanilla/internals'
 import {
@@ -12,7 +13,7 @@ import {
   INTERNAL_initializeStoreHooksRev2 as INTERNAL_initializeStoreHooks,
 } from 'jotai/vanilla/internals'
 
-const buildingBlockLength = 30
+const buildingBlockLength = 29
 
 describe('internals', () => {
   it('should not return a sparse building blocks array', () => {
@@ -215,9 +216,8 @@ describe('internals', () => {
     const unsub = store.sub(leafAtom, () => {})
     const internalBuildingBlocks = INTERNAL_getBuildingBlocks(store)
     const invalidateDependents = internalBuildingBlocks[15]
-    expect(() =>
-      invalidateDependents(internalBuildingBlocks, baseAtom),
-    ).not.toThrow()
+    const ctx = [...internalBuildingBlocks, store] as INTERNAL_Context
+    expect(() => invalidateDependents(ctx, baseAtom)).not.toThrow()
     unsub()
   })
 })


### PR DESCRIPTION
## Summary
Since 2.14.0, the building block architecture relies on passing the store as the first parameter to internal functions. This store was used as a WeakMap key to access building blocks. WeakMap access is not super performant so in certain heavy applications, performance was impacted.

This PR reworks the building block architecture to directly pass buildingBlocksContext `readonly [...buildingBlocks, store]` instead of `store`. This eliminates the WeakMap access per call site.

The breaking change is that BUILDING_BLOCK functions now accept buildingBlocksContext instead of store as the first parameter.

## What was done
- switch internal function signatures and call sites from store-first to `buildingBlocksContext`-first.
- update `useAtomValue` and internals tests to pass buildingBlocksContext instead of store as the first parameter.

## Next Steps
- We should drop TS3.8.3 and TS3.9.7. These versions of TS do not support spreading tuples.

## Other Changes
- WriteAtomState now uses `args` instead of `...args`
- Reworked types for `WithOnInit` and `WithOnMount`
- added `hasOnInit` for conditionally calling `AtomOnInit`
- dropped `getInternalBuildingBlocks`