### PR TITLE
fix(vanilla/utils/atomWithStorage): apply reviver when parsing subscription updates

### DIFF
--- a/src/vanilla/utils/atomWithStorage.ts
+++ b/src/vanilla/utils/atomWithStorage.ts
@@ -154,7 +154,7 @@ export function createJSONStorage<Value>(
       subscriber(key, (v) => {
         let newValue: Value
         try {
-          newValue = JSON.parse(v || '')
+          newValue = JSON.parse(v || '', options?.reviver)
         } catch {
           newValue = initialValue
         }

--- a/tests/react/vanilla-utils/atomWithStorage.test.tsx
+++ b/tests/react/vanilla-utils/atomWithStorage.test.tsx
@@ -933,6 +933,95 @@ describe('with subscribe method in string storage', () => {
     expect(screen.getByText('count: 12')).toBeInTheDocument()
     // expect(storageData.count).toBe('11')
   })
+
+  it('createJSONStorage reviver is applied on subscription updates (#3101)', () => {
+    const storageData: Record<string, string> = {
+      value: JSON.stringify({ n: 42 }),
+    }
+
+    // Reviver that converts the plain object back to a class instance
+    class Item {
+      n: number
+      constructor(n: number) {
+        this.n = n
+      }
+      doubled() {
+        return this.n * 2
+      }
+    }
+
+    const reviver = (_key: string, val: unknown) => {
+      if (
+        val !== null &&
+        typeof val === 'object' &&
+        'n' in val &&
+        !Array.isArray(val)
+      ) {
+        return new Item((val as { n: number }).n)
+      }
+      return val
+    }
+
+    const stringStorage = {
+      getItem: (key: string) => storageData[key] || null,
+      setItem: (key: string, newValue: string) => {
+        storageData[key] = newValue
+      },
+      removeItem: (key: string) => {
+        delete storageData[key]
+      },
+      subscribe(_key: string, callback: (value: string | null) => void) {
+        function handler(event: CustomEvent<string>) {
+          callback(event.detail)
+        }
+
+        window.addEventListener('revivertestchange', handler as EventListener)
+        return () =>
+          window.removeEventListener(
+            'revivertestchange',
+            handler as EventListener,
+          )
+      },
+    } as SyncStringStorage
+
+    const dummyStorage = createJSONStorage<Item>(() => stringStorage, {
+      reviver,
+    })
+
+    const store = createStore()
+    const valueAtom = atomWithStorage('value', new Item(0), dummyStorage)
+
+    const Component = () => {
+      const [value] = useAtom(valueAtom, { store })
+      return (
+        <div>
+          doubled: {value instanceof Item ? value.doubled() : 'NOT_ITEM'}
+        </div>
+      )
+    }
+
+    render(
+      <StrictMode>
+        <Component />
+      </StrictMode>,
+    )
+
+    // Initial value is read via getItem — reviver is applied correctly here
+    expect(screen.getByText('doubled: 84')).toBeInTheDocument()
+
+    // Simulate an external storage update (e.g. from another tab)
+    storageData.value = JSON.stringify({ n: 10 })
+    fireEvent(
+      window,
+      new CustomEvent('revivertestchange', {
+        detail: JSON.stringify({ n: 10 }),
+      }),
+    )
+
+    // Without the fix the reviver is not applied, value is a plain object,
+    // and doubled() would not exist — the component would render 'NOT_ITEM'.
+    expect(screen.getByText('doubled: 20')).toBeInTheDocument()
+  })
 })
 
 describe('with custom async storage', () => {

--- a/tests/react/vanilla-utils/atomWithStorage.test.tsx
+++ b/tests/react/vanilla-utils/atomWithStorage.test.tsx
@@ -954,7 +954,7 @@ describe('with subscribe method in string storage', () => {
       if (
         val !== null &&
         typeof val === 'object' &&
-        'n' in val &&
+        'n' in (val as Record<string, unknown>) &&
         !Array.isArray(val)
       ) {
         return new Item((val as { n: number }).n)


### PR DESCRIPTION
## Bug

When a custom `reviver` is passed to `createJSONStorage`, it is correctly applied in `getItem` (via `JSON.parse(str, options?.reviver)`), but **not** in the internal `createHandleSubscribe` handler that fires when the underlying string storage emits a change (e.g. via a cross-tab `storage` event or a custom `subscribe` callback).

This means that if an atom value is a class instance or otherwise requires revival from the raw JSON object graph, any subscription-driven update receives a plain object instead of the revived value — causing runtime errors for callers that invoke methods on the result.

Reported in discussion #3101.

## Root cause

`createHandleSubscribe` called `JSON.parse(v || '')` without forwarding `options?.reviver`:

```ts
// before
newValue = JSON.parse(v || '')

// after
newValue = JSON.parse(v || '', options?.reviver)
```

## Fix

One-line change in `src/vanilla/utils/atomWithStorage.ts`: pass `options?.reviver` as the second argument to `JSON.parse` inside `createHandleSubscribe`.

## Test

A new test `createJSONStorage reviver is applied on subscription updates (#3101)` is added to `tests/react/vanilla-utils/atomWithStorage.test.tsx`. It:
1. Creates a `createJSONStorage` with a reviver that turns plain `{ n: number }` objects into `Item` class instances.
2. Renders a component that calls `value.doubled()` — a method that only exists on `Item`.
3. Simulates an external storage update via a `CustomEvent`.
4. Without the fix the subscription callback returns a plain object, `value instanceof Item` is `false`, and the component renders `NOT_ITEM`. With the fix it renders the correct doubled value.

Closes #3101