### PR TITLE
docs(storage): fix unbalanced parenthesis in RESET example

### DIFF
--- a/docs/utilities/storage.mdx
+++ b/docs/utilities/storage.mdx
@@ -133,8 +133,10 @@ const TextBox = () => {
 
   return (
     <>
-      { isVisible && <h1>Header is visible!</h1> }
-      <button onClick={() => setIsVisible((prev) => (prev ? RESET : true))}>Toggle visible</button>
+      {isVisible && <h1>Header is visible!</h1>}
+      <button onClick={() => setIsVisible((prev) => (prev ? RESET : true))}>
+        Toggle visible
+      </button>
     </>
   )
 }

--- a/docs/utilities/storage.mdx
+++ b/docs/utilities/storage.mdx
@@ -134,7 +134,7 @@ const TextBox = () => {
   return (
     <>
       { isVisible && <h1>Header is visible!</h1> }
-      <button onClick={() => setIsVisible((prev) => prev ? RESET : true))}>Toggle visible</button>
+      <button onClick={() => setIsVisible((prev) => (prev ? RESET : true))}>Toggle visible</button>
     </>
   )
 }


### PR DESCRIPTION
## Summary

The `RESET` example in the **Storage** docs has a JSX snippet that doesn't parse — the `setIsVisible` call has an unbalanced extra closing parenthesis:

```jsx
<button onClick={() => setIsVisible((prev) => prev ? RESET : true))}>Toggle visible</button>
```

`setIsVisible(` opens one paren, `(prev) =>` is balanced, the first `)` closes `setIsVisible(...)`, and the trailing `)` is unmatched. Copy-pasting it throws `SyntaxError: Unexpected token` (reproduced with `@babel/preset-react`).

## Fix

Wrap the ternary in parentheses so the example parses (and reads more clearly):

```jsx
<button onClick={() => setIsVisible((prev) => (prev ? RESET : true))}>Toggle visible</button>
```

Docs-only change.
