### PR TITLE
writeAtomState setter early return

### DIFF
--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -747,6 +747,9 @@ const BUILDING_BLOCK_writeAtomState: WriteAtomState = (
         }
         const prevEpochNumber = aState.n
         const v = args[0] as V
+        if ('v' in aState && Object.is(aState.v, v)) {
+          return undefined as R
+        }
         setAtomStateValueOrPromise(store, a, v)
         mountDependencies(store, a)
         if (prevEpochNumber !== aState.n) {


### PR DESCRIPTION
## Summary
Adds an early return when setting a value that is already set. This avoids calling `setAtomValueOrPromise`, `mountDependencies`, (async) `recomputeInvalidatedAtoms`, (async) `flushCallbacks`.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
