### PR TITLE
docs: clarify browser storage in Next.js

### DIFF
--- a/docs/guides/nextjs.mdx
+++ b/docs/guides/nextjs.mdx
@@ -9,6 +9,37 @@ keywords: next,nextjs
 
 Jotai has support for hydration of atoms with `useHydrateAtoms`. The documentation for the hook can be seen [here](../utilities/ssr.mdx).
 
+### Browser storage
+
+Next.js still prerenders client components during static export, so browser storage APIs such as `localStorage` and `sessionStorage` are not available during the server render.
+
+If you use `atomWithStorage` with `createJSONStorage`, avoid referencing browser storage globals directly. Use `window` behind a server guard instead:
+
+```js
+import { atomWithStorage, createJSONStorage } from 'jotai/utils'
+
+const storage = createJSONStorage(() =>
+  typeof window !== 'undefined' ? window.sessionStorage : undefined,
+)
+
+const someAtom = atomWithStorage('some-key', someInitialValue, storage)
+```
+
+If the rendered UI depends on the stored value, render that subtree only on the client to avoid hydration mismatches:
+
+```js
+import dynamic from 'next/dynamic'
+
+const StoredPreferences = dynamic(
+  () => import('../components/StoredPreferences'),
+  {
+    ssr: false,
+  },
+)
+```
+
+See the [storage documentation](../utilities/storage.mdx#server-side-rendering) for more details.
+
 ### Sync with router
 
 It's possible to sync Jotai with the router. You can achieve this with `atomWithHash`:

--- a/docs/guides/persistence.mdx
+++ b/docs/guides/persistence.mdx
@@ -86,7 +86,9 @@ Same as AsyncStorage, just use `atomWithStorage` util and override the default s
 ```js
 import { atomWithStorage, createJSONStorage } from 'jotai/utils'
 
-const storage = createJSONStorage(() => sessionStorage)
+const storage = createJSONStorage(() =>
+  typeof window !== 'undefined' ? window.sessionStorage : undefined,
+)
 const someAtom = atomWithStorage('some-key', someInitialValue, storage)
 ```
 

--- a/docs/utilities/storage.mdx
+++ b/docs/utilities/storage.mdx
@@ -58,7 +58,7 @@ Usage:
 ```js
 const storage = createJSONStorage(
   // getStringStorage
-  () => localStorage, // or window.sessionStorage, asyncStorage or alike
+  () => window.localStorage, // or window.sessionStorage, asyncStorage or alike
   // options (optional)
   {
     reviver, // optional reviver option for JSON.parse

--- a/docs/utilities/storage.mdx
+++ b/docs/utilities/storage.mdx
@@ -58,7 +58,7 @@ Usage:
 ```js
 const storage = createJSONStorage(
   // getStringStorage
-  () => localStorage, // or sessionStorage, asyncStorage or alike
+  () => localStorage, // or window.sessionStorage, asyncStorage or alike
   // options (optional)
   {
     reviver, // optional reviver option for JSON.parse
@@ -70,6 +70,20 @@ const storage = createJSONStorage(
 Note: `JSON.parse` is not type safe. If it can't accept any types, some kind of validation would be necessary for production apps.
 
 ### Server-side rendering
+
+When using `atomWithStorage` in an environment that renders on the server, such as Next.js or Waku, the storage backing the atom should safely return `undefined` on the server.
+
+For example, use a guarded `createJSONStorage` getter when using `sessionStorage` in a Next.js static export:
+
+```js
+import { atomWithStorage, createJSONStorage } from 'jotai/utils'
+
+const storage = createJSONStorage(() =>
+  typeof window !== 'undefined' ? window.sessionStorage : undefined,
+)
+
+const someAtom = atomWithStorage('some-key', someInitialValue, storage)
+```
 
 Any JSX markup that depends on the value of a stored atom (e.g., a `className` or `style` prop) will use the `initialValue` when rendered on the server (since `localStorage` and `sessionStorage` are not available on the server).
 


### PR DESCRIPTION
## Related Bug Reports or Discussions

Related to #2620

## Summary

- document a guarded `createJSONStorage` getter for `sessionStorage` in server-rendered environments
- add Next.js guidance for static export and client-only rendering of storage-dependent UI
- update the persistence guide sessionStorage example to avoid direct browser global access

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs