### PR TITLE
fix(ci): pin downlevel-dts typescript to fix build failure

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  downlevel-dts>typescript: ^6.0.3
+
 importers:
 
   .:
@@ -8132,11 +8135,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@6.0.0-dev.20260416:
-    resolution: {integrity: sha512-64CCow5rQc6+oBAPqLtvZ8f3iz4WVCLwMVkg6/kOfMQlGshVOMkBhCXn+MMP4SX4Xtnz48VpD98FkptirMEuEQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -13080,7 +13078,7 @@ snapshots:
     dependencies:
       semver: 7.8.4
       shelljs: 0.8.5
-      typescript: 6.0.0-dev.20260416
+      typescript: 6.0.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -18077,8 +18075,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  typescript@6.0.0-dev.20260416: {}
 
   typescript@6.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,4 +20,4 @@ allowBuilds:
   msgpackr-extract: false
   sharp: false
 overrides:
-  "downlevel-dts>typescript": $typescript
+  "downlevel-dts>typescript": ^6.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,4 +20,4 @@ allowBuilds:
   msgpackr-extract: false
   sharp: false
 overrides:
-  "downlevel-dts>typescript": ^6.0.3
+  'downlevel-dts>typescript': ^6.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,3 +19,5 @@ allowBuilds:
   lmdb: false
   msgpackr-extract: false
   sharp: false
+overrides:
+  "downlevel-dts>typescript": $typescript


### PR DESCRIPTION
downlevel-dts depends on typescript@next, a floating tag that now resolves
to a TypeScript 7 nightly without ts.createProgram, crashing the build.
Only the React 16/17 CI jobs are affected because they run pnpm add before
building, which re-resolves the tag past the lockfile.

Fix: pin it to the repo's typescript via a pnpm override (in
pnpm-workspace.yaml, since pnpm 11 ignores pnpm.overrides in package.json).