### PR TITLE
docs: fix initialValue typo in atomWithStorage docs

### DIFF
--- a/docs/utilities/storage.mdx
+++ b/docs/utilities/storage.mdx
@@ -36,7 +36,7 @@ The `atomWithStorage` function creates an atom with a value persisted in `localS
 
 **storage** (optional): an object with the following methods:
 
-- **getItem(key, initialValue)** (required): Reads an item from storage, or falls back to the `intialValue`
+- **getItem(key, initialValue)** (required): Reads an item from storage, or falls back to the `initialValue`
 - **setItem(key, value)** (required): Saves an item to storage
 - **removeItem(key)** (required): Deletes the item from storage
 - **subscribe(key, callback, initialValue)** (optional): A method which subscribes to external storage updates.


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary
- fix a typo in `docs/utilities/storage.mdx`
- change `intialValue` to `initialValue` in the `getItem(key, initialValue)` parameter description
- improve clarity in the `atomWithStorage` documentation for storage API implementers

## Check List

- [ ] `pnpm run fix` for formatting and linting code and docs - N/A
