### PR TITLE
feat(website): update Vite guide for Vite 8

### DIFF
--- a/docs/guides/vite.mdx
+++ b/docs/guides/vite.mdx
@@ -13,13 +13,17 @@ In your `vite.config.ts`:
 ```js
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import babel from '@rolldown/plugin-babel'
 import jotaiDebugLabel from 'jotai-babel/plugin-debug-label'
 import jotaiReactRefresh from 'jotai-babel/plugin-react-refresh'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    react({ babel: { plugins: [jotaiDebugLabel, jotaiReactRefresh] } }),
+    react(),
+    babel({
+      plugins: [jotaiDebugLabel, jotaiReactRefresh],
+    }),
   ],
   // ... The rest of your configuration
 })


### PR DESCRIPTION
## Related Bug Reports or Discussions

None

## Summary

plugin-react v6 does not have babel support and that part was moved to `@rolldown/plugin-babel`. This PR updates the guide for that change.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
