### PR TITLE
fix recipe import placeholders in docs recipes

### DIFF
--- a/docs/recipes/atom-with-compare.mdx
+++ b/docs/recipes/atom-with-compare.mdx
@@ -30,9 +30,13 @@ export function atomWithCompare<Value>(
 Here's how you'd use it to make an atom that ignores updates that are shallow-equal:
 
 ```ts
-import { atomWithCompare } from 'XXX'
-import { shallowEquals } from 'YYY'
+import { atomWithCompare } from './atomWithCompare'
 import { CSSProperties } from 'react'
+
+const shallowEquals = (a: CSSProperties, b: CSSProperties) =>
+  Object.keys(a).every(
+    (key) => Object.is(a[key as keyof CSSProperties], b[key as keyof CSSProperties]),
+  ) && Object.keys(b).every((key) => key in a)
 
 const styleAtom = atomWithCompare<CSSProperties>(
   { backgroundColor: 'blue' },

--- a/docs/recipes/atom-with-toggle-and-storage.mdx
+++ b/docs/recipes/atom-with-toggle-and-storage.mdx
@@ -33,7 +33,7 @@ export function atomWithToggleAndStorage(
 And how it's used:
 
 ```js
-import { atomWithToggleAndStorage } from 'XXX'
+import { atomWithToggleAndStorage } from './atomWithToggleAndStorage'
 
 // will have an initial value set to false & get stored in localStorage under the key "isActive"
 const isActiveAtom = atomWithToggleAndStorage('isActive')

--- a/docs/recipes/atom-with-toggle.mdx
+++ b/docs/recipes/atom-with-toggle.mdx
@@ -30,7 +30,7 @@ The setter function can have an optional argument to force a particular state, s
 Here is how it's used.
 
 ```js
-import { atomWithToggle } from 'XXX'
+import { atomWithToggle } from './atomWithToggle'
 
 // will have an initial value set to true
 const isActiveAtom = atomWithToggle(true)


### PR DESCRIPTION

**Repo:** pmndrs/jotai (⭐ 20000)
**Type:** docs
**Files changed:** 3
**Lines:** +8/-4

## What
This change fixes three recipe pages that still showed placeholder imports instead of usable example imports. The `atomWithToggle` and `atomWithToggleAndStorage` recipes now import from local recipe modules, and the `atomWithCompare` recipe now imports from its local module and includes an inline `shallowEquals` helper so the example is self-contained.

## Why
The previous snippets were not copy-pasteable because they literally imported from `'XXX'` and `'YYY'`. That makes the published docs misleading at the point where readers are trying to adopt a recipe. Replacing those placeholders with concrete local imports and a small helper makes the examples immediately usable and aligns them with the repo's other recipe docs that import sibling helpers with `./...`.

## Testing
Verified by reviewing the resulting git diff and confirming the updated snippets are syntactically coherent and consistent with existing recipe documentation patterns. No local formatter or test scripts were run because the cloned repo does not include installed dependencies (`node_modules` is absent), and this is a docs-only change.

## Risk
Low / Docs-only change that narrows ambiguity in example code without affecting runtime behavior.
