### PR TITLE
fix(vanilla): subscriber not notified after nested store.set and sub/unsub inside a write

### DIFF
--- a/src/vanilla/internals.ts
+++ b/src/vanilla/internals.ts
@@ -1131,15 +1131,18 @@ const BUILDING_BLOCK_storeSub: StoreSub = (
   listener,
 ) => {
   const flushCallbacks = buildingBlocks[12]
+  const recomputeInvalidatedAtoms = buildingBlocks[13]
   const mountAtom = buildingBlocks[18]
   const unmountAtom = buildingBlocks[19]
   const mounted = mountAtom(buildingBlocks, store, atom)
   const listeners = mounted.l
   listeners.add(listener)
+  recomputeInvalidatedAtoms(buildingBlocks, store)
   flushCallbacks(buildingBlocks, store)
   return () => {
     listeners.delete(listener)
     unmountAtom(buildingBlocks, store, atom)
+    recomputeInvalidatedAtoms(buildingBlocks, store)
     flushCallbacks(buildingBlocks, store)
   }
 }

--- a/tests/vanilla/store.test.tsx
+++ b/tests/vanilla/store.test.tsx
@@ -1622,3 +1622,67 @@ it('does not recompute derived atom redundantly when store.set in read uses retu
   expect(derivedReadCount).not.toBe(3)
   expect(derivedReadCount).toBe(1)
 })
+
+it('notifies subscriber when a nested no-op store.set and a subscription happen inside the outer write (#3353)', () => {
+  const store = createStore()
+  const a = atom(0)
+  const derivedAtom = atom((get) => get(a))
+  const b = atom(0)
+
+  const listener = vi.fn()
+  store.sub(derivedAtom, listener)
+
+  const w = atom(null, (_get, set) => {
+    set(a, 1) // derivedAtom becomes invalidated, `a` is pending
+    // nested store.set that changes nothing: storeSet skips its
+    // recompute+flush because changedAtoms.size did not change
+    store.set(b, store.get(b))
+    // sub/unsub used to run flushCallbacks without recomputing
+    // invalidated atoms, clearing `a` from changedAtoms while
+    // derivedAtom was still invalidated (stranding its listener)
+    store.sub(b, () => {})()
+  })
+  store.set(w)
+
+  expect(store.get(derivedAtom)).toBe(1)
+  expect(listener).toHaveBeenCalledTimes(1)
+})
+
+it('notifies subscriber of interrupt-derived atom after a synchronous event cascade of nested store.set (#3353)', () => {
+  const store = createStore()
+  const interruptAtom = atom<{ resume: () => void } | undefined>(undefined)
+  const isInterruptedAtom = atom((get) => get(interruptAtom) !== undefined)
+  const dataAtom = atom(0)
+
+  // plain event emitter (not jotai)
+  const emitterListeners = new Set<() => void>()
+  const externalState = 0 // unchanged while interrupted -> no-op set
+
+  // atomEffect-style helper with temporary unsubscribe/resubscribe
+  let unsub = store.sub(dataAtom, () => {})
+  emitterListeners.add(() => {
+    store.set(dataAtom, externalState)
+    unsub()
+    unsub = store.sub(dataAtom, () => {})
+  })
+
+  const listener = vi.fn()
+  store.sub(isInterruptedAtom, listener)
+
+  const startInterruptAtom = atom(null, (_get, set) => {
+    set(interruptAtom, {
+      resume: () => emitterListeners.forEach((l) => l()),
+    })
+  })
+  const finishInterruptActionAtom = atom(null, (get, set) => {
+    const interrupt = get(interruptAtom)
+    set(interruptAtom, undefined)
+    interrupt?.resume() // synchronous cascade, not jotai
+  })
+
+  store.set(startInterruptAtom)
+  expect(listener).toHaveBeenCalledTimes(1) // false -> true
+  store.set(finishInterruptActionAtom)
+  expect(store.get(isInterruptedAtom)).toBe(false)
+  expect(listener).toHaveBeenCalledTimes(2) // true -> false
+})


### PR DESCRIPTION
Since v2.18.1, if a write function performs a nested store.set that changes
nothing and then a store.sub or unsubscribe, the flush inside sub/unsub
clears the pending changed atoms without recomputing their invalidated
dependents. A subscriber of a derived atom is then never notified, even
though store.get returns the updated value.

Fix: recompute invalidated atoms before flushing in storeSub and its
unsubscribe. Adds two regression tests (pass on 2.18.0, fail on 2.18.1+).

Closes #3353