### PR TITLE
Clarify when jotai-effect runs relative to the triggering write

### DIFF
--- a/docs/extensions/effect.mdx
+++ b/docs/extensions/effect.mdx
@@ -220,11 +220,12 @@ Aside from mount events, the effect runs when any of its dependencies change val
   })
   const actionAtom = atom(null, (get, set) => {
     get(logAtom) // 'count is 0'
-    set(countAtom, (value) => value + 1) // effect runs synchronously
-    get(logAtom) // 'count is 1'
+    set(countAtom, (value) => value + 1)
+    get(logAtom) // 'count is 0' - the effect runs once the write function completes
   })
   store.sub(logCounts, () => {})
   store.set(actionAtom)
+  store.get(logAtom) // 'count is 1' - the effect ran before `store.set` returned
   ```
 
   </details>


### PR DESCRIPTION
## Summary
- Document that an `effect` runs after the write that triggered it completes, not mid-write.
- Update the example so `get(logAtom)` inside a write function still shows the previous value, and `store.get(logAtom)` after `store.set` shows the effect result.

Fixes the mismatch called out in https://github.com/pmndrs/jotai/discussions/3364.
