### PR TITLE
bug: strange mounting behavior near the stack limit

### DIFF
--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -200,6 +200,7 @@ type BuildingBlocks = [
   abortPromise: AbortPromise, //                               27
   // store epoch
   storeEpochHolder: StoreEpochHolder, //                       28
+  thrownErrors: Map<AnyAtom, unknown>, //                        29
 ]
 
 export type {
@@ -419,6 +420,7 @@ const BUILDING_BLOCK_flushCallbacks: FlushCallbacks = (store) => {
   const unmountCallbacks = buildingBlocks[5]
   const storeHooks = buildingBlocks[6]
   const recomputeInvalidatedAtoms = buildingBlocks[13]
+  const thrownErrors = buildingBlocks[29]
   if (
     !storeHooks.f &&
     !changedAtoms.size &&
@@ -436,6 +438,8 @@ const BUILDING_BLOCK_flushCallbacks: FlushCallbacks = (store) => {
     }
   }
   do {
+    errors.push(...Array.from(thrownErrors.values()))
+    thrownErrors.clear()
     if (storeHooks.f) {
       call(storeHooks.f)
     }
@@ -577,6 +581,7 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (store, atom) => {
   const setAtomStateValueOrPromise = buildingBlocks[20]
   const registerAbortHandler = buildingBlocks[26]
   const storeEpochHolder = buildingBlocks[28]
+  const thrownErrors = buildingBlocks[29]
   const atomState = ensureAtomState(store, atom)
   const storeEpochNumber = storeEpochHolder[0]
   // See if we can skip recomputing this atom.
@@ -726,6 +731,7 @@ const BUILDING_BLOCK_readAtomState: ReadAtomState = (store, atom) => {
   } catch (error) {
     delete atomState.v
     atomState.e = error
+    thrownErrors.set(atom, error)
     ++atomState.n
     atomState.m = storeEpochNumber
     return atomState
@@ -969,6 +975,7 @@ const BUILDING_BLOCK_setAtomStateValueOrPromise: SetAtomStateValueOrPromise = (
   const buildingBlocks = getInternalBuildingBlocks(store)
   const ensureAtomState = buildingBlocks[11]
   const abortPromise = buildingBlocks[27]
+  const thrownErrors = buildingBlocks[29]
   const atomState = ensureAtomState(store, atom)
   const hasPrevValue = 'v' in atomState
   const prevValue = atomState.v
@@ -983,6 +990,7 @@ const BUILDING_BLOCK_setAtomStateValueOrPromise: SetAtomStateValueOrPromise = (
   }
   atomState.v = valueOrPromise
   delete atomState.e
+  thrownErrors.delete(atom)
   if (!hasPrevValue || !Object.is(prevValue, atomState.v)) {
     ++atomState.n
     if (isPromiseLike(prevValue)) {
@@ -1126,6 +1134,7 @@ function buildStore(...buildArgs: Partial<BuildingBlocks>): Store {
       BUILDING_BLOCK_abortPromise,
       // store epoch
       [0],
+      new Map(), // thrownErrors
     ] satisfies BuildingBlocks
   ).map((fn, i) => buildArgs[i] || fn) as BuildingBlocks
   buildingBlockMap.set(store, Object.freeze(buildingBlocks))

--- a/tests/vanilla/internals.test.tsx
+++ b/tests/vanilla/internals.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { atom, createStore } from 'jotai'
+import type { Atom } from 'jotai'
 import type {
   INTERNAL_AtomState,
   INTERNAL_AtomStateMap,
@@ -15,6 +16,24 @@ import {
 const buildingBlockLength = 29
 
 describe('internals', () => {
+  it('every dependency (deep) should be mounted', () => {
+    const depth = measureMaxSyncRecursionDepth()
+    const mountedMap = new Map()
+    const bb = []
+    bb[1] = mountedMap
+    const store = INTERNAL_buildStore(...bb)
+    const base = atom(0)
+    const chain: Atom<unknown>[] = [base]
+    for (let i = 0; i < depth; i++) {
+      const parent = chain[chain.length - 1]!
+      chain.push(atom((get) => get(parent)))
+    }
+    const leaf = chain[chain.length - 1]!
+    store.sub(leaf, () => {})
+    expect(chain.length).toBe(depth + 1)
+    expect(mountedMap.size).toBe(chain.length)
+  })
+
   it('should not return a sparse building blocks array', () => {
     {
       const store = createStore()
@@ -334,4 +353,18 @@ function isBuildingBlocks(blocks: ReadonlyArray<unknown> | undefined) {
     blocks.length === buildingBlockLength &&
     isSparse(blocks) === false
   )
+}
+
+/** Deepest nested synchronous self-call before the engine throws (stack overflow). */
+function measureMaxSyncRecursionDepth(): number {
+  let max = 0
+  const descend = (n: number) => {
+    try {
+      descend(n + 1)
+    } catch {
+      max = n
+    }
+  }
+  descend(0)
+  return max
 }

--- a/tests/vanilla/internals.test.tsx
+++ b/tests/vanilla/internals.test.tsx
@@ -13,7 +13,7 @@ import {
   INTERNAL_initializeStoreHooksRev2 as INTERNAL_initializeStoreHooks,
 } from 'jotai/vanilla/internals'
 
-const buildingBlockLength = 29
+const buildingBlockLength = 30
 
 describe('internals', () => {
   it('every dependency (deep) should be mounted', () => {


### PR DESCRIPTION
## Summary
I encountered a strange behavior when mounting a long chain of atoms. I am able to reliably reproduce this locally and in CI.

When mounting the leaf atom of a long chain of atoms (>996), only 996 atoms are mounted. Testing locally I got this result:
```
 FAIL   jotai  tests/vanilla/internals.test.tsx > internals > every dependency (deep) should be mounted
AssertionError: expected 996 to be 7548 // Object.is equality

- Expected
+ Received

- 7548
+ 996

 ❯ tests/vanilla/internals.test.tsx:33:29
     31|     const leaf = chain[chain.length - 1]!
     32|     store.sub(leaf, () => {})
     33|     expect(mountedMap.size).toBe(depth)
       |                             ^
     34|   })
     35| 
```

Why are only 996 atoms mounted?
Why are there no error throw / reported?


## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
